### PR TITLE
refactor: Always use unstructured in patch generators

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -6,6 +6,7 @@ module github.com/d2iq-labs/capi-runtime-extensions/common
 go 1.21
 
 require (
+	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/go-logr/logr v1.2.4
 	github.com/onsi/gomega v1.28.0
 	github.com/spf13/pflag v1.0.5
@@ -31,7 +32,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
-	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/common/pkg/capi/clustertopology/handlers/mutation/meta.go
+++ b/common/pkg/capi/clustertopology/handlers/mutation/meta.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/exp/runtime/topologymutation"
@@ -17,7 +18,7 @@ import (
 
 type MutateFunc func(
 	ctx context.Context,
-	obj runtime.Object,
+	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	clusterKey client.ObjectKey,
@@ -26,7 +27,7 @@ type MutateFunc func(
 type MetaMutator interface {
 	Mutate(
 		ctx context.Context,
-		obj runtime.Object,
+		obj *unstructured.Unstructured,
 		vars map[string]apiextensionsv1.JSON,
 		holderRef runtimehooksv1.HolderReference,
 		clusterKey client.ObjectKey,
@@ -64,7 +65,7 @@ func (mgp metaGeneratePatches) GeneratePatches(
 
 	topologymutation.WalkTemplates(
 		ctx,
-		mgp.decoder,
+		unstructured.UnstructuredJSONScheme,
 		req,
 		resp,
 		func(
@@ -74,7 +75,7 @@ func (mgp metaGeneratePatches) GeneratePatches(
 			holderRef runtimehooksv1.HolderReference,
 		) error {
 			for _, h := range mgp.mutators {
-				if err := h.Mutate(ctx, obj, vars, holderRef, clusterKey); err != nil {
+				if err := h.Mutate(ctx, obj.(*unstructured.Unstructured), vars, holderRef, clusterKey); err != nil {
 					return err
 				}
 			}

--- a/common/pkg/capi/clustertopology/handlers/mutation/meta.go
+++ b/common/pkg/capi/clustertopology/handlers/mutation/meta.go
@@ -36,18 +36,15 @@ type MetaMutator interface {
 
 type metaGeneratePatches struct {
 	name     string
-	decoder  runtime.Decoder
 	mutators []MetaMutator
 }
 
 func NewMetaGeneratePatchesHandler(
 	name string,
-	decoder runtime.Decoder,
 	mutators ...MetaMutator,
 ) handlers.Named {
 	return metaGeneratePatches{
 		name:     name,
-		decoder:  decoder,
 		mutators: mutators,
 	}
 }

--- a/common/pkg/capi/clustertopology/handlers/mutation/meta_test.go
+++ b/common/pkg/capi/clustertopology/handlers/mutation/meta_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/onsi/gomega"
 	"gomodules.xyz/jsonpatch/v2"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -34,7 +34,7 @@ var _ MetaMutator = &testHandler{}
 
 func (h *testHandler) Mutate(
 	_ context.Context,
-	obj runtime.Object,
+	obj *unstructured.Unstructured,
 	_ map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
@@ -44,7 +44,7 @@ func (h *testHandler) Mutate(
 	}
 
 	if h.mutateControlPlane {
-		return patches.Generate(
+		return patches.MutateIfApplicable(
 			obj, nil, &holderRef, selectors.ControlPlane(), logr.Discard(),
 			func(obj *controlplanev1.KubeadmControlPlaneTemplate) error {
 				obj.Spec.Template.Spec.KubeadmConfigSpec.PostKubeadmCommands = append(
@@ -59,7 +59,7 @@ func (h *testHandler) Mutate(
 		)
 	}
 
-	return patches.Generate(
+	return patches.MutateIfApplicable(
 		obj,
 		machineVars(),
 		&holderRef,

--- a/common/pkg/capi/clustertopology/handlers/mutation/meta_test.go
+++ b/common/pkg/capi/clustertopology/handlers/mutation/meta_test.go
@@ -19,7 +19,6 @@ import (
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/testutils/capitest/request"
@@ -220,7 +219,7 @@ func TestMetaGeneratePatches(t *testing.T) {
 
 			g := gomega.NewWithT(t)
 
-			h := NewMetaGeneratePatchesHandler("", apis.CAPIDecoder(), tt.mutaters...).(GeneratePatches)
+			h := NewMetaGeneratePatchesHandler("", tt.mutaters...).(GeneratePatches)
 
 			resp := &runtimehooksv1.GeneratePatchesResponse{}
 			h.GeneratePatches(context.Background(), &runtimehooksv1.GeneratePatchesRequest{

--- a/common/pkg/capi/clustertopology/patches/generator.go
+++ b/common/pkg/capi/clustertopology/patches/generator.go
@@ -63,7 +63,12 @@ func MutateIfApplicable[T runtime.Object](
 	}
 
 	// Create JSON patches of the modifications.
-	serializer := kjson.NewSerializerWithOptions(kjson.DefaultMetaFactory, nil, nil, kjson.SerializerOptions{})
+	serializer := kjson.NewSerializerWithOptions(
+		kjson.DefaultMetaFactory,
+		nil,
+		nil,
+		kjson.SerializerOptions{},
+	)
 	var unmodifiedTypedBuf, modifiedTypedBuf bytes.Buffer
 	if err := serializer.Encode(unmodifiedTyped, &unmodifiedTypedBuf); err != nil {
 		return fmt.Errorf("failed to serialize unmodified typed object: %w", err)

--- a/common/pkg/capi/clustertopology/patches/generator.go
+++ b/common/pkg/capi/clustertopology/patches/generator.go
@@ -4,38 +4,110 @@
 package patches
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
+	jsonpatchapply "github.com/evanphx/json-patch/v5"
 	"github.com/go-logr/logr"
+	"gomodules.xyz/jsonpatch/v2"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches/matchers"
 )
 
-func Generate[T runtime.Object](
-	obj runtime.Object,
+// MutateIfApplicable applies the typed mutFn function to the unstructured input if the input
+// matches the holderRef and patchSelector. This is used by handlers to reduce the boilerplate
+// required there.
+//
+// This function makes it easier for handlers to work with typed objects, while ensuring that
+// patches properly work with minimal input documents. While it would feel more natural to work
+// purely with typed objects, due to the semantics of `omitempty` and non-pointer struct fields,
+// it is required to work with unstructured objects for input and output. This leads to minimal
+// patches, regardless of the completeness of the input type.
+func MutateIfApplicable[T runtime.Object](
+	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef *runtimehooksv1.HolderReference,
 	patchSelector clusterv1.PatchSelector,
 	log logr.Logger,
 	mutFn func(T) error,
 ) error {
-	typed, ok := obj.(T)
-	if !ok {
-		log.V(5).WithValues(
-			"objType", fmt.Sprintf("%T", obj),
-			"expectedType", fmt.Sprintf("%T", *new(T)),
-		).Info("not matching type")
-		return nil
-	}
-
+	// Check the object matches the selector.
 	if !matchers.MatchesSelector(patchSelector, obj, holderRef, vars) {
 		log.V(5).WithValues("selector", patchSelector).Info("not matching selector")
 		return nil
 	}
 
-	return mutFn(typed)
+	// Convert the unstructured object to the expected type.
+	var typed T
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructuredWithValidation(obj.Object, &typed, true); err != nil {
+		log.V(5).WithValues(
+			"objKind", obj.GetObjectKind().GroupVersionKind(),
+			"expectedType", fmt.Sprintf("%T", &typed),
+		).Info("not matching type")
+		return nil
+	}
+
+	// Create a deep clone of the typed object.
+	unmodifiedTyped := typed.DeepCopyObject()
+
+	// Apply the mutation.
+	if err := mutFn(typed); err != nil {
+		return fmt.Errorf("failed to apply mutation: %w", err)
+	}
+
+	// Create JSON patches of the modifications.
+	serializer := kjson.NewSerializerWithOptions(kjson.DefaultMetaFactory, nil, nil, kjson.SerializerOptions{})
+	var unmodifiedTypedBuf, modifiedTypedBuf bytes.Buffer
+	if err := serializer.Encode(unmodifiedTyped, &unmodifiedTypedBuf); err != nil {
+		return fmt.Errorf("failed to serialize unmodified typed object: %w", err)
+	}
+	if err := serializer.Encode(typed, &modifiedTypedBuf); err != nil {
+		return fmt.Errorf("failed to serialize unmodified typed object: %w", err)
+	}
+
+	jsonOps, err := jsonpatch.CreatePatch(unmodifiedTypedBuf.Bytes(), modifiedTypedBuf.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to create JSON patches for modified typed object: %w", err)
+	}
+
+	// Apply the patches to the original unstructured input.
+	jsonOpsBytes, err := json.Marshal(jsonOps)
+	if err != nil {
+		return fmt.Errorf("failed to marshal json patch: %w", err)
+	}
+
+	jsonPatch, err := jsonpatchapply.DecodePatch(jsonOpsBytes)
+	if err != nil {
+		return fmt.Errorf("failed to decode json patch (RFC6902): %w", err)
+	}
+
+	marshalledInputObj, err := obj.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("failed to marshal unstructured input object: %w", err)
+	}
+
+	patchedTemplate, err := jsonPatch.ApplyWithOptions(
+		marshalledInputObj,
+		&jsonpatchapply.ApplyOptions{
+			EnsurePathExistsOnAdd:    true,
+			AllowMissingPathOnRemove: true,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to apply JSON patches to input: %w", err)
+	}
+
+	// Finally unmarshal patched input into the original object. Mutation complete!
+	if err := obj.UnmarshalJSON(patchedTemplate); err != nil {
+		return fmt.Errorf("failed to unmarshal patched unstructured input: %w", err)
+	}
+
+	return nil
 }

--- a/common/pkg/capi/clustertopology/patches/generator_test.go
+++ b/common/pkg/capi/clustertopology/patches/generator_test.go
@@ -1,0 +1,115 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package patches
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+
+	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches/selectors"
+)
+
+func TestMutateIfApplicable(t *testing.T) {
+	t.Parallel()
+
+	type testSpec[T runtime.Object] struct {
+		name          string
+		input         *unstructured.Unstructured
+		holderRef     *runtimehooksv1.HolderReference
+		patchSelector clusterv1.PatchSelector
+		mutFn         func(T) error
+		expected      *unstructured.Unstructured
+	}
+	tests := []testSpec[*v1.ConfigMap]{{
+		name: "empty input matches holder and selector",
+		input: &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "controlplane.cluster.x-k8s.io/v1beta1",
+			"kind":       "KubeadmControlPlaneTemplate",
+		}},
+		holderRef: &runtimehooksv1.HolderReference{
+			Kind:      "Cluster",
+			FieldPath: "spec.controlPlaneRef",
+		},
+		patchSelector: selectors.ControlPlane(),
+		mutFn: func(obj *v1.ConfigMap) error {
+			if obj.Data == nil {
+				obj.Data = map[string]string{}
+			}
+			obj.Data["foo"] = "bar"
+			return nil
+		},
+		expected: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "controlplane.cluster.x-k8s.io/v1beta1",
+				"kind":       "KubeadmControlPlaneTemplate",
+				"data": map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+		},
+	}, {
+		name:  "empty input not matching holder and selector",
+		input: &unstructured.Unstructured{Object: map[string]interface{}{}},
+		holderRef: &runtimehooksv1.HolderReference{
+			Kind:      "NotMatching",
+			FieldPath: "spec.controlPlaneRef",
+		},
+		patchSelector: selectors.ControlPlane(),
+		mutFn: func(obj *v1.ConfigMap) error {
+			if obj.Data == nil {
+				obj.Data = map[string]string{}
+			}
+			obj.Data["foo"] = "bar"
+			return nil
+		},
+		expected: &unstructured.Unstructured{
+			Object: map[string]interface{}{},
+		},
+	}, {
+		name: "invalid typed object - ignored",
+		input: &unstructured.Unstructured{Object: map[string]interface{}{
+			"unknownField": "foo",
+		}},
+		holderRef: &runtimehooksv1.HolderReference{
+			Kind:      "Cluster",
+			FieldPath: "spec.controlPlaneRef",
+		},
+		patchSelector: selectors.ControlPlane(),
+		mutFn: func(obj *v1.ConfigMap) error {
+			return nil
+		},
+		expected: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"unknownField": "foo",
+			},
+		},
+	}}
+	for testIdx := range tests {
+		tt := tests[testIdx] // Capture loop var.
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			g := gomega.NewGomegaWithT(t)
+
+			err := MutateIfApplicable(
+				tt.input,
+				nil,
+				tt.holderRef,
+				tt.patchSelector,
+				logr.Discard(),
+				tt.mutFn,
+			)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(tt.input).To(gomega.Equal(tt.expected))
+		})
+	}
+}

--- a/examples/capi-quick-start/aws-cluster-ami.yaml
+++ b/examples/capi-quick-start/aws-cluster-ami.yaml
@@ -1,0 +1,52 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: aws
+  name: aws-quick-start
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - 10.128.0.0/12
+  topology:
+    class: aws-quick-start
+    controlPlane:
+      replicas: 1
+    variables:
+      - name: clusterConfig
+        value:
+          addons:
+            cni:
+              provider: calico
+            csi:
+              providers:
+                - name: aws-ebs
+            nfd: {}
+          aws: {}
+          controlPlane:
+            aws:
+              ami:
+                id: "ami-0d5d9d301c853a04a"
+    version: v1.27.5
+    workers:
+      machineDeployments:
+        - class: default-worker
+          name: md-0
+          replicas: 1
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSClusterStaticIdentity
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: aws
+  name: aws-quick-start
+spec:
+  allowedNamespaces:
+    list:
+      - default
+  secretRef: aws-quick-start-creds

--- a/pkg/handlers/aws/mutation/cni/calico/inject.go
+++ b/pkg/handlers/aws/mutation/cni/calico/inject.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/exp/runtime/topologymutation"
@@ -17,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
@@ -72,7 +72,7 @@ func (h *calicoPatchHandler) Name() string {
 
 func (h *calicoPatchHandler) Mutate(
 	ctx context.Context,
-	obj runtime.Object,
+	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
@@ -109,7 +109,7 @@ func (h *calicoPatchHandler) Mutate(
 		cniVar,
 	)
 
-	return patches.Generate(
+	return patches.MutateIfApplicable(
 		obj,
 		vars,
 		&holderRef,
@@ -126,7 +126,7 @@ func (h *calicoPatchHandler) GeneratePatches(
 ) {
 	topologymutation.WalkTemplates(
 		ctx,
-		apis.DecoderForScheme(apis.CAPAScheme()),
+		unstructured.UnstructuredJSONScheme,
 		req,
 		resp,
 		func(
@@ -135,7 +135,13 @@ func (h *calicoPatchHandler) GeneratePatches(
 			vars map[string]apiextensionsv1.JSON,
 			holderRef runtimehooksv1.HolderReference,
 		) error {
-			return h.Mutate(ctx, obj, vars, holderRef, client.ObjectKey{})
+			return h.Mutate(
+				ctx,
+				obj.(*unstructured.Unstructured),
+				vars,
+				holderRef,
+				client.ObjectKey{},
+			)
 		},
 	)
 }

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/inject_control_plane.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/inject_control_plane.go
@@ -8,13 +8,12 @@ import (
 	_ "embed"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
@@ -70,7 +69,7 @@ func (h *awsIAMInstanceProfileControlPlanePatchHandler) Name() string {
 
 func (h *awsIAMInstanceProfileControlPlanePatchHandler) Mutate(
 	ctx context.Context,
-	obj runtime.Object,
+	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
@@ -101,7 +100,7 @@ func (h *awsIAMInstanceProfileControlPlanePatchHandler) Mutate(
 		iamInstanceProfileVar,
 	)
 
-	return patches.Generate(
+	return patches.MutateIfApplicable(
 		obj,
 		vars,
 		&holderRef,
@@ -128,5 +127,5 @@ func (h *awsIAMInstanceProfileControlPlanePatchHandler) GeneratePatches(
 	req *runtimehooksv1.GeneratePatchesRequest,
 	resp *runtimehooksv1.GeneratePatchesResponse,
 ) {
-	handlers.GeneratePatches(ctx, req, resp, apis.CAPADecoder(), h.Mutate)
+	handlers.GeneratePatches(ctx, req, resp, h.Mutate)
 }

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/inject_worker.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/inject_worker.go
@@ -8,13 +8,12 @@ import (
 	_ "embed"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
@@ -66,7 +65,7 @@ func (h *awsIAMInstanceProfileWorkerPatchHandler) Name() string {
 
 func (h *awsIAMInstanceProfileWorkerPatchHandler) Mutate(
 	ctx context.Context,
-	obj runtime.Object,
+	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
@@ -97,7 +96,7 @@ func (h *awsIAMInstanceProfileWorkerPatchHandler) Mutate(
 		iamInstanceProfileVar,
 	)
 
-	return patches.Generate(
+	return patches.MutateIfApplicable(
 		obj,
 		vars,
 		&holderRef,
@@ -124,5 +123,5 @@ func (h *awsIAMInstanceProfileWorkerPatchHandler) GeneratePatches(
 	req *runtimehooksv1.GeneratePatchesRequest,
 	resp *runtimehooksv1.GeneratePatchesResponse,
 ) {
-	handlers.GeneratePatches(ctx, req, resp, apis.CAPADecoder(), h.Mutate)
+	handlers.GeneratePatches(ctx, req, resp, h.Mutate)
 }

--- a/pkg/handlers/aws/mutation/instancetype/inject_control_plane.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_control_plane.go
@@ -8,13 +8,12 @@ import (
 	_ "embed"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
@@ -70,7 +69,7 @@ func (h *awsInstanceTypeControlPlanePatchHandler) Name() string {
 
 func (h *awsInstanceTypeControlPlanePatchHandler) Mutate(
 	ctx context.Context,
-	obj runtime.Object,
+	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
@@ -101,7 +100,7 @@ func (h *awsInstanceTypeControlPlanePatchHandler) Mutate(
 		instanceTypeVar,
 	)
 
-	return patches.Generate(
+	return patches.MutateIfApplicable(
 		obj,
 		vars,
 		&holderRef,
@@ -128,5 +127,5 @@ func (h *awsInstanceTypeControlPlanePatchHandler) GeneratePatches(
 	req *runtimehooksv1.GeneratePatchesRequest,
 	resp *runtimehooksv1.GeneratePatchesResponse,
 ) {
-	handlers.GeneratePatches(ctx, req, resp, apis.CAPADecoder(), h.Mutate)
+	handlers.GeneratePatches(ctx, req, resp, h.Mutate)
 }

--- a/pkg/handlers/aws/mutation/instancetype/inject_worker.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_worker.go
@@ -8,13 +8,12 @@ import (
 	_ "embed"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
@@ -66,7 +65,7 @@ func (h *awsInstanceTypeWorkerPatchHandler) Name() string {
 
 func (h *awsInstanceTypeWorkerPatchHandler) Mutate(
 	ctx context.Context,
-	obj runtime.Object,
+	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
@@ -97,7 +96,7 @@ func (h *awsInstanceTypeWorkerPatchHandler) Mutate(
 		instanceTypeVar,
 	)
 
-	return patches.Generate(
+	return patches.MutateIfApplicable(
 		obj,
 		vars,
 		&holderRef,
@@ -124,5 +123,5 @@ func (h *awsInstanceTypeWorkerPatchHandler) GeneratePatches(
 	req *runtimehooksv1.GeneratePatchesRequest,
 	resp *runtimehooksv1.GeneratePatchesResponse,
 ) {
-	handlers.GeneratePatches(ctx, req, resp, apis.CAPADecoder(), h.Mutate)
+	handlers.GeneratePatches(ctx, req, resp, h.Mutate)
 }

--- a/pkg/handlers/aws/mutation/metapatch_handler.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler.go
@@ -6,7 +6,6 @@ package mutation
 import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/aws/mutation/cni/calico"
@@ -30,7 +29,6 @@ func MetaPatchHandler(mgr manager.Manager) handlers.Named {
 
 	return mutation.NewMetaGeneratePatchesHandler(
 		"awsClusterConfigPatch",
-		apis.CAPADecoder(),
 		patchHandlers...,
 	)
 }
@@ -44,7 +42,6 @@ func MetaWorkerPatchHandler() handlers.Named {
 
 	return mutation.NewMetaGeneratePatchesHandler(
 		"awsWorkerConfigPatch",
-		apis.CAPADecoder(),
 		patchHandlers...,
 	)
 }

--- a/pkg/handlers/docker/mutation/customimage/inject_control_plane.go
+++ b/pkg/handlers/docker/mutation/customimage/inject_control_plane.go
@@ -10,13 +10,12 @@ import (
 	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
@@ -75,7 +74,7 @@ func (h *customImageControlPlanePatchHandler) Name() string {
 
 func (h *customImageControlPlanePatchHandler) Mutate(
 	ctx context.Context,
-	obj runtime.Object,
+	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
@@ -106,7 +105,7 @@ func (h *customImageControlPlanePatchHandler) Mutate(
 		customImageVar,
 	)
 
-	return patches.Generate(
+	return patches.MutateIfApplicable(
 		obj,
 		vars,
 		&holderRef,
@@ -153,5 +152,5 @@ func (h *customImageControlPlanePatchHandler) GeneratePatches(
 	req *runtimehooksv1.GeneratePatchesRequest,
 	resp *runtimehooksv1.GeneratePatchesResponse,
 ) {
-	handlers.GeneratePatches(ctx, req, resp, apis.CAPDDecoder(), h.Mutate)
+	handlers.GeneratePatches(ctx, req, resp, h.Mutate)
 }

--- a/pkg/handlers/docker/mutation/customimage/inject_worker.go
+++ b/pkg/handlers/docker/mutation/customimage/inject_worker.go
@@ -10,13 +10,12 @@ import (
 	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
@@ -72,7 +71,7 @@ func (h *customImageWorkerPatchHandler) Name() string {
 
 func (h *customImageWorkerPatchHandler) Mutate(
 	ctx context.Context,
-	obj runtime.Object,
+	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
@@ -103,7 +102,7 @@ func (h *customImageWorkerPatchHandler) Mutate(
 		customImageVar,
 	)
 
-	return patches.Generate(
+	return patches.MutateIfApplicable(
 		obj,
 		vars,
 		&holderRef,
@@ -150,5 +149,5 @@ func (h *customImageWorkerPatchHandler) GeneratePatches(
 	req *runtimehooksv1.GeneratePatchesRequest,
 	resp *runtimehooksv1.GeneratePatchesResponse,
 ) {
-	handlers.GeneratePatches(ctx, req, resp, apis.CAPDDecoder(), h.Mutate)
+	handlers.GeneratePatches(ctx, req, resp, h.Mutate)
 }

--- a/pkg/handlers/docker/mutation/metapatch_handler.go
+++ b/pkg/handlers/docker/mutation/metapatch_handler.go
@@ -6,7 +6,6 @@ package mutation
 import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/docker/mutation/customimage"
@@ -24,7 +23,6 @@ func MetaPatchHandler(mgr manager.Manager) handlers.Named {
 
 	return mutation.NewMetaGeneratePatchesHandler(
 		"dockerClusterConfigPatch",
-		apis.CAPDDecoder(),
 		patchHandlers...,
 	)
 }
@@ -37,7 +35,6 @@ func MetaWorkerPatchHandler() handlers.Named {
 
 	return mutation.NewMetaGeneratePatchesHandler(
 		"dockerWorkerConfigPatch",
-		apis.CAPDDecoder(),
 		patchHandlers...,
 	)
 }

--- a/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
+++ b/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
@@ -8,6 +8,7 @@ import (
 	_ "embed"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -17,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
@@ -66,7 +66,7 @@ func (h *extraAPIServerCertSANsPatchHandler) Name() string {
 
 func (h *extraAPIServerCertSANsPatchHandler) Mutate(
 	ctx context.Context,
-	obj runtime.Object,
+	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
@@ -97,7 +97,7 @@ func (h *extraAPIServerCertSANsPatchHandler) Mutate(
 		extraAPIServerCertSANsVar,
 	)
 
-	return patches.Generate(
+	return patches.MutateIfApplicable(
 		obj, vars, &holderRef, selectors.ControlPlane(), log,
 		func(obj *controlplanev1.KubeadmControlPlaneTemplate) error {
 			log.WithValues(
@@ -122,7 +122,7 @@ func (h *extraAPIServerCertSANsPatchHandler) GeneratePatches(
 ) {
 	topologymutation.WalkTemplates(
 		ctx,
-		apis.CAPIDecoder(),
+		unstructured.UnstructuredJSONScheme,
 		req,
 		resp,
 		func(
@@ -131,7 +131,13 @@ func (h *extraAPIServerCertSANsPatchHandler) GeneratePatches(
 			vars map[string]apiextensionsv1.JSON,
 			holderRef runtimehooksv1.HolderReference,
 		) error {
-			return h.Mutate(ctx, obj, vars, holderRef, client.ObjectKey{})
+			return h.Mutate(
+				ctx,
+				obj.(*unstructured.Unstructured),
+				vars,
+				holderRef,
+				client.ObjectKey{},
+			)
 		},
 	)
 }

--- a/pkg/handlers/generic/mutation/kubernetesimagerepository/inject.go
+++ b/pkg/handlers/generic/mutation/kubernetesimagerepository/inject.go
@@ -8,6 +8,7 @@ import (
 	_ "embed"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -17,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
 	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
@@ -66,7 +66,7 @@ func (h *imageRepositoryPatchHandler) Name() string {
 
 func (h *imageRepositoryPatchHandler) Mutate(
 	ctx context.Context,
-	obj runtime.Object,
+	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
@@ -97,7 +97,7 @@ func (h *imageRepositoryPatchHandler) Mutate(
 		imageRepositoryVar,
 	)
 
-	return patches.Generate(
+	return patches.MutateIfApplicable(
 		obj, vars, &holderRef, selectors.ControlPlane(), log,
 		func(obj *controlplanev1.KubeadmControlPlaneTemplate) error {
 			log.WithValues(
@@ -122,7 +122,7 @@ func (h *imageRepositoryPatchHandler) GeneratePatches(
 ) {
 	topologymutation.WalkTemplates(
 		ctx,
-		apis.CAPIDecoder(),
+		unstructured.UnstructuredJSONScheme,
 		req,
 		resp,
 		func(
@@ -131,7 +131,13 @@ func (h *imageRepositoryPatchHandler) GeneratePatches(
 			vars map[string]apiextensionsv1.JSON,
 			holderRef runtimehooksv1.HolderReference,
 		) error {
-			return h.Mutate(ctx, obj, vars, holderRef, client.ObjectKey{})
+			return h.Mutate(
+				ctx,
+				obj.(*unstructured.Unstructured),
+				vars,
+				holderRef,
+				client.ObjectKey{},
+			)
 		},
 	)
 }

--- a/pkg/handlers/patches.go
+++ b/pkg/handlers/patches.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/exp/runtime/topologymutation"
@@ -19,12 +20,11 @@ func GeneratePatches(
 	ctx context.Context,
 	req *runtimehooksv1.GeneratePatchesRequest,
 	resp *runtimehooksv1.GeneratePatchesResponse,
-	decoder runtime.Decoder,
 	mutate mutation.MutateFunc,
 ) {
 	topologymutation.WalkTemplates(
 		ctx,
-		decoder,
+		unstructured.UnstructuredJSONScheme,
 		req,
 		resp,
 		func(
@@ -33,7 +33,13 @@ func GeneratePatches(
 			vars map[string]apiextensionsv1.JSON,
 			holderRef runtimehooksv1.HolderReference,
 		) error {
-			return mutate(ctx, obj, vars, holderRef, client.ObjectKey{})
+			return mutate(
+				ctx,
+				obj.(*unstructured.Unstructured),
+				vars,
+				holderRef,
+				client.ObjectKey{},
+			)
 		},
 	)
 }


### PR DESCRIPTION
This produces a minimal patch output by converting back and forth between real types and unstructured. See `patches.MutateIfApplicable` (renamed `patches.GeneratePatches`) function for comments on what is happening. The fact that I haven't had to change existing test contents gives me confidence that this works well.