### PR TITLE
fix: Ensure CNI ingress rules are added to AWSCluster

### DIFF
--- a/common/pkg/testutils/capitest/request/items.go
+++ b/common/pkg/testutils/capitest/request/items.go
@@ -113,14 +113,26 @@ func NewKubeadmControlPlaneTemplateRequestItem(
 
 func NewAWSClusterTemplateRequestItem(
 	uid types.UID,
+	existingSpec ...capav1.AWSClusterTemplateSpec,
 ) runtimehooksv1.GeneratePatchesRequestItem {
-	return NewRequestItem(
-		&capav1.AWSClusterTemplate{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: capav1.GroupVersion.String(),
-				Kind:       "AWSClusterTemplate",
-			},
+	awsClusterTemplate := &capav1.AWSClusterTemplate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: capav1.GroupVersion.String(),
+			Kind:       "AWSClusterTemplate",
 		},
+	}
+
+	switch len(existingSpec) {
+	case 0:
+		// Do nothing.
+	case 1:
+		awsClusterTemplate.Spec = existingSpec[0]
+	default:
+		panic("can only take at most one existing spec")
+	}
+
+	return NewRequestItem(
+		awsClusterTemplate,
 		&runtimehooksv1.HolderReference{
 			Kind:      "Cluster",
 			FieldPath: "spec.infrastructureRef",

--- a/pkg/handlers/aws/mutation/cni/calico/inject.go
+++ b/pkg/handlers/aws/mutation/cni/calico/inject.go
@@ -48,7 +48,11 @@ func NewPatch() *calicoPatchHandler {
 }
 
 func NewMetaPatch() *calicoPatchHandler {
-	return newCalicoPatchHandler(clusterconfig.MetaVariableName, cni.VariableName)
+	return newCalicoPatchHandler(
+		clusterconfig.MetaVariableName,
+		"addons",
+		cni.VariableName,
+	)
 }
 
 func newCalicoPatchHandler(

--- a/pkg/handlers/aws/mutation/cni/calico/tests/generate_patches.go
+++ b/pkg/handlers/aws/mutation/cni/calico/tests/generate_patches.go
@@ -51,7 +51,7 @@ func TestGeneratePatches(
 				Path:      "/spec/template/spec/network/cni",
 				ValueMatcher: gomega.HaveKeyWithValue(
 					"cniIngressRules",
-					gomega.ContainElements(
+					gomega.ConsistOf(
 						gomega.SatisfyAll(
 							gomega.HaveKeyWithValue("description", "typha (calico)"),
 							gomega.HaveKeyWithValue(
@@ -98,6 +98,178 @@ func TestGeneratePatches(
 							gomega.HaveKeyWithValue("toPort", gomega.BeEquivalentTo(9093)),
 						),
 					),
+				),
+			}},
+		},
+		capitest.PatchTestDef{
+			Name: "provider set with AWSClusterTemplate pre-existing rules",
+			Vars: []runtimehooksv1.Variable{
+				capitest.VariableWithValue(
+					variableName,
+					v1alpha1.CNI{
+						Provider: v1alpha1.CNIProviderCalico,
+					},
+					variablePath...,
+				),
+			},
+			RequestItem: request.NewAWSClusterTemplateRequestItem(
+				"1234",
+				capav1.AWSClusterTemplateSpec{
+					Template: capav1.AWSClusterTemplateResource{
+						Spec: capav1.AWSClusterSpec{
+							NetworkSpec: capav1.NetworkSpec{
+								CNI: &capav1.CNISpec{
+									CNIIngressRules: []capav1.CNIIngressRule{{
+										Description: "test",
+										Protocol:    capav1.SecurityGroupProtocolAll,
+										FromPort:    1234,
+										ToPort:      12345,
+									}},
+								},
+							},
+						},
+					},
+				},
+			),
+			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{{
+				Operation: "add",
+				Path:      "/spec/template/spec/network/cni/cniIngressRules/1",
+				ValueMatcher: gomega.SatisfyAll(
+					gomega.HaveKeyWithValue("description", "typha (calico)"),
+					gomega.HaveKeyWithValue(
+						"protocol",
+						gomega.BeEquivalentTo(capav1.SecurityGroupProtocolTCP),
+					),
+					gomega.HaveKeyWithValue("fromPort", gomega.BeEquivalentTo(5473)),
+					gomega.HaveKeyWithValue("toPort", gomega.BeEquivalentTo(5473)),
+				),
+			}, {
+				Operation: "add",
+				Path:      "/spec/template/spec/network/cni/cniIngressRules/2",
+				ValueMatcher: gomega.SatisfyAll(
+					gomega.HaveKeyWithValue("description", "bgp (calico)"),
+					gomega.HaveKeyWithValue(
+						"protocol",
+						gomega.BeEquivalentTo(capav1.SecurityGroupProtocolTCP),
+					),
+					gomega.HaveKeyWithValue("fromPort", gomega.BeEquivalentTo(179)),
+					gomega.HaveKeyWithValue("toPort", gomega.BeEquivalentTo(179)),
+				),
+			}, {
+				Operation: "add",
+				Path:      "/spec/template/spec/network/cni/cniIngressRules/3",
+				ValueMatcher: gomega.SatisfyAll(
+					gomega.HaveKeyWithValue("description", "IP-in-IP (calico)"),
+					gomega.HaveKeyWithValue(
+						"protocol",
+						gomega.BeEquivalentTo(capav1.SecurityGroupProtocolIPinIP),
+					),
+					gomega.HaveKeyWithValue("fromPort", gomega.BeEquivalentTo(-1)),
+					gomega.HaveKeyWithValue("toPort", gomega.BeEquivalentTo(65535)),
+				),
+			}, {
+				Operation: "add",
+				Path:      "/spec/template/spec/network/cni/cniIngressRules/4",
+				ValueMatcher: gomega.SatisfyAll(
+					gomega.HaveKeyWithValue("description", "node metrics (calico)"),
+					gomega.HaveKeyWithValue(
+						"protocol",
+						gomega.BeEquivalentTo(capav1.SecurityGroupProtocolTCP),
+					),
+					gomega.HaveKeyWithValue("fromPort", gomega.BeEquivalentTo(9091)),
+					gomega.HaveKeyWithValue("toPort", gomega.BeEquivalentTo(9091)),
+				),
+			}, {
+				Operation: "add",
+				Path:      "/spec/template/spec/network/cni/cniIngressRules/5",
+				ValueMatcher: gomega.SatisfyAll(
+					gomega.HaveKeyWithValue("description", "typha metrics (calico)"),
+					gomega.HaveKeyWithValue(
+						"protocol",
+						gomega.BeEquivalentTo(capav1.SecurityGroupProtocolTCP),
+					),
+					gomega.HaveKeyWithValue("fromPort", gomega.BeEquivalentTo(9093)),
+					gomega.HaveKeyWithValue("toPort", gomega.BeEquivalentTo(9093)),
+				),
+			}},
+		},
+		capitest.PatchTestDef{
+			Name: "provider set with AWSClusterTemplate conflicting pre-existing rules",
+			Vars: []runtimehooksv1.Variable{
+				capitest.VariableWithValue(
+					variableName,
+					v1alpha1.CNI{
+						Provider: v1alpha1.CNIProviderCalico,
+					},
+					variablePath...,
+				),
+			},
+			RequestItem: request.NewAWSClusterTemplateRequestItem(
+				"1234",
+				capav1.AWSClusterTemplateSpec{
+					Template: capav1.AWSClusterTemplateResource{
+						Spec: capav1.AWSClusterSpec{
+							NetworkSpec: capav1.NetworkSpec{
+								CNI: &capav1.CNISpec{
+									CNIIngressRules: []capav1.CNIIngressRule{{
+										Description: "typha (calico)",
+										Protocol:    capav1.SecurityGroupProtocolTCP,
+										FromPort:    5473,
+										ToPort:      5473,
+									}},
+								},
+							},
+						},
+					},
+				},
+			),
+			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{{
+				Operation: "add",
+				Path:      "/spec/template/spec/network/cni/cniIngressRules/1",
+				ValueMatcher: gomega.SatisfyAll(
+					gomega.HaveKeyWithValue("description", "bgp (calico)"),
+					gomega.HaveKeyWithValue(
+						"protocol",
+						gomega.BeEquivalentTo(capav1.SecurityGroupProtocolTCP),
+					),
+					gomega.HaveKeyWithValue("fromPort", gomega.BeEquivalentTo(179)),
+					gomega.HaveKeyWithValue("toPort", gomega.BeEquivalentTo(179)),
+				),
+			}, {
+				Operation: "add",
+				Path:      "/spec/template/spec/network/cni/cniIngressRules/2",
+				ValueMatcher: gomega.SatisfyAll(
+					gomega.HaveKeyWithValue("description", "IP-in-IP (calico)"),
+					gomega.HaveKeyWithValue(
+						"protocol",
+						gomega.BeEquivalentTo(capav1.SecurityGroupProtocolIPinIP),
+					),
+					gomega.HaveKeyWithValue("fromPort", gomega.BeEquivalentTo(-1)),
+					gomega.HaveKeyWithValue("toPort", gomega.BeEquivalentTo(65535)),
+				),
+			}, {
+				Operation: "add",
+				Path:      "/spec/template/spec/network/cni/cniIngressRules/3",
+				ValueMatcher: gomega.SatisfyAll(
+					gomega.HaveKeyWithValue("description", "node metrics (calico)"),
+					gomega.HaveKeyWithValue(
+						"protocol",
+						gomega.BeEquivalentTo(capav1.SecurityGroupProtocolTCP),
+					),
+					gomega.HaveKeyWithValue("fromPort", gomega.BeEquivalentTo(9091)),
+					gomega.HaveKeyWithValue("toPort", gomega.BeEquivalentTo(9091)),
+				),
+			}, {
+				Operation: "add",
+				Path:      "/spec/template/spec/network/cni/cniIngressRules/4",
+				ValueMatcher: gomega.SatisfyAll(
+					gomega.HaveKeyWithValue("description", "typha metrics (calico)"),
+					gomega.HaveKeyWithValue(
+						"protocol",
+						gomega.BeEquivalentTo(capav1.SecurityGroupProtocolTCP),
+					),
+					gomega.HaveKeyWithValue("fromPort", gomega.BeEquivalentTo(9093)),
+					gomega.HaveKeyWithValue("toPort", gomega.BeEquivalentTo(9093)),
 				),
 			}},
 		},

--- a/pkg/handlers/aws/mutation/metapatch_handler.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/aws/mutation/cni/calico"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/aws/mutation/region"
 	genericmutation "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation"
 )
@@ -18,6 +19,7 @@ func MetaPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers := append(
 		[]mutation.MetaMutator{
 			region.NewMetaPatch(),
+			calico.NewMetaPatch(),
 		},
 		genericmutation.MetaMutators(mgr)...,
 	)

--- a/pkg/handlers/aws/mutation/metapatch_handler_test.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler_test.go
@@ -12,9 +12,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
+	awsclusterconfig "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/aws/clusterconfig"
 	calicotests "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/aws/mutation/cni/calico/tests"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/aws/mutation/region"
 	regiontests "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/aws/mutation/region/tests"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/clusterconfig"
 	auditpolicytests "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/auditpolicy/tests"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/cni"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/etcd"
@@ -23,6 +25,7 @@ import (
 	extraapiservercertsanstests "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/extraapiservercertsans/tests"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/httpproxy"
 	httpproxytests "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/httpproxy/tests"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/imageregistries"
 	imageregistrycredentials "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/imageregistries/credentials"
 	imageregistrycredentialstests "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/imageregistries/credentials/tests"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/kubernetesimagerepository"
@@ -50,9 +53,17 @@ func TestGeneratePatches(t *testing.T) {
 	regiontests.TestGeneratePatches(
 		t,
 		metaPatchGeneratorFunc(mgr),
-		"clusterConfig",
-		"aws",
+		clusterconfig.MetaVariableName,
+		awsclusterconfig.AWSVariableName,
 		region.VariableName,
+	)
+
+	calicotests.TestGeneratePatches(
+		t,
+		metaPatchGeneratorFunc(mgr),
+		clusterconfig.MetaVariableName,
+		"addons",
+		cni.VariableName,
 	)
 
 	auditpolicytests.TestGeneratePatches(
@@ -63,28 +74,28 @@ func TestGeneratePatches(t *testing.T) {
 	httpproxytests.TestGeneratePatches(
 		t,
 		metaPatchGeneratorFunc(mgr),
-		"clusterConfig",
+		clusterconfig.MetaVariableName,
 		httpproxy.VariableName,
 	)
 
 	etcdtests.TestGeneratePatches(
 		t,
 		metaPatchGeneratorFunc(mgr),
-		"clusterConfig",
+		clusterconfig.MetaVariableName,
 		etcd.VariableName,
 	)
 
 	extraapiservercertsanstests.TestGeneratePatches(
 		t,
 		metaPatchGeneratorFunc(mgr),
-		"clusterConfig",
+		clusterconfig.MetaVariableName,
 		extraapiservercertsans.VariableName,
 	)
 
 	kubernetesimagerepositorytests.TestGeneratePatches(
 		t,
 		metaPatchGeneratorFunc(mgr),
-		"clusterConfig",
+		clusterconfig.MetaVariableName,
 		kubernetesimagerepository.VariableName,
 	)
 
@@ -92,15 +103,8 @@ func TestGeneratePatches(t *testing.T) {
 		t,
 		metaPatchGeneratorFunc(mgr),
 		mgr.GetClient(),
-		"clusterConfig",
-		"imageRegistries",
+		clusterconfig.MetaVariableName,
+		imageregistries.VariableName,
 		imageregistrycredentials.VariableName,
-	)
-
-	calicotests.TestGeneratePatches(
-		t,
-		metaPatchGeneratorFunc(mgr),
-		"clusterConfig",
-		cni.VariableName,
 	)
 }

--- a/pkg/handlers/docker/mutation/metapatch_handler_test.go
+++ b/pkg/handlers/docker/mutation/metapatch_handler_test.go
@@ -12,8 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
+	dockerclusterconfig "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/docker/clusterconfig"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/docker/mutation/customimage"
 	customimagetests "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/docker/mutation/customimage/tests"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/clusterconfig"
 	auditpolicytests "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/auditpolicy/tests"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/etcd"
 	etcdtests "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/etcd/tests"
@@ -21,6 +23,7 @@ import (
 	extraapiservercertsanstests "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/extraapiservercertsans/tests"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/httpproxy"
 	httpproxytests "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/httpproxy/tests"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/imageregistries"
 	imageregistrycredentials "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/imageregistries/credentials"
 	imageregistrycredentialstests "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/imageregistries/credentials/tests"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/kubernetesimagerepository"
@@ -48,8 +51,8 @@ func TestGeneratePatches(t *testing.T) {
 	customimagetests.TestGeneratePatches(
 		t,
 		metaPatchGeneratorFunc(mgr),
-		"clusterConfig",
-		"docker",
+		clusterconfig.MetaVariableName,
+		dockerclusterconfig.DockerVariableName,
 		customimage.VariableName,
 	)
 
@@ -61,28 +64,28 @@ func TestGeneratePatches(t *testing.T) {
 	httpproxytests.TestGeneratePatches(
 		t,
 		metaPatchGeneratorFunc(mgr),
-		"clusterConfig",
+		clusterconfig.MetaVariableName,
 		httpproxy.VariableName,
 	)
 
 	etcdtests.TestGeneratePatches(
 		t,
 		metaPatchGeneratorFunc(mgr),
-		"clusterConfig",
+		clusterconfig.MetaVariableName,
 		etcd.VariableName,
 	)
 
 	extraapiservercertsanstests.TestGeneratePatches(
 		t,
 		metaPatchGeneratorFunc(mgr),
-		"clusterConfig",
+		clusterconfig.MetaVariableName,
 		extraapiservercertsans.VariableName,
 	)
 
 	kubernetesimagerepositorytests.TestGeneratePatches(
 		t,
 		metaPatchGeneratorFunc(mgr),
-		"clusterConfig",
+		clusterconfig.MetaVariableName,
 		kubernetesimagerepository.VariableName,
 	)
 
@@ -90,8 +93,8 @@ func TestGeneratePatches(t *testing.T) {
 		t,
 		metaPatchGeneratorFunc(mgr),
 		mgr.GetClient(),
-		"clusterConfig",
-		"imageRegistries",
+		clusterconfig.MetaVariableName,
+		imageregistries.VariableName,
 		imageregistrycredentials.VariableName,
 	)
 }


### PR DESCRIPTION
This fixes 2 problems:

- handler was not registered in AWS meta patch handler
- handler was not updated to use `clusterConfig.addons.cni` when CNI config was moved under addons property