### PR TITLE
fix: typo in docker cluster config api

### DIFF
--- a/api/v1alpha1/docker_clusterconfig_types.go
+++ b/api/v1alpha1/docker_clusterconfig_types.go
@@ -19,7 +19,7 @@ type DockerClusterConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec AWSClusterConfigSpec `json:"spec,omitempty"`
+	Spec DockerClusterConfigSpec `json:"spec,omitempty"`
 }
 
 // DockerClusterConfigSpec defines the desired state of DockerClusterConfig.


### PR DESCRIPTION
Found typo while going through the code. 