### PR TITLE
ci: Explicitly specify bash as shell for GHA run steps

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,6 +32,7 @@ jobs:
           enable-cache: true
 
       - name: Run unit tests
+        shell: bash
         run: devbox run -- make test
 
       - name: Annotate tests
@@ -60,18 +61,21 @@ jobs:
 
       - if: steps.check_e2e_tests_exist.outputs.files_exists == 'true'
         name: Build and install on KinD
+        shell: bash
         run: devbox run -- make dev.run-on-kind
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - if: steps.check_e2e_tests_exist.outputs.files_exists == 'true'
         name: Run e2e tests
+        shell: bash
         run: devbox run -- make e2e-test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - if: steps.check_e2e_tests_exist.outputs.files_exists == 'true' && always()
         name: Cleanup KinD cluster
+        shell: bash
         run: devbox run -- make kind.delete
 
   lint-go:
@@ -87,6 +91,7 @@ jobs:
 
       - name: Export golang and golangci-lint versions
         id: versions
+        shell: bash
         run: |
           echo "golangci-lint=$(devbox run -- golangci-lint version --format short)" >>"${GITHUB_OUTPUT}"
           echo "golang=$(devbox run -- go version | grep -o "[[:digit:]]\+.[[:digit:]]\+\(.[[:digit:]]\+\)\?")" >>"${GITHUB_OUTPUT}"
@@ -143,6 +148,7 @@ jobs:
           key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Run pre-commit
+        shell: bash
         run: devbox run -- make pre-commit
         env:
           SKIP: no-commit-to-branch,golangci-lint,actionlint-system
@@ -162,6 +168,7 @@ jobs:
 
       - name: Run chart-testing (list-changed)
         id: list-changed
+        shell: bash
         run: |
           changed="$(devbox run -- \
             ct list-changed --config charts/ct-config.yaml \
@@ -172,12 +179,14 @@ jobs:
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Run chart-testing (lint)
+        shell: bash
         run: |
           devbox run -- \
             ct lint --config charts/ct-config.yaml
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Create kind cluster
+        shell: bash
         run: |
           devbox run -- \
             kind create cluster \
@@ -188,12 +197,14 @@ jobs:
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Build Docker images
+        shell: bash
         run: |
           devbox run -- \
             make release-snapshot
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Sideload docker image
+        shell: bash
         run: |
           devbox run -- \
             kind load docker-image \
@@ -202,6 +213,7 @@ jobs:
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Setup Cluster API and cert-manager
+        shell: bash
         run: |
           devbox run -- \
             make clusterctl.init
@@ -210,6 +222,7 @@ jobs:
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Run chart-testing (install)
+        shell: bash
         run: |
           devbox run -- \
             ct install \
@@ -219,7 +232,8 @@ jobs:
           KUBECONFIG: ct-kind-kubeconfig
 
       - if: steps.list-changed.outputs.changed == 'true' && always()
-        name:
+        name: Delete chart-testing KinD cluster
+        shell: bash
         run: |
           devbox run -- \
             kind delete cluster --name chart-testing || true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,7 @@ jobs:
         enable-cache: true
 
     - name: Build
+      shell: bash
       run: devbox run -- make build-snapshot
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: dependabot/fetch-metadata@v1
       - uses: actions/checkout@v4
       - name: Approve a PR if not already approved
+        shell: bash
         run: |
           gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`
           if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ]; then
@@ -41,6 +42,7 @@ jobs:
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v1
       - name: Enable auto-merge for Dependabot PRs
+        shell: bash
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -36,10 +36,12 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install necessary packages
+        shell: bash
         run: npm ci
         working-directory: ./docs/
 
       - name: Build
+        shell: bash
         run: hugo --minify
         working-directory: ./docs/
 

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -35,6 +35,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
+        shell: bash
         run: devbox run -- make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitlint
+++ b/.gitlint
@@ -1,7 +1,7 @@
 # `gitlint` is used to validate commit messages via `pre-commit` hook, enabled
 # via `pre-commit install -t commit-msg`.
 #
-# The format of this file is detailed at https://jorisroovers.com/gitlint/#configuration.
+# The format of this file is detailed at https://jorisroovers.com/gitlint/latest/configuration/gitlint_file/.
 
 [general]
 # Validate the commit title conforms to conventional commits (https://www.conventionalcommits.org/en/v1.0.0/).
@@ -14,8 +14,12 @@ regex-style-search=True
 line-length=120
 
 [ignore-body-lines]
-# Ignore dependabot long lines.
-regex=^Bumps .+ from .+ to .+\.$
+regex=https?://
+
+[ignore-by-author-name]
+regex=(.*)dependabot(.*) #
+ignore=T1,body-min-length
+
 
 [contrib-title-conventional-commits]
 # Specify allowed commit types. For details see: https://www.conventionalcommits.org/


### PR DESCRIPTION
Enables detection of failing bash pipelines:

> When shell: bash is specified, -o pipefail is also applied to
> enforce early exit from pipelines that generate a non-zero exit status.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
