### PR TITLE
build: local development in macOS(and Linux) arm64/amd64 using local colima instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ See [upstream documentation](https://cluster-api.sigs.k8s.io/tasks/experimental-
 
 ## Development
 
+Install tools
+- [Devbox](https://github.com/jetpack-io/devbox?tab=readme-ov-file#installing-devbox)
+- [Direnv](https://direnv.net/docs/installation.html)
+- Container Runtime for your Operating System
+
 To deploy a local build, either initial install to update an existing deployment, run:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ See [upstream documentation](https://cluster-api.sigs.k8s.io/tasks/experimental-
 ## Development
 
 Install tools
+
 - [Devbox](https://github.com/jetpack-io/devbox?tab=readme-ov-file#installing-devbox)
 - [Direnv](https://direnv.net/docs/installation.html)
 - Container Runtime for your Operating System


### PR DESCRIPTION
- adds [colima](https://github.com/abiosoft/colima) to devbox
- uses local instance of container runtime supported by colima to run kind cluster and build container images

Tested on M3 Mac:
```
❯ make dev.run-on-kind
INFO[0000] starting colima
INFO[0000] runtime: docker
INFO[0000] creating and starting ...                     context=vm
INFO[0033] provisioning ...                              context=docker
INFO[0033] starting ...                                  context=docker
INFO[0034] done
▶ creating kind cluster - capi-runtime-extensions-dev
Creating cluster "capi-runtime-extensions-dev" ...
 ✓ Ensuring node image (ghcr.io/mesosphere/kind-node:v1.27.5) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-capi-runtime-extensions-dev"
You can now use your cluster with:

kubectl cluster-info --context kind-capi-runtime-extensions-dev

Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/
Fetching providers
Installing cert-manager Version="v1.13.2"
Waiting for cert-manager to be available...
Installing Provider="cluster-api" Version="v1.6.0" TargetNamespace="capi-system"
Installing Provider="bootstrap-kubeadm" Version="v1.6.0" TargetNamespace="capi-kubeadm-bootstrap-system"
Installing Provider="control-plane-kubeadm" Version="v1.6.0" TargetNamespace="capi-kubeadm-control-plane-system"
Installing Provider="infrastructure-docker" Version="v1.6.0" TargetNamespace="capd-system"
Installing Provider="infrastructure-aws" Version="v2.3.1" TargetNamespace="capa-system"
Waiting for providers to be available...

Your management cluster has been initialized successfully!

You can now create your first workload cluster by running the following:

  clusterctl generate cluster [name] --kubernetes-version [version] | kubectl apply -f -

WARNING! Your password will be stored unencrypted in /Users/shalinpatel/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
▶ running go generate
▶ go fixing root module
▶ go fixing common module
▶ building snapshot release
  • starting release...
  • loading                                          path=.goreleaser.yml
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=cd4aed11691d45242e11a52bd1f8f93e96bf4689 branch=main current_tag=v0.2.0 previous_tag=v0.1.2 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.3.0-dev
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/capi-runtime-extensions_linux_arm64/capi-runtime-extensions
    • building                                       binary=dist/capi-runtime-extensions_linux_amd64_v1/capi-runtime-extensions
    • running hook                                   hook=sh -ec 'if [ true == true ] && [ arm64 == arm64 ]; then
  env GOOS=linux GOARCH=arm64 \
      SOURCE_DATE_EPOCH=$(date +%s) \
      KO_DOCKER_REPO=ko.local/capi-runtime-extensions \
      ko build \
        --bare \
        -t v0.3.0-dev \
        ./cmd
fi'

    • running hook                                   hook=sh -ec 'if [ true == true ] && [ arm64 == amd64 ]; then
  env GOOS=linux GOARCH=amd64 \
      SOURCE_DATE_EPOCH=$(date +%s) \
      KO_DOCKER_REPO=ko.local/capi-runtime-extensions \
      ko build \
        --bare \
        -t v0.3.0-dev \
        ./cmd
fi'

    • took: 9s
  • archives
    • creating                                       archive=dist/capi-runtime-extensions_v0.3.0-dev_linux_amd64.tar.gz
    • creating                                       archive=dist/capi-runtime-extensions_v0.3.0-dev_linux_arm64.tar.gz
    • took: 3s
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 11s
  • thanks for using goreleaser!
Image: "ko.local/capi-runtime-extensions:v0.3.0-dev" with ID "sha256:7b313af702d8bef15c6eebbb8a39e5bf0fdd7a30940650021b3d548dbd99da83" not yet present on node "capi-runtime-extensions-dev-control-plane", loading...
Release "capi-runtime-extensions" does not exist. Installing it now.
NAME: capi-runtime-extensions
LAST DEPLOYED: Wed Jan 10 08:51:56 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
deployment.apps/capi-runtime-extensions restarted
Waiting for deployment "capi-runtime-extensions" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "capi-runtime-extensions" rollout to finish: 1 old replicas are pending termination...
deployment "capi-runtime-extensions" successfully rolled out
```
**TODO:**
- I will be testing it on Linux and update here.
- Test on M1 Mac
