### PR TITLE
fix: Reduce log verbosity for http proxy variable not found

### DIFF
--- a/pkg/handlers/generic/mutation/httpproxy/inject.go
+++ b/pkg/handlers/generic/mutation/httpproxy/inject.go
@@ -100,7 +100,7 @@ func (h *httpProxyPatchHandler) Mutate(
 		return err
 	}
 	if !found {
-		log.Info("http proxy variable not defined")
+		log.V(5).Info("http proxy variable not defined")
 		return nil
 	}
 


### PR DESCRIPTION
Stop spamming logs...
