### PR TITLE
build: Lint for missed errors in tests too

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,10 +74,6 @@ linters-settings:
 
 issues:
   exclude-rules:
-    # ignore errcheck for code under a /test folder
-    - path: "test/*"
-      linters:
-        - errcheck
     # ignore errcheck for flags.Parse (it is expected that we flag.ExitOnError)
     # ignore response.WriteError as it always returns the err it was passed
     - source: "flags.Parse|response.WriteError"

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/tests/generate_patches.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/tests/generate_patches.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/storage/names"
@@ -35,22 +36,31 @@ func TestGeneratePatches(
 
 	// Server side apply does not work with the fake client, hack around it by pre-creating empty Secrets
 	// https://github.com/kubernetes-sigs/controller-runtime/issues/2341
-	fakeClient.Create(
-		context.Background(),
-		newTestSecret(validSecretName, request.Namespace),
-	)
-	fakeClient.Create(
-		context.Background(),
-		newEmptySecret(
-			request.KubeadmControlPlaneTemplateRequestObjectName+"-registry-config",
-			request.Namespace,
+	require.NoError(
+		t,
+		fakeClient.Create(
+			context.Background(),
+			newTestSecret(validSecretName, request.Namespace),
 		),
 	)
-	fakeClient.Create(
-		context.Background(),
-		newEmptySecret(
-			request.KubeadmConfigTemplateRequestObjectName+"-registry-config",
-			request.Namespace,
+	require.NoError(
+		t,
+		fakeClient.Create(
+			context.Background(),
+			newEmptySecret(
+				request.KubeadmControlPlaneTemplateRequestObjectName+"-registry-config",
+				request.Namespace,
+			),
+		),
+	)
+	require.NoError(
+		t,
+		fakeClient.Create(
+			context.Background(),
+			newEmptySecret(
+				request.KubeadmConfigTemplateRequestObjectName+"-registry-config",
+				request.Namespace,
+			),
 		),
 	)
 


### PR DESCRIPTION
Noticed this was disabled, but would prefer to always explicitly
check errors even, or rather especially, in tests.
