### PR TITLE
feat: Support infra-specific httpproxy patches

### DIFF
--- a/pkg/handlers/httpproxy/inject.go
+++ b/pkg/handlers/httpproxy/inject.go
@@ -193,15 +193,12 @@ func generateNoProxy(cluster *capiv1.Cluster) []string {
 		serviceDomain = cluster.Spec.ClusterNetwork.ServiceDomain
 	}
 
-	noProxy = append(noProxy, []string{
+	noProxy = append(
+		noProxy,
 		"kubernetes",
 		"kubernetes.default",
 		".svc",
-	}...)
-
-	// append .svc.<SERVICE_DOMAIN>
-	noProxy = append(
-		noProxy,
+		// append .svc.<SERVICE_DOMAIN>
 		fmt.Sprintf(".svc.%s", strings.TrimLeft(serviceDomain, ".")),
 	)
 
@@ -212,18 +209,22 @@ func generateNoProxy(cluster *capiv1.Cluster) []string {
 	// Add infra-specific entries
 	switch cluster.Spec.InfrastructureRef.Kind {
 	case "AWSCluster", "AWSManagedCluster":
-		noProxy = append(noProxy,
+		noProxy = append(
+			noProxy,
 			// Exclude the instance metadata service
 			instanceMetadataIP,
 			// Exclude the control plane endpoint
 			".elb.amazonaws.com",
 		)
 	case "AzureCluster", "AzureManagedControlPlane":
-		noProxy = append(noProxy,
+		noProxy = append(
+			noProxy,
 			// Exclude the instance metadata service
-			instanceMetadataIP)
+			instanceMetadataIP,
+		)
 	case "GCPCluster":
-		noProxy = append(noProxy,
+		noProxy = append(
+			noProxy,
 			// Exclude the instance metadata service
 			instanceMetadataIP,
 			// Exclude aliases for instance metadata service.

--- a/pkg/handlers/httpproxy/inject_test.go
+++ b/pkg/handlers/httpproxy/inject_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apiserver/pkg/storage/names"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -132,6 +133,90 @@ func TestGenerateNoProxy(t *testing.T) {
 			expectedNoProxy: []string{
 				"localhost", "127.0.0.1", "10.0.0.0/24", "10.0.1.0/24", "kubernetes",
 				"kubernetes.default", ".svc", ".svc.cluster.local",
+			},
+		},
+		{
+			name: "Unknown infrastructure cluster",
+			cluster: &capiv1.Cluster{
+				Spec: capiv1.ClusterSpec{
+					InfrastructureRef: &v1.ObjectReference{
+						Kind: "SomeFakeInfrastructureCluster",
+					},
+				},
+			},
+			expectedNoProxy: []string{
+				"localhost", "127.0.0.1", "kubernetes", "kubernetes.default",
+				".svc", ".svc.cluster.local",
+			},
+		},
+		{
+			name: "AWS cluster",
+			cluster: &capiv1.Cluster{
+				Spec: capiv1.ClusterSpec{
+					InfrastructureRef: &v1.ObjectReference{
+						Kind: "AWSCluster",
+					},
+				},
+			},
+			expectedNoProxy: []string{
+				"localhost", "127.0.0.1", "kubernetes", "kubernetes.default",
+				".svc", ".svc.cluster.local", "169.254.169.254", ".elb.amazonaws.com",
+			},
+		},
+		{
+			name: "AWS managed (EKS) cluster",
+			cluster: &capiv1.Cluster{
+				Spec: capiv1.ClusterSpec{
+					InfrastructureRef: &v1.ObjectReference{
+						Kind: "AWSManagedCluster",
+					},
+				},
+			},
+			expectedNoProxy: []string{
+				"localhost", "127.0.0.1", "kubernetes", "kubernetes.default",
+				".svc", ".svc.cluster.local", "169.254.169.254", ".elb.amazonaws.com",
+			},
+		},
+		{
+			name: "Azure cluster",
+			cluster: &capiv1.Cluster{
+				Spec: capiv1.ClusterSpec{
+					InfrastructureRef: &v1.ObjectReference{
+						Kind: "AzureCluster",
+					},
+				},
+			},
+			expectedNoProxy: []string{
+				"localhost", "127.0.0.1", "kubernetes", "kubernetes.default",
+				".svc", ".svc.cluster.local", "169.254.169.254",
+			},
+		},
+		{
+			name: "Azure managed (AKS) cluster",
+			cluster: &capiv1.Cluster{
+				Spec: capiv1.ClusterSpec{
+					InfrastructureRef: &v1.ObjectReference{
+						Kind: "AzureCluster",
+					},
+				},
+			},
+			expectedNoProxy: []string{
+				"localhost", "127.0.0.1", "kubernetes", "kubernetes.default",
+				".svc", ".svc.cluster.local", "169.254.169.254",
+			},
+		},
+		{
+			name: "GCP cluster",
+			cluster: &capiv1.Cluster{
+				Spec: capiv1.ClusterSpec{
+					InfrastructureRef: &v1.ObjectReference{
+						Kind: "GCPCluster",
+					},
+				},
+			},
+			expectedNoProxy: []string{
+				"localhost", "127.0.0.1", "kubernetes", "kubernetes.default",
+				".svc", ".svc.cluster.local", "169.254.169.254", "metadata", "metadata.google.internal",
 			},
 		},
 		{


### PR DESCRIPTION
Adds infra-specific exceptions to `no_proxy`. This should wrap up https://github.com/d2iq-labs/capi-runtime-extensions/issues/30