### PR TITLE
feat: delete Services type LoadBalancer on BeforeClusterDelete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.8.1
 	github.com/onsi/gomega v1.26.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.8.0
 	golang.org/x/sync v0.1.0
 	k8s.io/apimachinery v0.25.6
 	k8s.io/component-base v0.25.6
@@ -21,9 +22,11 @@ require (
 )
 
 require (
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/fluxcd/pkg/apis/acl v0.1.0 // indirect
 	github.com/fluxcd/pkg/apis/kustomize v0.7.0 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,5 +4,5 @@
 package constants
 
 const (
-	LoadBalancerGCAnnotation = "capi-runtime-extensions.d2iq-labs.com/loadbalancer-gc"
+	LoadBalancerGCAnnotation = "labs.d2iq.io/loadbalancer-gc"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,8 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+const (
+	LoadBalancerGCAnnotation = "capi-runtime-extensions.d2iq-labs.com/loadbalancer-gc"
+)

--- a/pkg/k8s/annotations/annotations.go
+++ b/pkg/k8s/annotations/annotations.go
@@ -6,13 +6,8 @@ package annotations
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // Get will get the value of the supplied annotation.
-func Get(obj metav1.Object, name string) (value string, found bool) {
+func Get(obj metav1.Object, name string) (string, bool) {
 	annotations := obj.GetAnnotations()
-	if len(annotations) == 0 {
-		return "", false
-	}
-
-	value, found = annotations[name]
-
-	return
+	val, found := annotations[name]
+	return val, found
 }

--- a/pkg/k8s/annotations/annotations.go
+++ b/pkg/k8s/annotations/annotations.go
@@ -1,0 +1,18 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package annotations
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// Get will get the value of the supplied annotation.
+func Get(obj metav1.Object, name string) (value string, found bool) {
+	annotations := obj.GetAnnotations()
+	if len(annotations) == 0 {
+		return "", false
+	}
+
+	value, found = annotations[name]
+
+	return
+}

--- a/pkg/k8s/deleter/deleter.go
+++ b/pkg/k8s/deleter/deleter.go
@@ -72,7 +72,7 @@ func deleteServicesWithLoadBalancer(
 		svc := &services.Items[i]
 		if needsDelete(svc) {
 			log.Info(fmt.Sprintf("Deleting Service %s/%s", svc.Namespace, svc.Name))
-			if err = c.Delete(ctx, svc); err != nil {
+			if err = c.Delete(ctx, svc); client.IgnoreNotFound(err) != nil {
 				log.Error(
 					err,
 					fmt.Sprintf(

--- a/pkg/k8s/deleter/deleter_test.go
+++ b/pkg/k8s/deleter/deleter_test.go
@@ -1,0 +1,307 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package deleter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/constants"
+)
+
+//nolint:funlen // Long tests are OK
+func Test_ShouldDeleteServicesWithLoadBalancer(t *testing.T) {
+	tests := []struct {
+		name         string
+		cluster      *v1beta1.Cluster
+		shouldDelete bool
+	}{
+		{
+			name: "should delete",
+			cluster: &v1beta1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-should-delete",
+				},
+				Status: v1beta1.ClusterStatus{
+					Conditions: v1beta1.Conditions{
+						{
+							Type:   v1beta1.ControlPlaneInitializedCondition,
+							Status: corev1.ConditionTrue,
+						},
+					},
+					Phase: string(v1beta1.ClusterPhaseProvisioned),
+				},
+			},
+			shouldDelete: true,
+		},
+		{
+			name: "should delete: annotation is set to true",
+			cluster: &v1beta1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-should-delete",
+					Annotations: map[string]string{
+						constants.LoadBalancerGCAnnotation: "true",
+					},
+				},
+				Status: v1beta1.ClusterStatus{
+					Conditions: v1beta1.Conditions{
+						{
+							Type:   v1beta1.ControlPlaneInitializedCondition,
+							Status: corev1.ConditionTrue,
+						},
+					},
+					Phase: string(v1beta1.ClusterPhaseProvisioned),
+				},
+			},
+			shouldDelete: true,
+		},
+		{
+			name: "should not delete: annotation is set to false",
+			cluster: &v1beta1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-should-delete",
+					Annotations: map[string]string{
+						constants.LoadBalancerGCAnnotation: "false",
+					},
+				},
+				Status: v1beta1.ClusterStatus{
+					Phase: string(v1beta1.ClusterPhaseProvisioned),
+				},
+			},
+			shouldDelete: false,
+		},
+		{
+			name: "should not delete: phase is Pending",
+			cluster: &v1beta1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-should-delete",
+				},
+				Status: v1beta1.ClusterStatus{
+					Phase: string(v1beta1.ClusterPhasePending),
+				},
+			},
+			shouldDelete: false,
+		},
+		{
+			name: "should not delete: ControlPlaneInitialized condition is False",
+			cluster: &v1beta1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-should-delete",
+				},
+				Status: v1beta1.ClusterStatus{
+					Conditions: v1beta1.Conditions{
+						{
+							Type:   v1beta1.ControlPlaneInitializedCondition,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			shouldDelete: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shouldDelete, err := ShouldDeleteServicesWithLoadBalancer(tt.cluster)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.shouldDelete, shouldDelete)
+		})
+	}
+}
+
+//nolint:funlen // Long tests are OK
+func Test_deleteServicesWithLoadBalancer(t *testing.T) {
+	tests := []struct {
+		name          string
+		startServices []corev1.Service
+		endServices   []corev1.Service
+	}{
+		{
+			name:          "no services",
+			startServices: []corev1.Service(nil),
+			endServices:   []corev1.Service(nil),
+		},
+		{
+			name: "should not delete, all services with ClusterIP",
+			startServices: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "ns-1",
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeClusterIP,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-2",
+						Namespace: "ns-2",
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeClusterIP,
+					},
+				},
+			},
+			endServices: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "svc-1",
+						Namespace:       "ns-1",
+						ResourceVersion: "1",
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeClusterIP,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "svc-2",
+						Namespace:       "ns-2",
+						ResourceVersion: "1",
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeClusterIP,
+					},
+				},
+			},
+		},
+		{
+			name: "should delete 1 services with LoadBalancer",
+			startServices: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "ns-1",
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeClusterIP,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-2",
+						Namespace: "ns-2",
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeLoadBalancer,
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{Hostname: "lb-123.com"}},
+						},
+					},
+				},
+			},
+			endServices: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "svc-1",
+						Namespace:       "ns-1",
+						ResourceVersion: "1",
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeClusterIP,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewClientBuilder().Build()
+			for i := range tt.startServices {
+				svc := &tt.startServices[i]
+				if err := client.Create(context.Background(), svc); err != nil {
+					t.Errorf("error creating Service: %v", err)
+				}
+			}
+
+			if err := deleteServicesWithLoadBalancer(context.TODO(), client, logr.Discard()); err != nil {
+				t.Error(err)
+			}
+
+			services := &corev1.ServiceList{}
+			if err := client.List(context.Background(), services); err != nil {
+				t.Errorf("error listing Services: %v", err)
+			}
+			assert.Equal(t, tt.endServices, services.Items)
+		})
+	}
+}
+
+func Test_needsDelete(t *testing.T) {
+	tests := []struct {
+		name         string
+		service      *corev1.Service
+		shouldDelete bool
+	}{
+		{
+			name: "shouldDelete",
+			service: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{Hostname: "lb-123.com"}},
+					},
+				},
+			},
+			shouldDelete: true,
+		},
+		{
+			name: "false: ServiceTypeNodePort",
+			service: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{Hostname: "lb-123.com"}},
+					},
+				},
+			},
+			shouldDelete: false,
+		},
+		{
+			name: "false: LoadBalancer is empty",
+			service: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+				Status: corev1.ServiceStatus{},
+			},
+			shouldDelete: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			del := needsDelete(tt.service)
+			assert.Equal(t, tt.shouldDelete, del)
+		})
+	}
+}
+
+// this test is mainly here to visually show what the error will look like.
+func Test_failedToDeleteServicesError(t *testing.T) {
+	svcs := objectMetaList{
+		metav1.ObjectMeta{Namespace: "ns-1", Name: "svc-1"},
+		metav1.ObjectMeta{Namespace: "ns-2", Name: "svc-2"},
+		metav1.ObjectMeta{Namespace: "ns-3", Name: "svc-3"},
+		metav1.ObjectMeta{Namespace: "ns-4", Name: "svc-4"},
+		metav1.ObjectMeta{Namespace: "ns-5", Name: "svc-5"},
+	}
+	//nolint:lll // want to show the full error in one line
+	expectedErrString := "the following Services could not be deleted and must cleaned up manually before deleting the cluster: ns-1/svc-1, ns-2/svc-2, ns-3/svc-3, ns-4/svc-4, ns-5/svc-5"
+	assert.EqualError(t, failedToDeleteServicesError(svcs), expectedErrString)
+}

--- a/pkg/k8s/deleter/deleter_test.go
+++ b/pkg/k8s/deleter/deleter_test.go
@@ -302,6 +302,6 @@ func Test_failedToDeleteServicesError(t *testing.T) {
 		metav1.ObjectMeta{Namespace: "ns-5", Name: "svc-5"},
 	}
 	//nolint:lll // want to show the full error in one line
-	expectedErrString := "the following Services could not be deleted and must cleaned up manually before deleting the cluster: ns-1/svc-1, ns-2/svc-2, ns-3/svc-3, ns-4/svc-4, ns-5/svc-5"
+	expectedErrString := "kubernetes Services deletion failed: the following Services could not be deleted and must cleaned up manually before deleting the cluster: ns-1/svc-1, ns-2/svc-2, ns-3/svc-3, ns-4/svc-4, ns-5/svc-5"
 	assert.EqualError(t, failedToDeleteServicesError(svcs), expectedErrString)
 }


### PR DESCRIPTION
Fixes https://github.com/d2iq-labs/capi-runtime-extensions/issues/4

Automatically delete workload cluster Services with type `LoadBalancers` before deleting the cluster.

It checks for certain conditions on the Cluster object if Services should be deleted.
It's also possible to disable this behavior by adding an annotation `capi-runtime-extensions.d2iq-labs.com/loadbalancer-gc` to the Cluster object.