### PR TITLE
fix: incorrect audit policy handler name

### DIFF
--- a/pkg/handlers/auditpolicy/inject.go
+++ b/pkg/handlers/auditpolicy/inject.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// HandlerNamePatch is the name of the inject handler.
-	HandlerNamePatch = "AuditPolicy"
+	HandlerNamePatch = "AuditPolicyPatch"
 )
 
 type auditPolicyPatchHandler struct {


### PR DESCRIPTION
Match the other handlers and the docs https://github.com/d2iq-labs/capi-runtime-extensions/blob/main/docs/content/audit-policy.md