### PR TITLE
build: Increase golangci-lint timeout for slower GHA runners

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 run:
+  timeout: 10m
   skip-dirs:
     - pkg/external
 

--- a/api/v1alpha1/clusterconfig_types.go
+++ b/api/v1alpha1/clusterconfig_types.go
@@ -93,7 +93,7 @@ type GenericClusterConfig struct {
 	Addons *Addons `json:"addons,omitempty"`
 }
 
-func (s GenericClusterConfig) VariableSchema() clusterv1.VariableSchema {
+func (s GenericClusterConfig) VariableSchema() clusterv1.VariableSchema { //nolint:gocritic,lll // Passed by value for no potential side-effect.
 	return clusterv1.VariableSchema{
 		OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 			Description: "Cluster configuration",

--- a/common/pkg/testutils/capitest/request/items.go
+++ b/common/pkg/testutils/capitest/request/items.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -16,7 +17,6 @@ import (
 	capav1 "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capdv1 "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/external/sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/testutils/capitest/serializer"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (

--- a/pkg/handlers/aws/clusterconfig/variables_test.go
+++ b/pkg/handlers/aws/clusterconfig/variables_test.go
@@ -46,7 +46,9 @@ func TestVariableValidation(t *testing.T) {
 			Name: "specified instance type",
 			Vals: v1alpha1.ClusterConfigSpec{
 				ControlPlane: &v1alpha1.NodeConfigSpec{
-					AWS: &v1alpha1.AWSNodeSpec{InstanceType: ptr.To(v1alpha1.InstanceType("m5.small"))},
+					AWS: &v1alpha1.AWSNodeSpec{
+						InstanceType: ptr.To(v1alpha1.InstanceType("m5.small")),
+					},
 				},
 			},
 		},

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/inject_worker.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/inject_worker.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	_ "embed"
 
-	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
-
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -17,14 +15,13 @@ import (
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/apis"
-
+	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
-
-	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
 	capav1 "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
 	awsworkerconfig "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/aws/workerconfig"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/workerconfig"
 )

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/tests/generate_patches.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/tests/generate_patches.go
@@ -6,9 +6,8 @@ package tests
 import (
 	"testing"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"

--- a/pkg/handlers/aws/mutation/instancetype/inject_control_plane.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_control_plane.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	_ "embed"
 
-	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
-
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -23,6 +21,7 @@ import (
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
 	capav1 "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
 	awsclusterconfig "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/aws/clusterconfig"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/clusterconfig"
 )

--- a/pkg/handlers/aws/mutation/instancetype/inject_worker.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_worker.go
@@ -7,11 +7,6 @@ import (
 	"context"
 	_ "embed"
 
-	awsworkerconfig "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/aws/workerconfig"
-	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/workerconfig"
-
-	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
-
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -26,6 +21,9 @@ import (
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
 	capav1 "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
+	awsworkerconfig "github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/aws/workerconfig"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/workerconfig"
 )
 
 const (

--- a/pkg/handlers/aws/mutation/instancetype/tests/generate_patches.go
+++ b/pkg/handlers/aws/mutation/instancetype/tests/generate_patches.go
@@ -6,9 +6,8 @@ package tests
 import (
 	"testing"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"

--- a/pkg/handlers/generic/lifecycle/csi/aws-ebs/handler.go
+++ b/pkg/handlers/generic/lifecycle/csi/aws-ebs/handler.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/k8s/client"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/k8s/client"
 )
 
 type AWSEBSConfig struct {

--- a/pkg/handlers/generic/lifecycle/csi/handler.go
+++ b/pkg/handlers/generic/lifecycle/csi/handler.go
@@ -7,12 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/lifecycle"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/k8s/client"
-	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/clusterconfig"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +17,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
+	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
+	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/lifecycle"
+	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
+	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/k8s/client"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/clusterconfig"
 )
 
 const (
@@ -134,23 +135,13 @@ func (c *CSIHandler) AfterControlPlaneInitialized(
 		if cm != nil {
 			if provider.Name == csiProviders.DefaultClassName {
 				log.Info("Setting default storage class ", provider, csiProviders.DefaultClassName)
-				err = setDefaultStorageClass(ctx, log, cm)
+				err = setDefaultStorageClass(log, cm)
 				if err != nil {
-					log.Error(
-						err,
-						fmt.Sprintf(
-							"failed to set default storage class",
-						),
-					)
+					log.Error(err, "failed to set default storage class")
 					resp.SetStatus(runtimehooksv1.ResponseStatusFailure)
 				}
 				if err := c.client.Update(ctx, cm); err != nil {
-					log.Error(
-						err,
-						fmt.Sprintf(
-							"failed to apply default storage class annotation to configmap",
-						),
-					)
+					log.Error(err, "failed to apply default storage class annotation to configmap")
 					resp.SetStatus(runtimehooksv1.ResponseStatusFailure)
 				}
 			}
@@ -206,7 +197,6 @@ func (c *CSIHandler) EnsureCSICRSForCluster(
 }
 
 func setDefaultStorageClass(
-	ctx context.Context,
 	log logr.Logger,
 	cm *corev1.ConfigMap,
 ) error {

--- a/pkg/handlers/generic/lifecycle/csi/handler_test.go
+++ b/pkg/handlers/generic/lifecycle/csi/handler_test.go
@@ -4,13 +4,12 @@
 package csi
 
 import (
-	"context"
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var startAWSConfigMap = `
@@ -47,7 +46,10 @@ func Test_setDefaultStorageClass(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := setDefaultStorageClass(context.TODO(), ctrl.LoggerFrom(context.TODO()), tt.startConfigMap)
+			err := setDefaultStorageClass(
+				logr.Discard(),
+				tt.startConfigMap,
+			)
 			if err != nil {
 				t.Fatal("failed to set default storage class", err)
 			}


### PR DESCRIPTION
Without this, the reviewdog/action-golangci-lint action can give false
positives. See reviewdog/action-golangci-lint#27
for details.

This occurred in a GHA run in
https://github.com/d2iq-labs/capi-runtime-extensions/actions/runs/6451051901/job/17511173049?pr=192#step:5:88.

Second commit refactors code to satisfy linters.