### PR TITLE
feat: calculate default no_proxy values based on cluster

### DIFF
--- a/charts/capi-runtime-extensions/templates/role.yaml
+++ b/charts/capi-runtime-extensions/templates/role.yaml
@@ -30,3 +30,11 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/cmd/capi-runtime-extensions/main.go
+++ b/cmd/capi-runtime-extensions/main.go
@@ -79,7 +79,7 @@ func main() {
 		servicelbgc.New(client),
 		calico.New(client, calicoCNIConfig),
 		httpproxy.NewVariable(),
-		httpproxy.NewPatch(),
+		httpproxy.NewPatch(client),
 		extraapiservercertsans.NewVariable(),
 		extraapiservercertsans.NewPatch(),
 	)

--- a/docs/content/http-proxy.md
+++ b/docs/content/http-proxy.md
@@ -32,13 +32,16 @@ spec:
   topology:
     variables:
       - name: proxy
-        value:
+        values:
           http: http://example.com
-          https: https://example.com
-          no:
+          https: http://example.com
+          additionalNo:
             - no-proxy-1.example.com
             - no-proxy-2.example.com
 ```
+
+The `additionalNo` list will be added to default pre-calculated values that apply on k8s networking
+`localhost,127.0.0.1,<POD CIDRS>,<SERVICE CIDRS>,kubernetes,kubernetes.default,.svc,.svc.cluster.local`.
 
 Applying this configuration will result in new bootstrap files on the `KubeadmControlPlaneTemplate`
 and `KubeadmConfigTemplate`.

--- a/pkg/handlers/httpproxy/inject.go
+++ b/pkg/handlers/httpproxy/inject.go
@@ -1,20 +1,27 @@
 // Copyright 2023 D2iQ, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=watch;list;get
+
 package httpproxy
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/exp/runtime/topologymutation"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/handlers/mutation"
@@ -30,6 +37,7 @@ const (
 
 type httpProxyPatchHandler struct {
 	decoder runtime.Decoder
+	client  ctrlclient.Reader
 }
 
 var (
@@ -37,7 +45,7 @@ var (
 	_ mutation.GeneratePatches = &httpProxyPatchHandler{}
 )
 
-func NewPatch() *httpProxyPatchHandler {
+func NewPatch(cl ctrlclient.Reader) *httpProxyPatchHandler {
 	scheme := runtime.NewScheme()
 	_ = bootstrapv1.AddToScheme(scheme)
 	_ = controlplanev1.AddToScheme(scheme)
@@ -46,6 +54,7 @@ func NewPatch() *httpProxyPatchHandler {
 			controlplanev1.GroupVersion,
 			bootstrapv1.GroupVersion,
 		),
+		client: cl,
 	}
 }
 
@@ -58,6 +67,12 @@ func (h *httpProxyPatchHandler) GeneratePatches(
 	req *runtimehooksv1.GeneratePatchesRequest,
 	resp *runtimehooksv1.GeneratePatchesResponse,
 ) {
+	log := ctrl.LoggerFrom(ctx)
+	noProxy, err := h.detectNoProxy(ctx, req)
+	if err != nil {
+		log.Error(err, "failed to resolve no proxy value")
+	}
+
 	topologymutation.WalkTemplates(
 		ctx,
 		h.decoder,
@@ -69,7 +84,7 @@ func (h *httpProxyPatchHandler) GeneratePatches(
 			vars map[string]apiextensionsv1.JSON,
 			holderRef runtimehooksv1.HolderReference,
 		) error {
-			log := ctrl.LoggerFrom(ctx).WithValues(
+			log = log.WithValues(
 				"holderRef", holderRef,
 			)
 
@@ -92,11 +107,11 @@ func (h *httpProxyPatchHandler) GeneratePatches(
 				func(obj *controlplanev1.KubeadmControlPlaneTemplate) error {
 					log.WithValues(
 						"patchedObjectKind", obj.GetObjectKind().GroupVersionKind().String(),
-						"patchedObjectName", client.ObjectKeyFromObject(obj),
+						"patchedObjectName", ctrlclient.ObjectKeyFromObject(obj),
 					).Info("adding files to control plane kubeadm config spec")
 					obj.Spec.Template.Spec.KubeadmConfigSpec.Files = append(
 						obj.Spec.Template.Spec.KubeadmConfigSpec.Files,
-						generateSystemdFiles(httpProxyVariable)...,
+						generateSystemdFiles(httpProxyVariable, noProxy)...,
 					)
 					return nil
 				}); err != nil {
@@ -108,11 +123,11 @@ func (h *httpProxyPatchHandler) GeneratePatches(
 				func(obj *bootstrapv1.KubeadmConfigTemplate) error {
 					log.WithValues(
 						"patchedObjectKind", obj.GetObjectKind().GroupVersionKind().String(),
-						"patchedObjectName", client.ObjectKeyFromObject(obj),
+						"patchedObjectName", ctrlclient.ObjectKeyFromObject(obj),
 					).Info("adding files to worker node kubeadm config template")
 					obj.Spec.Template.Spec.Files = append(
 						obj.Spec.Template.Spec.Files,
-						generateSystemdFiles(httpProxyVariable)...,
+						generateSystemdFiles(httpProxyVariable, noProxy)...,
 					)
 					return nil
 				}); err != nil {
@@ -122,4 +137,71 @@ func (h *httpProxyPatchHandler) GeneratePatches(
 			return nil
 		},
 	)
+}
+
+func (h *httpProxyPatchHandler) detectNoProxy(
+	ctx context.Context,
+	req *runtimehooksv1.GeneratePatchesRequest,
+) ([]string, error) {
+	clusterKey := types.NamespacedName{}
+
+	for i := range req.Items {
+		item := req.Items[i]
+		if item.HolderReference.Kind == "Cluster" &&
+			item.HolderReference.APIVersion == capiv1.GroupVersion.String() {
+			clusterKey.Name = item.HolderReference.Name
+			clusterKey.Namespace = item.HolderReference.Namespace
+		}
+	}
+
+	if clusterKey.Name == "" {
+		return nil, errors.New("failed to detect cluster name from GeneratePatch request")
+	}
+
+	cluster := &capiv1.Cluster{}
+	if err := h.client.Get(ctx, clusterKey, cluster); err != nil {
+		return nil, err
+	}
+
+	return generateNoProxy(cluster), nil
+}
+
+// generateNoProxy creates default NO_PROXY values that should be applied on cluster
+// in any environment and are preventing the use of proxy for cluster internal
+// networking.
+func generateNoProxy(cluster *capiv1.Cluster) []string {
+	noProxy := []string{
+		"localhost",
+		"127.0.0.1",
+	}
+
+	if cluster.Spec.ClusterNetwork != nil &&
+		cluster.Spec.ClusterNetwork.Pods != nil {
+		noProxy = append(noProxy, cluster.Spec.ClusterNetwork.Pods.CIDRBlocks...)
+	}
+
+	if cluster.Spec.ClusterNetwork != nil &&
+		cluster.Spec.ClusterNetwork.Services != nil {
+		noProxy = append(noProxy, cluster.Spec.ClusterNetwork.Services.CIDRBlocks...)
+	}
+
+	serviceDomain := "cluster.local"
+	if cluster.Spec.ClusterNetwork != nil &&
+		cluster.Spec.ClusterNetwork.ServiceDomain != "" {
+		serviceDomain = cluster.Spec.ClusterNetwork.ServiceDomain
+	}
+
+	noProxy = append(noProxy, []string{
+		"kubernetes",
+		"kubernetes.default",
+		".svc",
+	}...)
+
+	// append .svc.<SERVICE_DOMAIN>
+	noProxy = append(
+		noProxy,
+		fmt.Sprintf(".svc.%s", strings.TrimLeft(serviceDomain, ".")),
+	)
+
+	return noProxy
 }

--- a/pkg/handlers/httpproxy/systemd_proxy_config.go
+++ b/pkg/handlers/httpproxy/systemd_proxy_config.go
@@ -26,10 +26,14 @@ var (
 	}
 )
 
-func generateSystemdFiles(vars HTTPProxyVariables) []bootstrapv1.File {
-	if vars.HTTP == "" && vars.HTTPS == "" && len(vars.No) == 0 {
+func generateSystemdFiles(vars HTTPProxyVariables, noProxy []string) []bootstrapv1.File {
+	if vars.HTTP == "" && vars.HTTPS == "" && len(vars.AdditionalNo) == 0 {
 		return nil
 	}
+
+	allNoProxy := []string{}
+	allNoProxy = append(allNoProxy, noProxy...)
+	allNoProxy = append(allNoProxy, vars.AdditionalNo...)
 
 	tplVars := struct {
 		HTTP  string
@@ -38,7 +42,7 @@ func generateSystemdFiles(vars HTTPProxyVariables) []bootstrapv1.File {
 	}{
 		HTTP:  vars.HTTP,
 		HTTPS: vars.HTTPS,
-		NO:    strings.Join(vars.No, ","),
+		NO:    strings.Join(allNoProxy, ","),
 	}
 
 	var buf bytes.Buffer

--- a/pkg/handlers/httpproxy/variables.go
+++ b/pkg/handlers/httpproxy/variables.go
@@ -58,8 +58,11 @@ type HTTPProxyVariables struct {
 	// HTTPS proxy.
 	HTTPS string `json:"https,omitempty"`
 
-	// No Proxy list.
-	No []string `json:"no,omitempty"`
+	// AdditionalNo Proxy list that will be added to the automatically calculated
+	// values that will apply no_proxy configuration for cluster internal network.
+	// Default values: localhost,127.0.0.1,<POD_NETWORK>,<SERVICE_NETWORK>,kubernetes
+	//   ,kubernetes.default,.svc,.svc.<SERVICE_DOMAIN>
+	AdditionalNo []string `json:"additionalNo"`
 }
 
 // VariableSchema provides Cluster Class variable schema definition.
@@ -76,9 +79,12 @@ func (HTTPProxyVariables) VariableSchema() clusterv1.VariableSchema {
 					Description: "HTTPS proxy value.",
 					Type:        "string",
 				},
-				"no": {
-					Description: "No Proxy list.",
-					Type:        "array",
+				"additionalNo": {
+					Description: "Additional No Proxy list that will be added to the automatically calculated " +
+						"values that will apply no_proxy configuration for cluster internal network. " +
+						"Default value: localhost,127.0.0.1,<POD_NETWORK>,<SERVICE_NETWORK>,kubernetes," +
+						"kubernetes.default,.svc,.svc.<SERVICE_DOMAIN>",
+					Type: "array",
 					Items: &clusterv1.JSONSchemaProps{
 						Type: "string",
 					},

--- a/pkg/handlers/httpproxy/variables_test.go
+++ b/pkg/handlers/httpproxy/variables_test.go
@@ -20,9 +20,9 @@ func TestVariableValidation(t *testing.T) {
 		capitest.VariableTestDef{
 			Name: "valid values",
 			Vals: HTTPProxyVariables{
-				HTTP:  "http://a.b.c.example.com",
-				HTTPS: "https://a.b.c.example.com",
-				No:    []string{"d.e.f.example.com"},
+				HTTP:         "http://a.b.c.example.com",
+				HTTPS:        "https://a.b.c.example.com",
+				AdditionalNo: []string{"d.e.f.example.com"},
 			},
 		},
 	)


### PR DESCRIPTION
Implements https://github.com/d2iq-labs/capi-runtime-extensions/issues/30

Example of generated values:

```
          [Service]
          Environment="HTTP_PROXY=http://example.com"
          Environment="http_proxy=http://example.com"
          Environment="NO_PROXY=localhost,127.0.0.1,192.168.0.0/16,10.128.0.0/12,kubernetes,kubernetes.default,.svc,.svc,.svc.cluster,.svc.cluster.
local,no-1.example.com"
          Environment="no_proxy=localhost,127.0.0.1,192.168.0.0/16,10.128.0.0/12,kubernetes,kubernetes.default,.svc,.svc,.svc.cluster,.svc.cluster.
local,no-1.example.com"
```