### PR TITLE
refactor: Use consistent decoder in mutators

### DIFF
--- a/common/pkg/capi/clustertopology/handlers/mutation/meta.go
+++ b/common/pkg/capi/clustertopology/handlers/mutation/meta.go
@@ -15,7 +15,7 @@ import (
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 )
 
-type MetaMutater interface {
+type MetaMutator interface {
 	Mutate(
 		ctx context.Context,
 		obj runtime.Object,
@@ -28,18 +28,18 @@ type MetaMutater interface {
 type metaGeneratePatches struct {
 	name     string
 	decoder  runtime.Decoder
-	mutaters []MetaMutater
+	mutators []MetaMutator
 }
 
 func NewMetaGeneratePatchesHandler(
 	name string,
 	decoder runtime.Decoder,
-	mutators ...MetaMutater,
+	mutators ...MetaMutator,
 ) handlers.Named {
 	return metaGeneratePatches{
 		name:     name,
 		decoder:  decoder,
-		mutaters: mutators,
+		mutators: mutators,
 	}
 }
 
@@ -65,7 +65,7 @@ func (mgp metaGeneratePatches) GeneratePatches(
 			vars map[string]apiextensionsv1.JSON,
 			holderRef runtimehooksv1.HolderReference,
 		) error {
-			for _, h := range mgp.mutaters {
+			for _, h := range mgp.mutators {
 				if err := h.Mutate(ctx, obj, vars, holderRef, clusterKey); err != nil {
 					return err
 				}

--- a/common/pkg/capi/clustertopology/handlers/mutation/meta_test.go
+++ b/common/pkg/capi/clustertopology/handlers/mutation/meta_test.go
@@ -30,7 +30,7 @@ type testHandler struct {
 	mutateControlPlane bool
 }
 
-var _ MetaMutater = &testHandler{}
+var _ MetaMutator = &testHandler{}
 
 func (h *testHandler) Mutate(
 	_ context.Context,
@@ -89,7 +89,7 @@ func TestMetaGeneratePatches(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		mutaters         []MetaMutater
+		mutaters         []MetaMutator
 		expectedResponse *runtimehooksv1.GeneratePatchesResponse
 	}{{
 		name: "no handlers",
@@ -109,7 +109,7 @@ func TestMetaGeneratePatches(t *testing.T) {
 		},
 	}, {
 		name: "single success handler",
-		mutaters: []MetaMutater{
+		mutaters: []MetaMutator{
 			&testHandler{},
 		},
 		expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
@@ -134,7 +134,7 @@ func TestMetaGeneratePatches(t *testing.T) {
 		},
 	}, {
 		name: "single failure handler",
-		mutaters: []MetaMutater{
+		mutaters: []MetaMutator{
 			&testHandler{
 				returnErr: true,
 			},
@@ -147,7 +147,7 @@ func TestMetaGeneratePatches(t *testing.T) {
 		},
 	}, {
 		name: "multiple success handlers",
-		mutaters: []MetaMutater{
+		mutaters: []MetaMutator{
 			&testHandler{},
 			&testHandler{},
 			&testHandler{mutateControlPlane: true},
@@ -184,7 +184,7 @@ func TestMetaGeneratePatches(t *testing.T) {
 		},
 	}, {
 		name: "success handler followed by failure handler",
-		mutaters: []MetaMutater{
+		mutaters: []MetaMutator{
 			&testHandler{},
 			&testHandler{
 				returnErr: true,
@@ -198,7 +198,7 @@ func TestMetaGeneratePatches(t *testing.T) {
 		},
 	}, {
 		name: "failure handler followed by success handler",
-		mutaters: []MetaMutater{
+		mutaters: []MetaMutator{
 			&testHandler{
 				returnErr: true,
 			},

--- a/pkg/handlers/aws/mutation/metapatch_handler.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler.go
@@ -16,10 +16,10 @@ import (
 // MetaPatchHandler returns a meta patch handler for mutating CAPD clusters.
 func MetaPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers := append(
-		[]mutation.MetaMutater{
+		[]mutation.MetaMutator{
 			region.NewMetaPatch(),
 		},
-		genericmutation.MetaMutaters(mgr)...,
+		genericmutation.MetaMutators(mgr)...,
 	)
 
 	return mutation.NewMetaGeneratePatchesHandler(

--- a/pkg/handlers/aws/mutation/region/inject.go
+++ b/pkg/handlers/aws/mutation/region/inject.go
@@ -31,7 +31,6 @@ const (
 )
 
 type awsRegionPatchHandler struct {
-	decoder           runtime.Decoder
 	variableName      string
 	variableFieldPath []string
 }
@@ -39,7 +38,7 @@ type awsRegionPatchHandler struct {
 var (
 	_ commonhandlers.Named     = &awsRegionPatchHandler{}
 	_ mutation.GeneratePatches = &awsRegionPatchHandler{}
-	_ mutation.MetaMutater     = &awsRegionPatchHandler{}
+	_ mutation.MetaMutator     = &awsRegionPatchHandler{}
 )
 
 func NewPatch() *awsRegionPatchHandler {
@@ -55,7 +54,6 @@ func newAWSRegionPatchHandler(
 	variableFieldPath ...string,
 ) *awsRegionPatchHandler {
 	return &awsRegionPatchHandler{
-		decoder:           apis.CAPADecoder(),
 		variableName:      variableName,
 		variableFieldPath: variableFieldPath,
 	}
@@ -124,7 +122,7 @@ func (h *awsRegionPatchHandler) GeneratePatches(
 ) {
 	topologymutation.WalkTemplates(
 		ctx,
-		h.decoder,
+		apis.CAPADecoder(),
 		req,
 		resp,
 		func(

--- a/pkg/handlers/docker/mutation/customimage/inject.go
+++ b/pkg/handlers/docker/mutation/customimage/inject.go
@@ -35,7 +35,6 @@ const (
 )
 
 type customImagePatchHandler struct {
-	decoder           runtime.Decoder
 	variableName      string
 	variableFieldPath []string
 }
@@ -43,7 +42,7 @@ type customImagePatchHandler struct {
 var (
 	_ commonhandlers.Named     = &customImagePatchHandler{}
 	_ mutation.GeneratePatches = &customImagePatchHandler{}
-	_ mutation.MetaMutater     = &customImagePatchHandler{}
+	_ mutation.MetaMutator     = &customImagePatchHandler{}
 )
 
 func NewPatch() *customImagePatchHandler {
@@ -59,7 +58,6 @@ func newCustomImagePatchHandler(
 	variableFieldPath ...string,
 ) *customImagePatchHandler {
 	return &customImagePatchHandler{
-		decoder:           apis.CAPDDecoder(),
 		variableName:      variableName,
 		variableFieldPath: variableFieldPath,
 	}
@@ -195,7 +193,7 @@ func (h *customImagePatchHandler) GeneratePatches(
 ) {
 	topologymutation.WalkTemplates(
 		ctx,
-		h.decoder,
+		apis.CAPDDecoder(),
 		req,
 		resp,
 		func(

--- a/pkg/handlers/docker/mutation/metapatch_handler.go
+++ b/pkg/handlers/docker/mutation/metapatch_handler.go
@@ -16,10 +16,10 @@ import (
 // MetaPatchHandler returns a meta patch handler for mutating CAPD clusters.
 func MetaPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers := append(
-		[]mutation.MetaMutater{
+		[]mutation.MetaMutator{
 			customimage.NewMetaPatch(),
 		},
-		genericmutation.MetaMutaters(mgr)...,
+		genericmutation.MetaMutators(mgr)...,
 	)
 
 	return mutation.NewMetaGeneratePatchesHandler(

--- a/pkg/handlers/generic/mutation/auditpolicy/inject.go
+++ b/pkg/handlers/generic/mutation/auditpolicy/inject.go
@@ -28,14 +28,12 @@ const (
 	HandlerNamePatch = "AuditPolicyPatch"
 )
 
-type auditPolicyPatchHandler struct {
-	decoder runtime.Decoder
-}
+type auditPolicyPatchHandler struct{}
 
 var (
 	_ handlers.Named           = &auditPolicyPatchHandler{}
 	_ mutation.GeneratePatches = &auditPolicyPatchHandler{}
-	_ mutation.MetaMutater     = &auditPolicyPatchHandler{}
+	_ mutation.MetaMutator     = &auditPolicyPatchHandler{}
 
 	//go:embed embedded/apiserver-audit-policy.yaml
 	auditPolicy string
@@ -44,9 +42,7 @@ var (
 const auditPolicyPath = "/etc/kubernetes/audit-policy/apiserver-audit-policy.yaml"
 
 func NewPatch() *auditPolicyPatchHandler {
-	return &auditPolicyPatchHandler{
-		decoder: apis.CAPIDecoder(),
-	}
+	return &auditPolicyPatchHandler{}
 }
 
 func (h *auditPolicyPatchHandler) Name() string {
@@ -126,7 +122,7 @@ func (h *auditPolicyPatchHandler) GeneratePatches(
 ) {
 	topologymutation.WalkTemplates(
 		ctx,
-		h.decoder,
+		apis.CAPIDecoder(),
 		req,
 		resp,
 		func(

--- a/pkg/handlers/generic/mutation/etcd/inject.go
+++ b/pkg/handlers/generic/mutation/etcd/inject.go
@@ -32,7 +32,6 @@ const (
 )
 
 type etcdPatchHandler struct {
-	decoder           runtime.Decoder
 	variableName      string
 	variableFieldPath []string
 }
@@ -40,7 +39,7 @@ type etcdPatchHandler struct {
 var (
 	_ commonhandlers.Named     = &etcdPatchHandler{}
 	_ mutation.GeneratePatches = &etcdPatchHandler{}
-	_ mutation.MetaMutater     = &etcdPatchHandler{}
+	_ mutation.MetaMutator     = &etcdPatchHandler{}
 )
 
 func NewPatch() *etcdPatchHandler {
@@ -56,7 +55,6 @@ func newEtcdPatchHandler(
 	variableFieldPath ...string,
 ) *etcdPatchHandler {
 	return &etcdPatchHandler{
-		decoder:           apis.CAPIDecoder(),
 		variableName:      variableName,
 		variableFieldPath: variableFieldPath,
 	}
@@ -134,7 +132,7 @@ func (h *etcdPatchHandler) GeneratePatches(
 ) {
 	topologymutation.WalkTemplates(
 		ctx,
-		h.decoder,
+		apis.CAPIDecoder(),
 		req,
 		resp,
 		func(

--- a/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
+++ b/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
@@ -32,7 +32,6 @@ const (
 )
 
 type extraAPIServerCertSANsPatchHandler struct {
-	decoder           runtime.Decoder
 	variableName      string
 	variableFieldPath []string
 }
@@ -40,7 +39,7 @@ type extraAPIServerCertSANsPatchHandler struct {
 var (
 	_ commonhandlers.Named     = &extraAPIServerCertSANsPatchHandler{}
 	_ mutation.GeneratePatches = &extraAPIServerCertSANsPatchHandler{}
-	_ mutation.MetaMutater     = &extraAPIServerCertSANsPatchHandler{}
+	_ mutation.MetaMutator     = &extraAPIServerCertSANsPatchHandler{}
 )
 
 func NewPatch() *extraAPIServerCertSANsPatchHandler {
@@ -56,7 +55,6 @@ func newExtraAPIServerCertSANsPatchHandler(
 	variableFieldPath ...string,
 ) *extraAPIServerCertSANsPatchHandler {
 	return &extraAPIServerCertSANsPatchHandler{
-		decoder:           apis.CAPIDecoder(),
 		variableName:      variableName,
 		variableFieldPath: variableFieldPath,
 	}
@@ -124,7 +122,7 @@ func (h *extraAPIServerCertSANsPatchHandler) GeneratePatches(
 ) {
 	topologymutation.WalkTemplates(
 		ctx,
-		h.decoder,
+		apis.CAPIDecoder(),
 		req,
 		resp,
 		func(

--- a/pkg/handlers/generic/mutation/handlers.go
+++ b/pkg/handlers/generic/mutation/handlers.go
@@ -15,9 +15,9 @@ import (
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/kubernetesimagerepository"
 )
 
-// MetaMutaters returns all generic patch handlers.
-func MetaMutaters(mgr manager.Manager) []mutation.MetaMutater {
-	return []mutation.MetaMutater{
+// MetaMutators returns all generic patch handlers.
+func MetaMutators(mgr manager.Manager) []mutation.MetaMutator {
+	return []mutation.MetaMutator{
 		auditpolicy.NewPatch(),
 		etcd.NewMetaPatch(),
 		extraapiservercertsans.NewMetaPatch(),

--- a/pkg/handlers/generic/mutation/httpproxy/inject.go
+++ b/pkg/handlers/generic/mutation/httpproxy/inject.go
@@ -38,8 +38,7 @@ const (
 )
 
 type httpProxyPatchHandler struct {
-	decoder runtime.Decoder
-	client  ctrlclient.Reader
+	client ctrlclient.Reader
 
 	variableName      string
 	variableFieldPath []string
@@ -68,7 +67,6 @@ func newHTTPProxyPatchHandler(
 	variableFieldPath ...string,
 ) *httpProxyPatchHandler {
 	return &httpProxyPatchHandler{
-		decoder:           apis.CAPIDecoder(),
 		client:            cl,
 		variableName:      variableName,
 		variableFieldPath: variableFieldPath,
@@ -159,7 +157,7 @@ func (h *httpProxyPatchHandler) GeneratePatches(
 
 	topologymutation.WalkTemplates(
 		ctx,
-		h.decoder,
+		apis.CAPIDecoder(),
 		req,
 		resp,
 		func(

--- a/pkg/handlers/generic/mutation/kubernetesimagerepository/inject.go
+++ b/pkg/handlers/generic/mutation/kubernetesimagerepository/inject.go
@@ -32,7 +32,6 @@ const (
 )
 
 type imageRepositoryPatchHandler struct {
-	decoder           runtime.Decoder
 	variableName      string
 	variableFieldPath []string
 }
@@ -40,7 +39,7 @@ type imageRepositoryPatchHandler struct {
 var (
 	_ commonhandlers.Named     = &imageRepositoryPatchHandler{}
 	_ mutation.GeneratePatches = &imageRepositoryPatchHandler{}
-	_ mutation.MetaMutater     = &imageRepositoryPatchHandler{}
+	_ mutation.MetaMutator     = &imageRepositoryPatchHandler{}
 )
 
 func NewPatch() *imageRepositoryPatchHandler {
@@ -56,7 +55,6 @@ func newImageRepositoryPatchHandler(
 	variableFieldPath ...string,
 ) *imageRepositoryPatchHandler {
 	return &imageRepositoryPatchHandler{
-		decoder:           apis.CAPIDecoder(),
 		variableName:      variableName,
 		variableFieldPath: variableFieldPath,
 	}
@@ -124,7 +122,7 @@ func (h *imageRepositoryPatchHandler) GeneratePatches(
 ) {
 	topologymutation.WalkTemplates(
 		ctx,
-		h.decoder,
+		apis.CAPIDecoder(),
 		req,
 		resp,
 		func(


### PR DESCRIPTION
Also fixes my typo in `mutater` to `mutator`.
