### PR TITLE
refactor: Use common handler code

### DIFF
--- a/pkg/handlers/generic/mutation/etcd/inject.go
+++ b/pkg/handlers/generic/mutation/etcd/inject.go
@@ -4,25 +4,18 @@
 package etcd
 
 import (
-	"context"
 	_ "embed"
 
+	"github.com/go-logr/logr"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
-	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
-	"sigs.k8s.io/cluster-api/exp/runtime/topologymutation"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/clusterconfig"
 )
 
@@ -32,15 +25,8 @@ const (
 )
 
 type etcdPatchHandler struct {
-	variableName      string
-	variableFieldPath []string
+	*handlers.GenericPatchHandler[*controlplanev1.KubeadmControlPlaneTemplate]
 }
-
-var (
-	_ commonhandlers.Named     = &etcdPatchHandler{}
-	_ mutation.GeneratePatches = &etcdPatchHandler{}
-	_ mutation.MetaMutator     = &etcdPatchHandler{}
-)
 
 func NewPatch() *etcdPatchHandler {
 	return newEtcdPatchHandler(VariableName)
@@ -55,99 +41,49 @@ func newEtcdPatchHandler(
 	variableFieldPath ...string,
 ) *etcdPatchHandler {
 	return &etcdPatchHandler{
-		variableName:      variableName,
-		variableFieldPath: variableFieldPath,
+		handlers.NewGenericPatchHandler[*controlplanev1.KubeadmControlPlaneTemplate](
+			HandlerNamePatch,
+			variableFunc,
+			selectors.ControlPlane(),
+			mutateFunc,
+			variableName,
+			variableFieldPath...,
+		),
 	}
 }
 
-func (h *etcdPatchHandler) Name() string {
-	return HandlerNamePatch
+func variableFunc(vars map[string]apiextensionsv1.JSON, name string, fields ...string) (any, bool, error) {
+	return variables.Get[v1alpha1.Etcd](vars, name, fields...)
 }
 
-func (h *etcdPatchHandler) Mutate(
-	ctx context.Context,
-	obj *unstructured.Unstructured,
-	vars map[string]apiextensionsv1.JSON,
-	holderRef runtimehooksv1.HolderReference,
-	_ client.ObjectKey,
-) error {
-	log := ctrl.LoggerFrom(ctx).WithValues(
-		"holderRef", holderRef,
-	)
+func mutateFunc(
+	log logr.Logger,
+	_ map[string]apiextensionsv1.JSON,
+	patchVar any,
+) func(obj *controlplanev1.KubeadmControlPlaneTemplate) error {
+	return func(obj *controlplanev1.KubeadmControlPlaneTemplate) error {
+		etcd := patchVar.(v1alpha1.Etcd)
 
-	etcd, found, err := variables.Get[v1alpha1.Etcd](
-		vars,
-		h.variableName,
-		h.variableFieldPath...,
-	)
-	if err != nil {
-		return err
-	}
-	if !found {
-		log.V(5).Info("etcd variable not defined")
+		log.WithValues(
+			"patchedObjectKind", obj.GetObjectKind().GroupVersionKind().String(),
+			"patchedObjectName", client.ObjectKeyFromObject(obj),
+		).Info("setting etcd configuration in kubeadm config spec")
+
+		if obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration == nil {
+			obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration = &bootstrapv1.ClusterConfiguration{}
+		}
+		if obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local == nil {
+			obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local = &bootstrapv1.LocalEtcd{}
+		}
+
+		localEtcd := obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local
+		if etcd.Image != nil && etcd.Image.Tag != "" {
+			localEtcd.ImageTag = etcd.Image.Tag
+		}
+		if etcd.Image != nil && etcd.Image.Repository != "" {
+			localEtcd.ImageRepository = etcd.Image.Repository
+		}
+
 		return nil
 	}
-
-	log = log.WithValues(
-		"variableName",
-		h.variableName,
-		"variableFieldPath",
-		h.variableFieldPath,
-		"variableValue",
-		etcd,
-	)
-
-	return patches.MutateIfApplicable(
-		obj, vars, &holderRef, selectors.ControlPlane(), log,
-		func(obj *controlplanev1.KubeadmControlPlaneTemplate) error {
-			log.WithValues(
-				"patchedObjectKind", obj.GetObjectKind().GroupVersionKind().String(),
-				"patchedObjectName", client.ObjectKeyFromObject(obj),
-			).Info("setting etcd configuration in kubeadm config spec")
-
-			if obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration == nil {
-				obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration = &bootstrapv1.ClusterConfiguration{}
-			}
-			if obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local == nil {
-				obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local = &bootstrapv1.LocalEtcd{}
-			}
-
-			localEtcd := obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local
-			if etcd.Image != nil && etcd.Image.Tag != "" {
-				localEtcd.ImageTag = etcd.Image.Tag
-			}
-			if etcd.Image != nil && etcd.Image.Repository != "" {
-				localEtcd.ImageRepository = etcd.Image.Repository
-			}
-
-			return nil
-		},
-	)
-}
-
-func (h *etcdPatchHandler) GeneratePatches(
-	ctx context.Context,
-	req *runtimehooksv1.GeneratePatchesRequest,
-	resp *runtimehooksv1.GeneratePatchesResponse,
-) {
-	topologymutation.WalkTemplates(
-		ctx,
-		unstructured.UnstructuredJSONScheme,
-		req,
-		resp,
-		func(
-			ctx context.Context,
-			obj runtime.Object,
-			vars map[string]apiextensionsv1.JSON,
-			holderRef runtimehooksv1.HolderReference,
-		) error {
-			return h.Mutate(
-				ctx,
-				obj.(*unstructured.Unstructured),
-				vars,
-				holderRef,
-				client.ObjectKey{},
-			)
-		},
-	)
 }

--- a/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
+++ b/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
@@ -4,25 +4,18 @@
 package extraapiservercertsans
 
 import (
-	"context"
 	_ "embed"
 
+	"github.com/go-logr/logr"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
-	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
-	"sigs.k8s.io/cluster-api/exp/runtime/topologymutation"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
-	commonhandlers "github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
-	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/variables"
+	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers"
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/clusterconfig"
 )
 
@@ -32,15 +25,8 @@ const (
 )
 
 type extraAPIServerCertSANsPatchHandler struct {
-	variableName      string
-	variableFieldPath []string
+	*handlers.GenericPatchHandler[*controlplanev1.KubeadmControlPlaneTemplate]
 }
-
-var (
-	_ commonhandlers.Named     = &extraAPIServerCertSANsPatchHandler{}
-	_ mutation.GeneratePatches = &extraAPIServerCertSANsPatchHandler{}
-	_ mutation.MetaMutator     = &extraAPIServerCertSANsPatchHandler{}
-)
 
 func NewPatch() *extraAPIServerCertSANsPatchHandler {
 	return newExtraAPIServerCertSANsPatchHandler(VariableName)
@@ -55,89 +41,39 @@ func newExtraAPIServerCertSANsPatchHandler(
 	variableFieldPath ...string,
 ) *extraAPIServerCertSANsPatchHandler {
 	return &extraAPIServerCertSANsPatchHandler{
-		variableName:      variableName,
-		variableFieldPath: variableFieldPath,
+		handlers.NewGenericPatchHandler[*controlplanev1.KubeadmControlPlaneTemplate](
+			HandlerNamePatch,
+			variableFunc,
+			selectors.ControlPlane(),
+			mutateFunc,
+			variableName,
+			variableFieldPath...,
+		),
 	}
 }
 
-func (h *extraAPIServerCertSANsPatchHandler) Name() string {
-	return HandlerNamePatch
+func variableFunc(vars map[string]apiextensionsv1.JSON, name string, fields ...string) (any, bool, error) {
+	return variables.Get[v1alpha1.ExtraAPIServerCertSANs](vars, name, fields...)
 }
 
-func (h *extraAPIServerCertSANsPatchHandler) Mutate(
-	ctx context.Context,
-	obj *unstructured.Unstructured,
-	vars map[string]apiextensionsv1.JSON,
-	holderRef runtimehooksv1.HolderReference,
-	_ client.ObjectKey,
-) error {
-	log := ctrl.LoggerFrom(ctx).WithValues(
-		"holderRef", holderRef,
-	)
+func mutateFunc(
+	log logr.Logger,
+	_ map[string]apiextensionsv1.JSON,
+	patchVar any,
+) func(obj *controlplanev1.KubeadmControlPlaneTemplate) error {
+	return func(obj *controlplanev1.KubeadmControlPlaneTemplate) error {
+		extraAPIServerCertSANsVar := patchVar.(v1alpha1.ExtraAPIServerCertSANs)
 
-	extraAPIServerCertSANsVar, found, err := variables.Get[v1alpha1.ExtraAPIServerCertSANs](
-		vars,
-		h.variableName,
-		h.variableFieldPath...,
-	)
-	if err != nil {
-		return err
-	}
-	if !found {
-		log.V(5).Info("Extra API server cert SANs variable not defined")
+		log.WithValues(
+			"patchedObjectKind", obj.GetObjectKind().GroupVersionKind().String(),
+			"patchedObjectName", client.ObjectKeyFromObject(obj),
+		).Info("adding API server extra cert SANs in kubeadm config spec")
+
+		if obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration == nil {
+			obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration = &bootstrapv1.ClusterConfiguration{}
+		}
+		obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.CertSANs = extraAPIServerCertSANsVar
+
 		return nil
 	}
-
-	log = log.WithValues(
-		"variableName",
-		h.variableName,
-		"variableFieldPath",
-		h.variableFieldPath,
-		"variableValue",
-		extraAPIServerCertSANsVar,
-	)
-
-	return patches.MutateIfApplicable(
-		obj, vars, &holderRef, selectors.ControlPlane(), log,
-		func(obj *controlplanev1.KubeadmControlPlaneTemplate) error {
-			log.WithValues(
-				"patchedObjectKind", obj.GetObjectKind().GroupVersionKind().String(),
-				"patchedObjectName", client.ObjectKeyFromObject(obj),
-			).Info("adding API server extra cert SANs in kubeadm config spec")
-
-			if obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration == nil {
-				obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration = &bootstrapv1.ClusterConfiguration{}
-			}
-			obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.CertSANs = extraAPIServerCertSANsVar
-
-			return nil
-		},
-	)
-}
-
-func (h *extraAPIServerCertSANsPatchHandler) GeneratePatches(
-	ctx context.Context,
-	req *runtimehooksv1.GeneratePatchesRequest,
-	resp *runtimehooksv1.GeneratePatchesResponse,
-) {
-	topologymutation.WalkTemplates(
-		ctx,
-		unstructured.UnstructuredJSONScheme,
-		req,
-		resp,
-		func(
-			ctx context.Context,
-			obj runtime.Object,
-			vars map[string]apiextensionsv1.JSON,
-			holderRef runtimehooksv1.HolderReference,
-		) error {
-			return h.Mutate(
-				ctx,
-				obj.(*unstructured.Unstructured),
-				vars,
-				holderRef,
-				client.ObjectKey{},
-			)
-		},
-	)
 }

--- a/pkg/handlers/generic_patch_with_variable.go
+++ b/pkg/handlers/generic_patch_with_variable.go
@@ -1,0 +1,127 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+	"sigs.k8s.io/cluster-api/exp/runtime/topologymutation"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/patches"
+)
+
+type GenericPatchHandler[T runtime.Object] struct {
+	handlerName string
+
+	variableFn func(map[string]apiextensionsv1.JSON, string, ...string) (any, bool, error)
+
+	patchSelector clusterv1.PatchSelector
+	alwaysMutate  bool
+	mutateFn      func(logr.Logger, map[string]apiextensionsv1.JSON, any) func(T) error
+
+	variableName      string
+	variableFieldPath []string
+}
+
+func NewGenericPatchHandler[T runtime.Object](
+	handlerName string,
+	variableFn func(map[string]apiextensionsv1.JSON, string, ...string) (any, bool, error),
+	patchSelector clusterv1.PatchSelector,
+	mutateFn func(logr.Logger, map[string]apiextensionsv1.JSON, any) func(T) error,
+	variableName string,
+	variableFieldPath ...string,
+) *GenericPatchHandler[T] {
+	return &GenericPatchHandler[T]{
+		handlerName:       handlerName,
+		variableFn:        variableFn,
+		patchSelector:     patchSelector,
+		mutateFn:          mutateFn,
+		variableName:      variableName,
+		variableFieldPath: variableFieldPath,
+	}
+}
+
+func (h *GenericPatchHandler[T]) AlwaysMutate() *GenericPatchHandler[T] {
+	h.alwaysMutate = true
+	return h
+}
+
+func (h *GenericPatchHandler[_]) Name() string {
+	return h.handlerName
+}
+
+func (h *GenericPatchHandler[_]) Mutate(
+	ctx context.Context,
+	obj *unstructured.Unstructured,
+	vars map[string]apiextensionsv1.JSON,
+	holderRef runtimehooksv1.HolderReference,
+	_ client.ObjectKey,
+) error {
+	log := ctrl.LoggerFrom(ctx).WithValues(
+		"holderRef", holderRef,
+	)
+
+	variable, found, err := h.variableFn(
+		vars,
+		h.variableName,
+		h.variableFieldPath...,
+	)
+	if err != nil {
+		return err
+	}
+	if !found {
+		log.V(5).Info("Variable not defined", "handler", h.handlerName, "variableName", h.variableName)
+		if !h.alwaysMutate {
+			return nil
+		}
+	}
+
+	log = log.WithValues(
+		"variableName",
+		h.variableName,
+		"variableFieldPath",
+		h.variableFieldPath,
+		"variableValue",
+		variable,
+	)
+
+	return patches.MutateIfApplicable(
+		obj, vars, &holderRef, h.patchSelector, log, h.mutateFn(log, vars, variable),
+	)
+}
+
+func (h *GenericPatchHandler[_]) GeneratePatches(
+	ctx context.Context,
+	req *runtimehooksv1.GeneratePatchesRequest,
+	resp *runtimehooksv1.GeneratePatchesResponse,
+) {
+	topologymutation.WalkTemplates(
+		ctx,
+		unstructured.UnstructuredJSONScheme,
+		req,
+		resp,
+		func(
+			ctx context.Context,
+			obj runtime.Object,
+			vars map[string]apiextensionsv1.JSON,
+			holderRef runtimehooksv1.HolderReference,
+		) error {
+			return h.Mutate(
+				ctx,
+				obj.(*unstructured.Unstructured),
+				vars,
+				holderRef,
+				client.ObjectKey{},
+			)
+		},
+	)
+}


### PR DESCRIPTION
Refactor common handler code. This is not meant to completely support all handlers (i.e. `auditpolicy` with no vars, `httpproxy` that fetches additional information from the Cluster)

Its a little tricky because we rely on generics, so I would like to get some feedback before making change to the rest of the handlers.
Honestly I don' think this really solves much, but would love some feedback anyways.
Im going to explore additional refactoring to make the existing handler code less verbose.