### PR TITLE
fix: bring back missing docker handlers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -150,10 +151,7 @@ func main() {
 
 	// dockerMetaPatchHandlers combines all Docker patch and variable handlers under a single handler.
 	// It allows to specify configuration under a single variable.
-	dockerMetaPatchHandlers := append(
-		[]mutation.MetaMutater{},
-		genericMetaPatchHandlers...,
-	)
+	dockerMetaPatchHandlers := slices.Clone(genericMetaPatchHandlers)
 	dockerMetaHandlers := []handlers.Named{
 		dockerclusterconfig.NewVariable(),
 		mutation.NewMetaGeneratePatchesHandler(

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -150,7 +150,10 @@ func main() {
 
 	// dockerMetaPatchHandlers combines all Docker patch and variable handlers under a single handler.
 	// It allows to specify configuration under a single variable.
-	dockerMetaPatchHandlers := []mutation.MetaMutater{}
+	dockerMetaPatchHandlers := append(
+		[]mutation.MetaMutater{},
+		genericMetaPatchHandlers...,
+	)
 	dockerMetaHandlers := []handlers.Named{
 		dockerclusterconfig.NewVariable(),
 		mutation.NewMetaGeneratePatchesHandler(


### PR DESCRIPTION
Structured this in the same way as the AWS handlers.