### PR TITLE
refactor: how handlers are added to server

### DIFF
--- a/common/pkg/capi/clustertopology/handlers/mutation/meta.go
+++ b/common/pkg/capi/clustertopology/handlers/mutation/meta.go
@@ -12,6 +12,11 @@ import (
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 )
 
+const (
+	// MetaVariableName is the meta cluster config patch variable name.
+	MetaVariableName = "clusterConfig"
+)
+
 type metaGeneratePatches struct {
 	name            string
 	wrappedHandlers []GeneratePatches

--- a/common/pkg/capi/clustertopology/handlers/mutation/meta.go
+++ b/common/pkg/capi/clustertopology/handlers/mutation/meta.go
@@ -12,11 +12,6 @@ import (
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 )
 
-const (
-	// MetaVariableName is the meta cluster config patch variable name.
-	MetaVariableName = "clusterConfig"
-)
-
 type metaGeneratePatches struct {
 	name            string
 	wrappedHandlers []GeneratePatches

--- a/pkg/handlers/clusterconfig/variables.go
+++ b/pkg/handlers/clusterconfig/variables.go
@@ -20,9 +20,6 @@ var (
 )
 
 const (
-	// VariableName is http proxy external patch variable name.
-	VariableName = "clusterConfig"
-
 	// HandlerNameVariable is the name of the variable handler.
 	HandlerNameVariable = "ClusterConfigVars"
 )
@@ -43,7 +40,7 @@ func (h *clusterConfigVariableHandler) DiscoverVariables(
 	resp *runtimehooksv1.DiscoverVariablesResponse,
 ) {
 	resp.Variables = append(resp.Variables, clusterv1.ClusterClassVariable{
-		Name:     VariableName,
+		Name:     mutation.MetaVariableName,
 		Required: false,
 		Schema:   v1alpha1.ClusterConfigSpec{}.VariableSchema(),
 	})

--- a/pkg/handlers/clusterconfig/variables.go
+++ b/pkg/handlers/clusterconfig/variables.go
@@ -10,12 +10,13 @@ import (
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
+	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
 )
 
 var (
-	_ handlers.Named             = &clusterConfigVariableHandler{}
+	_ commonhandlers.Named       = &clusterConfigVariableHandler{}
 	_ mutation.DiscoverVariables = &clusterConfigVariableHandler{}
 )
 
@@ -40,7 +41,7 @@ func (h *clusterConfigVariableHandler) DiscoverVariables(
 	resp *runtimehooksv1.DiscoverVariablesResponse,
 ) {
 	resp.Variables = append(resp.Variables, clusterv1.ClusterClassVariable{
-		Name:     mutation.MetaVariableName,
+		Name:     handlers.MetaVariableName,
 		Required: false,
 		Schema:   v1alpha1.ClusterConfigSpec{}.VariableSchema(),
 	})

--- a/pkg/handlers/clusterconfig/variables_test.go
+++ b/pkg/handlers/clusterconfig/variables_test.go
@@ -9,14 +9,14 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/testutils/capitest"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
 )
 
 func TestVariableValidation(t *testing.T) {
 	capitest.ValidateDiscoverVariables(
 		t,
-		mutation.MetaVariableName,
+		handlers.MetaVariableName,
 		ptr.To(v1alpha1.ClusterConfigSpec{}.VariableSchema()),
 		NewVariable,
 		capitest.VariableTestDef{

--- a/pkg/handlers/clusterconfig/variables_test.go
+++ b/pkg/handlers/clusterconfig/variables_test.go
@@ -9,13 +9,14 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
+	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/testutils/capitest"
 )
 
 func TestVariableValidation(t *testing.T) {
 	capitest.ValidateDiscoverVariables(
 		t,
-		VariableName,
+		mutation.MetaVariableName,
 		ptr.To(v1alpha1.ClusterConfigSpec{}.VariableSchema()),
 		NewVariable,
 		capitest.VariableTestDef{

--- a/pkg/handlers/cni/calico/handler.go
+++ b/pkg/handlers/cni/calico/handler.go
@@ -26,10 +26,15 @@ import (
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/lifecycle"
+	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/k8s/client"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/k8s/parser"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/cni"
+)
+
+const (
+	variableName = "cni"
 )
 
 type CalicoCNIConfig struct {
@@ -78,17 +83,15 @@ var (
 	calicoInstallationGK = schema.GroupKind{Group: "operator.tigera.io", Kind: "Installation"}
 )
 
-func New(
+func NewMetaHandler(
 	c ctrlclient.Client,
 	cfg *CalicoCNIConfig,
-	variableName string,
-	variablePath ...string,
 ) *CalicoCNI {
 	return &CalicoCNI{
 		client:       c,
 		config:       cfg,
-		variableName: variableName,
-		variablePath: variablePath,
+		variableName: mutation.MetaVariableName,
+		variablePath: []string{variableName},
 	}
 }
 

--- a/pkg/handlers/cni/calico/handler.go
+++ b/pkg/handlers/cni/calico/handler.go
@@ -24,12 +24,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
+	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/lifecycle"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/k8s/client"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/k8s/parser"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/cni"
 )
 
@@ -77,7 +77,7 @@ type CalicoCNI struct {
 }
 
 var (
-	_ handlers.Named                         = &CalicoCNI{}
+	_ commonhandlers.Named                   = &CalicoCNI{}
 	_ lifecycle.AfterControlPlaneInitialized = &CalicoCNI{}
 
 	calicoInstallationGK = schema.GroupKind{Group: "operator.tigera.io", Kind: "Installation"}
@@ -90,7 +90,7 @@ func NewMetaHandler(
 	return &CalicoCNI{
 		client:       c,
 		config:       cfg,
-		variableName: mutation.MetaVariableName,
+		variableName: handlers.MetaVariableName,
 		variablePath: []string{variableName},
 	}
 }

--- a/pkg/handlers/etcd/inject.go
+++ b/pkg/handlers/etcd/inject.go
@@ -41,7 +41,15 @@ var (
 	_ mutation.GeneratePatches = &etcdPatchHandler{}
 )
 
-func NewPatch(
+func NewPatch() *etcdPatchHandler {
+	return newEtcdPatchHandler(variableName)
+}
+
+func NewMetaPatch() *etcdPatchHandler {
+	return newEtcdPatchHandler(mutation.MetaVariableName, variableName)
+}
+
+func newEtcdPatchHandler(
 	variableName string,
 	variableFieldPath ...string,
 ) *etcdPatchHandler {

--- a/pkg/handlers/etcd/inject.go
+++ b/pkg/handlers/etcd/inject.go
@@ -18,11 +18,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
+	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
 )
 
 const (
@@ -37,7 +38,7 @@ type etcdPatchHandler struct {
 }
 
 var (
-	_ handlers.Named           = &etcdPatchHandler{}
+	_ commonhandlers.Named     = &etcdPatchHandler{}
 	_ mutation.GeneratePatches = &etcdPatchHandler{}
 )
 
@@ -46,7 +47,7 @@ func NewPatch() *etcdPatchHandler {
 }
 
 func NewMetaPatch() *etcdPatchHandler {
-	return newEtcdPatchHandler(mutation.MetaVariableName, variableName)
+	return newEtcdPatchHandler(handlers.MetaVariableName, variableName)
 }
 
 func newEtcdPatchHandler(

--- a/pkg/handlers/etcd/inject_test.go
+++ b/pkg/handlers/etcd/inject_test.go
@@ -17,7 +17,7 @@ import (
 func TestGeneratePatches(t *testing.T) {
 	capitest.ValidateGeneratePatches(
 		t,
-		func() mutation.GeneratePatches { return NewPatch(VariableName) },
+		func() mutation.GeneratePatches { return NewPatch() },
 		capitest.PatchTestDef{
 			Name: "unset variable",
 		},
@@ -25,7 +25,7 @@ func TestGeneratePatches(t *testing.T) {
 			Name: "etcd imageRepository and imageTag set",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					VariableName,
+					variableName,
 					v1alpha1.Etcd{
 						Image: &v1alpha1.Image{
 							Repository: "my-registry.io/my-org/my-repo",
@@ -55,7 +55,7 @@ func TestGeneratePatches(t *testing.T) {
 			Name: "etcd imageRepository set",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					VariableName,
+					variableName,
 					v1alpha1.Etcd{
 						Image: &v1alpha1.Image{
 							Repository: "my-registry.io/my-org/my-repo",
@@ -83,7 +83,7 @@ func TestGeneratePatches(t *testing.T) {
 			Name: "etcd imageTag set",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					VariableName,
+					variableName,
 					v1alpha1.Etcd{
 						Image: &v1alpha1.Image{
 							Tag: "v3.5.99_custom.0",

--- a/pkg/handlers/etcd/variables.go
+++ b/pkg/handlers/etcd/variables.go
@@ -20,8 +20,8 @@ var (
 )
 
 const (
-	// VariableName is http proxy external patch variable name.
-	VariableName = "etcd"
+	// variableName is etcd external patch variable name.
+	variableName = "etcd"
 
 	// HandlerNameVariable is the name of the variable handler.
 	HandlerNameVariable = "etcdVars"
@@ -43,7 +43,7 @@ func (h *etcdVariableHandler) DiscoverVariables(
 	resp *runtimehooksv1.DiscoverVariablesResponse,
 ) {
 	resp.Variables = append(resp.Variables, clusterv1.ClusterClassVariable{
-		Name:     VariableName,
+		Name:     variableName,
 		Required: false,
 		Schema:   v1alpha1.Etcd{}.VariableSchema(),
 	})

--- a/pkg/handlers/etcd/variables_test.go
+++ b/pkg/handlers/etcd/variables_test.go
@@ -15,7 +15,7 @@ import (
 func TestVariableValidation(t *testing.T) {
 	capitest.ValidateDiscoverVariables(
 		t,
-		VariableName,
+		variableName,
 		ptr.To(v1alpha1.Etcd{}.VariableSchema()),
 		NewVariable,
 		capitest.VariableTestDef{

--- a/pkg/handlers/extraapiservercertsans/inject.go
+++ b/pkg/handlers/extraapiservercertsans/inject.go
@@ -18,11 +18,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
+	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
 )
 
 const (
@@ -37,7 +38,7 @@ type extraAPIServerCertSANsPatchHandler struct {
 }
 
 var (
-	_ handlers.Named           = &extraAPIServerCertSANsPatchHandler{}
+	_ commonhandlers.Named     = &extraAPIServerCertSANsPatchHandler{}
 	_ mutation.GeneratePatches = &extraAPIServerCertSANsPatchHandler{}
 )
 
@@ -46,7 +47,7 @@ func NewPatch() *extraAPIServerCertSANsPatchHandler {
 }
 
 func NewMetaPatch() *extraAPIServerCertSANsPatchHandler {
-	return newExtraAPIServerCertSANsPatchHandler(mutation.MetaVariableName, variableName)
+	return newExtraAPIServerCertSANsPatchHandler(handlers.MetaVariableName, variableName)
 }
 
 func newExtraAPIServerCertSANsPatchHandler(

--- a/pkg/handlers/extraapiservercertsans/inject.go
+++ b/pkg/handlers/extraapiservercertsans/inject.go
@@ -41,7 +41,15 @@ var (
 	_ mutation.GeneratePatches = &extraAPIServerCertSANsPatchHandler{}
 )
 
-func NewPatch(
+func NewPatch() *extraAPIServerCertSANsPatchHandler {
+	return newExtraAPIServerCertSANsPatchHandler(variableName)
+}
+
+func NewMetaPatch() *extraAPIServerCertSANsPatchHandler {
+	return newExtraAPIServerCertSANsPatchHandler(mutation.MetaVariableName, variableName)
+}
+
+func newExtraAPIServerCertSANsPatchHandler(
 	variableName string,
 	variableFieldPath ...string,
 ) *extraAPIServerCertSANsPatchHandler {

--- a/pkg/handlers/extraapiservercertsans/inject_test.go
+++ b/pkg/handlers/extraapiservercertsans/inject_test.go
@@ -17,7 +17,7 @@ import (
 func TestGeneratePatches(t *testing.T) {
 	capitest.ValidateGeneratePatches(
 		t,
-		func() mutation.GeneratePatches { return NewPatch(VariableName) },
+		func() mutation.GeneratePatches { return NewPatch() },
 		capitest.PatchTestDef{
 			Name: "unset variable",
 		},
@@ -25,7 +25,7 @@ func TestGeneratePatches(t *testing.T) {
 			Name: "extra API server cert SANs set",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					VariableName,
+					variableName,
 					v1alpha1.ExtraAPIServerCertSANs{"a.b.c.example.com", "d.e.f.example.com"},
 				),
 			},

--- a/pkg/handlers/extraapiservercertsans/variables.go
+++ b/pkg/handlers/extraapiservercertsans/variables.go
@@ -20,8 +20,8 @@ var (
 )
 
 const (
-	// VariableName is http proxy external patch variable name.
-	VariableName = "extraAPIServerCertSANs"
+	// variableName is http proxy external patch variable name.
+	variableName = "extraAPIServerCertSANs"
 
 	// HandlerNameVariable is the name of the variable handler.
 	HandlerNameVariable = "ExtraAPIServerCertSANsVars"
@@ -43,7 +43,7 @@ func (h *extraAPIServerCertSANsVariableHandler) DiscoverVariables(
 	resp *runtimehooksv1.DiscoverVariablesResponse,
 ) {
 	resp.Variables = append(resp.Variables, clusterv1.ClusterClassVariable{
-		Name:     VariableName,
+		Name:     variableName,
 		Required: false,
 		Schema:   v1alpha1.ExtraAPIServerCertSANs{}.VariableSchema(),
 	})

--- a/pkg/handlers/extraapiservercertsans/variables_test.go
+++ b/pkg/handlers/extraapiservercertsans/variables_test.go
@@ -15,7 +15,7 @@ import (
 func TestVariableValidation(t *testing.T) {
 	capitest.ValidateDiscoverVariables(
 		t,
-		VariableName,
+		variableName,
 		ptr.To(v1alpha1.ExtraAPIServerCertSANs{}.VariableSchema()),
 		NewVariable,
 		capitest.VariableTestDef{

--- a/pkg/handlers/httpproxy/inject.go
+++ b/pkg/handlers/httpproxy/inject.go
@@ -53,6 +53,18 @@ var (
 
 func NewPatch(
 	cl ctrlclient.Reader,
+) *httpProxyPatchHandler {
+	return newHTTPProxyPatchHandler(cl, variableName)
+}
+
+func NewMetaPatch(
+	cl ctrlclient.Reader,
+) *httpProxyPatchHandler {
+	return newHTTPProxyPatchHandler(cl, mutation.MetaVariableName, variableName)
+}
+
+func newHTTPProxyPatchHandler(
+	cl ctrlclient.Reader,
 	variableName string,
 	variableFieldPath ...string,
 ) *httpProxyPatchHandler {

--- a/pkg/handlers/httpproxy/inject.go
+++ b/pkg/handlers/httpproxy/inject.go
@@ -22,11 +22,12 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
+	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
 )
 
 const (
@@ -47,7 +48,7 @@ type httpProxyPatchHandler struct {
 }
 
 var (
-	_ handlers.Named           = &httpProxyPatchHandler{}
+	_ commonhandlers.Named     = &httpProxyPatchHandler{}
 	_ mutation.GeneratePatches = &httpProxyPatchHandler{}
 )
 
@@ -60,7 +61,7 @@ func NewPatch(
 func NewMetaPatch(
 	cl ctrlclient.Reader,
 ) *httpProxyPatchHandler {
-	return newHTTPProxyPatchHandler(cl, mutation.MetaVariableName, variableName)
+	return newHTTPProxyPatchHandler(cl, handlers.MetaVariableName, variableName)
 }
 
 func newHTTPProxyPatchHandler(

--- a/pkg/handlers/httpproxy/inject_test.go
+++ b/pkg/handlers/httpproxy/inject_test.go
@@ -22,7 +22,7 @@ func TestGeneratePatches(t *testing.T) {
 		t,
 		func() *httpProxyPatchHandler {
 			fakeClient := fake.NewClientBuilder().Build()
-			return NewPatch(fakeClient, VariableName)
+			return NewPatch(fakeClient)
 		},
 		capitest.PatchTestDef{
 			Name: "unset variable",
@@ -31,7 +31,7 @@ func TestGeneratePatches(t *testing.T) {
 			Name: "http proxy set for KubeadmConfigTemplate default-worker",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					VariableName,
+					variableName,
 					v1alpha1.HTTPProxy{
 						HTTP:         "http://example.com",
 						HTTPS:        "https://example.com",
@@ -58,7 +58,7 @@ func TestGeneratePatches(t *testing.T) {
 			Name: "http proxy set for KubeadmConfigTemplate generic worker",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					VariableName,
+					variableName,
 					v1alpha1.HTTPProxy{
 						HTTP:         "http://example.com",
 						HTTPS:        "https://example.com",
@@ -85,7 +85,7 @@ func TestGeneratePatches(t *testing.T) {
 			Name: "http proxy set for KubeadmControlPlaneTemplate",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					VariableName,
+					variableName,
 					v1alpha1.HTTPProxy{
 						HTTP:         "http://example.com",
 						HTTPS:        "https://example.com",

--- a/pkg/handlers/httpproxy/variables.go
+++ b/pkg/handlers/httpproxy/variables.go
@@ -20,8 +20,8 @@ var (
 )
 
 const (
-	// VariableName is http proxy external patch variable name.
-	VariableName = "proxy"
+	// variableName is http proxy external patch variable name.
+	variableName = "proxy"
 
 	// HandlerNameVariable is the name of the variable handler.
 	HandlerNameVariable = "HTTPProxyVars"
@@ -43,7 +43,7 @@ func (h *httpProxyVariableHandler) DiscoverVariables(
 	resp *runtimehooksv1.DiscoverVariablesResponse,
 ) {
 	resp.Variables = append(resp.Variables, clusterv1.ClusterClassVariable{
-		Name:     VariableName,
+		Name:     variableName,
 		Required: false,
 		Schema:   v1alpha1.HTTPProxy{}.VariableSchema(),
 	})

--- a/pkg/handlers/httpproxy/variables_test.go
+++ b/pkg/handlers/httpproxy/variables_test.go
@@ -15,7 +15,7 @@ import (
 func TestVariableValidation(t *testing.T) {
 	capitest.ValidateDiscoverVariables(
 		t,
-		VariableName,
+		variableName,
 		ptr.To(v1alpha1.HTTPProxy{}.VariableSchema()),
 		NewVariable,
 		capitest.VariableTestDef{

--- a/pkg/handlers/kubernetesimagerepository/inject.go
+++ b/pkg/handlers/kubernetesimagerepository/inject.go
@@ -18,11 +18,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
+	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
 )
 
 const (
@@ -37,7 +38,7 @@ type imageRepositoryPatchHandler struct {
 }
 
 var (
-	_ handlers.Named           = &imageRepositoryPatchHandler{}
+	_ commonhandlers.Named     = &imageRepositoryPatchHandler{}
 	_ mutation.GeneratePatches = &imageRepositoryPatchHandler{}
 )
 
@@ -46,7 +47,7 @@ func NewPatch() *imageRepositoryPatchHandler {
 }
 
 func NewMetaPatch() *imageRepositoryPatchHandler {
-	return newImageRegistryPatchHandler(mutation.MetaVariableName, variableName)
+	return newImageRegistryPatchHandler(handlers.MetaVariableName, variableName)
 }
 
 func newImageRegistryPatchHandler(

--- a/pkg/handlers/kubernetesimagerepository/inject.go
+++ b/pkg/handlers/kubernetesimagerepository/inject.go
@@ -41,7 +41,15 @@ var (
 	_ mutation.GeneratePatches = &imageRepositoryPatchHandler{}
 )
 
-func NewPatch(
+func NewPatch() *imageRepositoryPatchHandler {
+	return newImageRegistryPatchHandler(variableName)
+}
+
+func NewMetaPatch() *imageRepositoryPatchHandler {
+	return newImageRegistryPatchHandler(mutation.MetaVariableName, variableName)
+}
+
+func newImageRegistryPatchHandler(
 	variableName string,
 	variableFieldPath ...string,
 ) *imageRepositoryPatchHandler {

--- a/pkg/handlers/kubernetesimagerepository/inject_test.go
+++ b/pkg/handlers/kubernetesimagerepository/inject_test.go
@@ -17,7 +17,7 @@ import (
 func TestGeneratePatches(t *testing.T) {
 	capitest.ValidateGeneratePatches(
 		t,
-		func() mutation.GeneratePatches { return NewPatch(VariableName) },
+		func() mutation.GeneratePatches { return NewPatch() },
 		capitest.PatchTestDef{
 			Name: "unset variable",
 		},
@@ -25,7 +25,7 @@ func TestGeneratePatches(t *testing.T) {
 			Name: "kubernetesImageRepository set",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					VariableName,
+					variableName,
 					v1alpha1.KubernetesImageRepository("my-registry.io/my-org/my-repo"),
 				),
 			},

--- a/pkg/handlers/kubernetesimagerepository/variables.go
+++ b/pkg/handlers/kubernetesimagerepository/variables.go
@@ -21,7 +21,7 @@ var (
 
 const (
 	// VariableName is http proxy external patch variable name.
-	VariableName = "kubernetesImageRepository"
+	variableName = "kubernetesImageRepository"
 
 	// HandlerNameVariable is the name of the variable handler.
 	HandlerNameVariable = "ImageRepositoryVars"
@@ -43,7 +43,7 @@ func (h *imageRepositoryVariableHandler) DiscoverVariables(
 	resp *runtimehooksv1.DiscoverVariablesResponse,
 ) {
 	resp.Variables = append(resp.Variables, clusterv1.ClusterClassVariable{
-		Name:     VariableName,
+		Name:     variableName,
 		Required: false,
 		Schema:   v1alpha1.KubernetesImageRepository("").VariableSchema(),
 	})

--- a/pkg/handlers/kubernetesimagerepository/variables_test.go
+++ b/pkg/handlers/kubernetesimagerepository/variables_test.go
@@ -15,7 +15,7 @@ import (
 func TestVariableValidation(t *testing.T) {
 	capitest.ValidateDiscoverVariables(
 		t,
-		VariableName,
+		variableName,
 		ptr.To(v1alpha1.KubernetesImageRepository("").VariableSchema()),
 		NewVariable,
 		capitest.VariableTestDef{

--- a/pkg/handlers/metadata.go
+++ b/pkg/handlers/metadata.go
@@ -7,4 +7,7 @@ import "github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
 
 const (
 	MetadataDomain = v1alpha1.APIGroup
+
+	// MetaVariableName is the meta cluster config patch variable name.
+	MetaVariableName = "clusterConfig"
 )


### PR DESCRIPTION
When adding new handlers I kept forgetting to add it to the meta hander. Although this commit doesn't really solve it does make it easier to visually see a difference. It also simplifies adding handlers to the server by not asking for a package variable when calling `<patchpackage>.NewPatch()`.

Ideally we should be able to automatically build the metahandler from `patchHandlers` but I didn't see how to do that with the 2 interfaces we have now `Named` and `GeneratePatches`.