### PR TITLE
feat: Use latest dynamic credential provider and v1 kubelet API

### DIFF
--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files.go
@@ -12,8 +12,7 @@ import (
 	"path"
 	"text/template"
 
-	credentialproviderv1alpha1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1alpha1"
-	credentialproviderv1beta1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1beta1"
+	credentialproviderv1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1"
 	cabpkv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 
 	"github.com/d2iq-labs/capi-runtime-extensions/pkg/handlers/generic/mutation/imageregistries/credentials/credentialprovider"
@@ -151,7 +150,7 @@ func templateDynamicCredentialProviderConfig(
 func kubeletCredentialProvider() (providerBinary string, providerArgs []string, providerAPIVersion string) {
 	return "dynamic-credential-provider",
 		[]string{"get-credentials", "-c", kubeletDynamicCredentialProviderConfigOnRemote},
-		credentialproviderv1beta1.SchemeGroupVersion.String()
+		credentialproviderv1.SchemeGroupVersion.String()
 }
 
 func dynamicCredentialProvider(host string) (
@@ -159,24 +158,24 @@ func dynamicCredentialProvider(host string) (
 ) {
 	if matches, err := credentialprovider.URLMatchesECR(host); matches || err != nil {
 		return "ecr-credential-provider", []string{"get-credentials"},
-			credentialproviderv1alpha1.SchemeGroupVersion.String(), err
+			credentialproviderv1.SchemeGroupVersion.String(), err
 	}
 
 	if matches, err := credentialprovider.URLMatchesGCR(host); matches || err != nil {
 		return "gcr-credential-provider", []string{"get-credentials"},
-			credentialproviderv1alpha1.SchemeGroupVersion.String(), err
+			credentialproviderv1.SchemeGroupVersion.String(), err
 	}
 
 	if matches, err := credentialprovider.URLMatchesACR(host); matches || err != nil {
 		return "acr-credential-provider", []string{
 			azureCloudConfigFilePath,
-		}, credentialproviderv1alpha1.SchemeGroupVersion.String(), err
+		}, credentialproviderv1.SchemeGroupVersion.String(), err
 	}
 
 	// if no supported provider was found, assume we are using the static credential provider
 	return "static-credential-provider",
 		[]string{kubeletStaticCredentialProviderCredentialsOnRemote},
-		credentialproviderv1beta1.SchemeGroupVersion.String(),
+		credentialproviderv1.SchemeGroupVersion.String(),
 		nil
 }
 

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files_test.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files_test.go
@@ -28,7 +28,7 @@ func Test_templateKubeletCredentialProviderConfig(t *testing.T) {
 				Permissions: "0600",
 				Encoding:    "",
 				Append:      false,
-				Content: `apiVersion: kubelet.config.k8s.io/v1beta1
+				Content: `apiVersion: kubelet.config.k8s.io/v1
 kind: CredentialProviderConfig
 providers:
 - name: dynamic-credential-provider
@@ -44,7 +44,7 @@ providers:
   - "*.*.*.*.*"
   - "*.*.*.*.*.*"
   defaultCacheDuration: "0s"
-  apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
+  apiVersion: credentialprovider.kubelet.k8s.io/v1
 `,
 			},
 		},
@@ -61,7 +61,7 @@ providers:
 				Permissions: "0600",
 				Encoding:    "",
 				Append:      false,
-				Content: `apiVersion: kubelet.config.k8s.io/v1beta1
+				Content: `apiVersion: kubelet.config.k8s.io/v1
 kind: CredentialProviderConfig
 providers:
 - name: dynamic-credential-provider
@@ -77,7 +77,7 @@ providers:
   - "*.*.*.*.*"
   - "*.*.*.*.*.*"
   defaultCacheDuration: "0s"
-  apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
+  apiVersion: credentialprovider.kubelet.k8s.io/v1
 `,
 			},
 		},
@@ -115,7 +115,7 @@ func Test_templateDynamicCredentialProviderConfig(t *testing.T) {
 kind: DynamicCredentialProviderConfig
 credentialProviderPluginBinDir: /etc/kubernetes/image-credential-provider/
 credentialProviders:
-  apiVersion: kubelet.config.k8s.io/v1beta1
+  apiVersion: kubelet.config.k8s.io/v1
   kind: CredentialProviderConfig
   providers:
   - name: ecr-credential-provider
@@ -124,7 +124,7 @@ credentialProviders:
     matchImages:
     - "123456789.dkr.ecr.us-east-1.amazonaws.com"
     defaultCacheDuration: "0s"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1
 `,
 			},
 		},
@@ -145,7 +145,7 @@ credentialProviders:
 kind: DynamicCredentialProviderConfig
 credentialProviderPluginBinDir: /etc/kubernetes/image-credential-provider/
 credentialProviders:
-  apiVersion: kubelet.config.k8s.io/v1beta1
+  apiVersion: kubelet.config.k8s.io/v1
   kind: CredentialProviderConfig
   providers:
   - name: static-credential-provider
@@ -154,7 +154,7 @@ credentialProviders:
     matchImages:
     - "myregistry.com"
     defaultCacheDuration: "0s"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1
 `,
 			},
 		},
@@ -175,7 +175,7 @@ credentialProviders:
 kind: DynamicCredentialProviderConfig
 credentialProviderPluginBinDir: /etc/kubernetes/image-credential-provider/
 credentialProviders:
-  apiVersion: kubelet.config.k8s.io/v1beta1
+  apiVersion: kubelet.config.k8s.io/v1
   kind: CredentialProviderConfig
   providers:
   - name: static-credential-provider
@@ -185,7 +185,7 @@ credentialProviders:
     - "registry-1.docker.io"
     - "docker.io"
     defaultCacheDuration: "0s"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1
 `,
 			},
 		},

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_install_files.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_install_files.go
@@ -19,7 +19,7 @@ const (
 	installKubeletCredentialProvidersScriptOnRemoteCommand = "/bin/bash " + installKubeletCredentialProvidersScriptOnRemote
 
 	//nolint:gosec // Does not contain hard coded credentials.
-	dynamicCredentialProviderImage = "ghcr.io/mesosphere/dynamic-credential-provider:v0.2.0"
+	dynamicCredentialProviderImage = "ghcr.io/mesosphere/dynamic-credential-provider:v0.5.0"
 
 	//nolint:gosec // Does not contain hard coded credentials.
 	credentialProviderTargetDir = "/etc/kubernetes/image-credential-provider/"

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/templates/dynamic-credential-provider-config.yaml.gotmpl
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/templates/dynamic-credential-provider-config.yaml.gotmpl
@@ -2,7 +2,7 @@ apiVersion: credentialprovider.d2iq.com/v1alpha1
 kind: DynamicCredentialProviderConfig
 credentialProviderPluginBinDir: /etc/kubernetes/image-credential-provider/
 credentialProviders:
-  apiVersion: kubelet.config.k8s.io/v1beta1
+  apiVersion: kubelet.config.k8s.io/v1
   kind: CredentialProviderConfig
   providers:
   - name: {{ .ProviderBinary }}

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/templates/kubelet-image-credential-provider-config.yaml.gotmpl
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/templates/kubelet-image-credential-provider-config.yaml.gotmpl
@@ -1,4 +1,4 @@
-apiVersion: kubelet.config.k8s.io/v1beta1
+apiVersion: kubelet.config.k8s.io/v1
 kind: CredentialProviderConfig
 providers:
 - name: {{ .ProviderBinary }}

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/templates/static-credential-provider.json.gotmpl
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/templates/static-credential-provider.json.gotmpl
@@ -1,6 +1,6 @@
 {
   "kind":"CredentialProviderResponse",
-  "apiVersion":"credentialprovider.kubelet.k8s.io/v1beta1",
+  "apiVersion":"credentialprovider.kubelet.k8s.io/v1",
   "cacheKeyType":"Image",
   "cacheDuration":"0s",
   "auth":{


### PR DESCRIPTION
Required to fully support latest kubelet credential providers prior to merging #292.