### PR TITLE
fix: Don't set AWS region as required

### DIFF
--- a/api/v1alpha1/aws_clusterconfig_types.go
+++ b/api/v1alpha1/aws_clusterconfig_types.go
@@ -5,8 +5,6 @@ package v1alpha1
 
 import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
 )
 
 type AWSSpec struct {
@@ -22,7 +20,6 @@ func (AWSSpec) VariableSchema() clusterv1.VariableSchema {
 			Properties: map[string]clusterv1.JSONSchemaProps{
 				"region": Region("").VariableSchema().OpenAPIV3Schema,
 			},
-			Required: []string{"region"},
 		},
 	}
 }
@@ -33,7 +30,6 @@ func (Region) VariableSchema() clusterv1.VariableSchema {
 	return clusterv1.VariableSchema{
 		OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 			Type:        "string",
-			Default:     variables.MustMarshal("us-west-2"),
 			Description: "AWS region to create cluster in",
 		},
 	}

--- a/examples/capi-quick-start/aws-cluster.yaml
+++ b/examples/capi-quick-start/aws-cluster.yaml
@@ -27,7 +27,8 @@ spec:
               providers:
                 - name: aws-ebs
             nfd: {}
-          aws: {}
+          aws:
+            region: us-west-2
     version: v1.27.5
     workers:
       machineDeployments:

--- a/hack/examples/bases/aws/kustomization.yaml.tmpl
+++ b/hack/examples/bases/aws/kustomization.yaml.tmpl
@@ -31,7 +31,8 @@ patches:
       value:
         - name: "clusterConfig"
           value:
-            aws: {}
+            aws:
+              region: us-west-2
     - op: "add"
       path: "/spec/topology/variables/0/value/addons"
       value:


### PR DESCRIPTION
AWS region should not be required as it can be set in the ClusterClass. Making it optional and setting it in the example instead. It also doesn't really make sense to have a default in the code for a region since there is no "default".