### PR TITLE
fix: Fix panic when applying CNI CRS via hook

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,8 +12,6 @@ on:
       - opened
       - synchronize
       - reopened
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/charts/capi-runtime-extensions/templates/clusterrole.yaml
+++ b/charts/capi-runtime-extensions/templates/clusterrole.yaml
@@ -9,8 +9,8 @@ metadata:
   name: {{ include "chart.name" . }}
 rules:
 - apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["watch", "list", "get"]
+  resources: ["configmaps"]
+  verbs: ["watch", "list", "get", "create", "patch", "update", "delete"]
 - apiGroups:
     - addons.cluster.x-k8s.io
     - bootstrap.cluster.x-k8s.io
@@ -20,4 +20,4 @@ rules:
     - ipam.cluster.x-k8s.io
     - runtime.cluster.x-k8s.io
   resources: ["*"]
-  verbs: ["watch", "list", "get"]
+  verbs: ["watch", "list", "get", "create", "patch", "update", "delete"]

--- a/make/clusterctl.mk
+++ b/make/clusterctl.mk
@@ -3,7 +3,10 @@
 
 .PHONY: clusterctl.init
 clusterctl.init: install-tool.clusterctl
-	env CLUSTER_TOPOLOGY=true EXP_RUNTIME_SDK=true clusterctl init \
+	env CLUSTER_TOPOLOGY=true \
+			EXP_RUNTIME_SDK=true \
+			EXP_CLUSTER_RESOURCE_SET=true \
+			clusterctl init \
 		--kubeconfig=$(KIND_KUBECONFIG) \
 		--infrastructure docker \
 		--wait-providers

--- a/pkg/addons/crs.go
+++ b/pkg/addons/crs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/yamlprocessor"
 )
@@ -25,9 +26,10 @@ func crsObjsFromTemplates(ns string, templates ...[]byte) ([]unstructured.Unstru
 
 func objsFromTemplate(template []byte, ns string) ([]unstructured.Unstructured, error) {
 	ti := repository.TemplateInput{
-		RawArtifact:     template,
-		TargetNamespace: ns,
-		Processor:       yamlprocessor.NewSimpleProcessor(),
+		RawArtifact:           template,
+		TargetNamespace:       ns,
+		Processor:             yamlprocessor.NewSimpleProcessor(),
+		ConfigVariablesClient: config.NewMemoryReader(),
 	}
 
 	t, err := repository.NewTemplate(ti)

--- a/pkg/addons/templates/cni/calico-cni-installation-crs.yaml
+++ b/pkg/addons/templates/cni/calico-cni-installation-crs.yaml
@@ -14,4 +14,4 @@ spec:
       name: tigera-operator
     - kind: ConfigMap
       name: calico-cni-installation
-  strategy: ApplyAlways
+  strategy: ApplyOnce

--- a/pkg/addons/templates/cni/docker-calico-cni-installation-configmap.yaml
+++ b/pkg/addons/templates/cni/docker-calico-cni-installation-configmap.yaml
@@ -18,7 +18,7 @@ data:
         # Note: The ipPools section cannot be modified post-install.
         ipPools:
         - blockSize: 26
-          cidr: ${POD_SUBNET}
+          cidr: 192.168.0.0/16
           encapsulation: VXLANCrossSubnet
           natOutgoing: Enabled
           nodeSelector: all()

--- a/pkg/handlers/lifecycle/handlers.go
+++ b/pkg/handlers/lifecycle/handlers.go
@@ -52,7 +52,7 @@ func (m *ExtensionHandlers) DoAfterControlPlaneInitialized(
 		response.Message = err.Error()
 		return
 	}
-	err = genericResourcesClient.Create(ctx, objs)
+	err = genericResourcesClient.Apply(ctx, objs)
 	if err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()


### PR DESCRIPTION
Missing variable reader when using clusterctl templating functions.

Tested via:

```shell
make dev.run-on-kind
eval $(make kind.kubeconfig)
clusterctl generate cluster capi-quickstart --flavor development --kubernetes-version v1.26.0 --control-plane-machine-count=1 --worker-machine-count=1 | k apply -f -
watch -n 1 clusterctl describe cluster capi-quickstart
k label cluster capi-quickstart capi-runtime-extensions.d2iq-labs.com/cni=calico
k get clusterresourcesetbindings.addons.cluster.x-k8s.io capi-quickstart
clusterctl get kubeconfig capi-quickstart > capd-kubeconfig
k --kubeconfig capd-kubeconfig get installations
```

Calico still doesn't work properly (PodSecurity issues) but this is good to merge.

Requires #11.