### PR TITLE
test: fix race condition between registry credentials and mirror tests

### DIFF
--- a/common/pkg/testutils/capitest/request/items.go
+++ b/common/pkg/testutils/capitest/request/items.go
@@ -21,8 +21,8 @@ import (
 
 const (
 	ClusterName                                  = "test-cluster"
-	KubeadmConfigTemplateRequestObjectName       = "test-kubeadmconfigtemplate"
-	KubeadmControlPlaneTemplateRequestObjectName = "test-kubeadmcontrolplanetemplate"
+	kubeadmConfigTemplateRequestObjectName       = "test-kubeadmconfigtemplate"
+	kubeadmControlPlaneTemplateRequestObjectName = "test-kubeadmcontrolplanetemplate"
 	Namespace                                    = corev1.NamespaceDefault
 )
 
@@ -45,7 +45,16 @@ func NewRequestItem(
 	}
 }
 
-func NewKubeadmConfigTemplateRequestItem(uid types.UID) runtimehooksv1.GeneratePatchesRequestItem {
+func NewKubeadmConfigTemplateRequestItem(
+	uid types.UID,
+) runtimehooksv1.GeneratePatchesRequestItem {
+	return NewKubeadmConfigTemplateRequest(uid, kubeadmConfigTemplateRequestObjectName)
+}
+
+func NewKubeadmConfigTemplateRequest(
+	uid types.UID,
+	name string,
+) runtimehooksv1.GeneratePatchesRequestItem {
 	return NewRequestItem(
 		&bootstrapv1.KubeadmConfigTemplate{
 			TypeMeta: metav1.TypeMeta{
@@ -53,7 +62,7 @@ func NewKubeadmConfigTemplateRequestItem(uid types.UID) runtimehooksv1.GenerateP
 				Kind:       "KubeadmConfigTemplate",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      KubeadmConfigTemplateRequestObjectName,
+				Name:      name,
 				Namespace: Namespace,
 			},
 			Spec: bootstrapv1.KubeadmConfigTemplateSpec{
@@ -75,8 +84,9 @@ func NewKubeadmConfigTemplateRequestItem(uid types.UID) runtimehooksv1.GenerateP
 	)
 }
 
-func NewKubeadmControlPlaneTemplateRequestItem(
+func NewKubeadmControlPlaneTemplateRequest(
 	uid types.UID,
+	name string,
 ) runtimehooksv1.GeneratePatchesRequestItem {
 	return NewRequestItem(
 		&controlplanev1.KubeadmControlPlaneTemplate{
@@ -85,7 +95,7 @@ func NewKubeadmControlPlaneTemplateRequestItem(
 				Kind:       "KubeadmControlPlaneTemplate",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      KubeadmControlPlaneTemplateRequestObjectName,
+				Name:      name,
 				Namespace: Namespace,
 			},
 			Spec: controlplanev1.KubeadmControlPlaneTemplateSpec{
@@ -111,6 +121,12 @@ func NewKubeadmControlPlaneTemplateRequestItem(
 		},
 		uid,
 	)
+}
+
+func NewKubeadmControlPlaneTemplateRequestItem(
+	uid types.UID,
+) runtimehooksv1.GeneratePatchesRequestItem {
+	return NewKubeadmControlPlaneTemplateRequest(uid, kubeadmControlPlaneTemplateRequestObjectName)
 }
 
 func NewAWSClusterTemplateRequestItem(

--- a/pkg/handlers/aws/mutation/metapatch_handler_test.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler_test.go
@@ -156,6 +156,14 @@ func TestGeneratePatches(t *testing.T) {
 		imageregistries.VariableName,
 	)
 
+	imageregistrycredentialstests.TestGenerateMirrorPatches(
+		t,
+		metaPatchGeneratorFunc(mgr),
+		mgr.GetClient(),
+		clusterconfig.MetaVariableName,
+		imageregistries.VariableName,
+	)
+
 	amitests.TestControlPlaneGeneratePatches(
 		t,
 		metaPatchGeneratorFunc(mgr),

--- a/pkg/handlers/docker/mutation/metapatch_handler_test.go
+++ b/pkg/handlers/docker/mutation/metapatch_handler_test.go
@@ -112,4 +112,12 @@ func TestGeneratePatches(t *testing.T) {
 		clusterconfig.MetaVariableName,
 		imageregistries.VariableName,
 	)
+
+	imageregistrycredentialstests.TestGenerateMirrorPatches(
+		t,
+		metaPatchGeneratorFunc(mgr),
+		mgr.GetClient(),
+		clusterconfig.MetaVariableName,
+		imageregistries.VariableName,
+	)
 }

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/tests/generate_mirror_patches.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/tests/generate_mirror_patches.go
@@ -1,0 +1,262 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/storage/names"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/d2iq-labs/capi-runtime-extensions/api/v1alpha1"
+	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/capi/clustertopology/handlers/mutation"
+	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/testutils/capitest"
+	"github.com/d2iq-labs/capi-runtime-extensions/common/pkg/testutils/capitest/request"
+)
+
+const (
+	validMirrorCredentialsSecretName = "my-mirror-registry-credentials"
+	validMirrorCASecretName          = "myregistry-mirror-cacert"
+	//nolint:gosec // Does not contain hard coded credentials.
+	cpRegistryAsMirrorCreds = "kubeadmControlPlaneRegistryAsMirrorCreds"
+	//nolint:gosec // Does not contain hard coded credentials.
+	workerRegistryAsMirrorCreds           = "kubeadmConfigTemplateRegistryAsMirrorCreds"
+	registryStaticCredentialsSecretSuffix = "registry-config"
+)
+
+func TestGenerateMirrorPatches(
+	t *testing.T,
+	generatorFunc func() mutation.GeneratePatches,
+	fakeClient client.Client,
+	variableName string,
+	variablePath ...string,
+) {
+	t.Helper()
+
+	require.NoError(
+		t,
+		fakeClient.Create(
+			context.Background(),
+			newRegistryCredentialsSecret(validMirrorCredentialsSecretName, request.Namespace),
+		),
+	)
+
+	require.NoError(
+		t,
+		fakeClient.Create(
+			context.Background(),
+			newMirrorSecret(validMirrorCASecretName, request.Namespace),
+		),
+	)
+
+	// Server side apply does not work with the fake client, hack around it by pre-creating empty Secrets
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/2341
+	require.NoError(
+		t,
+		fakeClient.Create(
+			context.Background(),
+			newEmptySecret(
+				fmt.Sprintf(
+					"%s-%s",
+					cpRegistryAsMirrorCreds,
+					registryStaticCredentialsSecretSuffix,
+				),
+				request.Namespace,
+			),
+		),
+	)
+
+	require.NoError(
+		t,
+		fakeClient.Create(
+			context.Background(),
+			newEmptySecret(
+				fmt.Sprintf(
+					"%s-%s",
+					workerRegistryAsMirrorCreds,
+					registryStaticCredentialsSecretSuffix,
+				),
+				request.Namespace,
+			),
+		),
+	)
+
+	capitest.ValidateGeneratePatches(
+		t,
+		generatorFunc,
+		capitest.PatchTestDef{
+			Name: "files added in KubeadmControlPlaneTemplate for registry with mirror without CA Certificate",
+			Vars: []runtimehooksv1.Variable{
+				capitest.VariableWithValue(
+					variableName,
+					v1alpha1.ImageRegistries{
+						v1alpha1.ImageRegistry{
+							URL:    "https://123456789.dkr.ecr.us-east-1.amazonaws.com",
+							Mirror: &v1alpha1.RegistryMirror{},
+						},
+					},
+					variablePath...,
+				),
+			},
+			RequestItem: request.NewKubeadmControlPlaneTemplateRequestItem(""),
+			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{
+				{
+					Operation: "add",
+					Path:      "/spec/template/spec/kubeadmConfigSpec/files",
+					ValueMatcher: gomega.ContainElements(
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/certs.d/_default/hosts.toml",
+						),
+					),
+				},
+			},
+		},
+		capitest.PatchTestDef{
+			Name: "files added in KubeadmControlPlaneTemplate for registry with mirror with CA Certificate",
+			Vars: []runtimehooksv1.Variable{
+				capitest.VariableWithValue(
+					variableName,
+					v1alpha1.ImageRegistries{
+						v1alpha1.ImageRegistry{
+							URL: "https://mirror-registry.com",
+							Credentials: &v1alpha1.ImageCredentials{
+								SecretRef: &corev1.ObjectReference{
+									Name: validSecretName,
+								},
+							},
+							Mirror: &v1alpha1.RegistryMirror{
+								SecretRef: &corev1.ObjectReference{
+									Name: validMirrorCASecretName,
+								},
+							},
+						},
+					},
+					variablePath...,
+				),
+			},
+			RequestItem: request.NewKubeadmControlPlaneTemplateRequest("", cpRegistryAsMirrorCreds),
+			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{
+				{
+					Operation: "add",
+					Path:      "/spec/template/spec/kubeadmConfigSpec/files",
+					ValueMatcher: gomega.ContainElements(
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/certs.d/_default/hosts.toml",
+						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/certs/mirror.pem",
+						),
+					),
+				},
+			},
+		},
+		capitest.PatchTestDef{
+			Name: "files added in KubeadmConfigTemplate for registry mirror wihthout CA certificate",
+			Vars: []runtimehooksv1.Variable{
+				capitest.VariableWithValue(
+					variableName,
+					v1alpha1.ImageRegistries{
+						v1alpha1.ImageRegistry{
+							URL:    "https://123456789.dkr.ecr.us-east-1.amazonaws.com",
+							Mirror: &v1alpha1.RegistryMirror{},
+						},
+					},
+					variablePath...,
+				),
+				capitest.VariableWithValue(
+					"builtin",
+					map[string]any{
+						"machineDeployment": map[string]any{
+							"class": names.SimpleNameGenerator.GenerateName("worker-"),
+						},
+					},
+				),
+			},
+			RequestItem: request.NewKubeadmConfigTemplateRequestItem(""),
+			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{
+				{
+					Operation: "add",
+					Path:      "/spec/template/spec/files",
+					ValueMatcher: gomega.ContainElements(
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/certs.d/_default/hosts.toml",
+						),
+					),
+				},
+			},
+		},
+		capitest.PatchTestDef{
+			Name: "files added in KubeadmConfigTemplate for registry mirror with secret for CA certificate",
+			Vars: []runtimehooksv1.Variable{
+				capitest.VariableWithValue(
+					variableName,
+					v1alpha1.ImageRegistries{
+						v1alpha1.ImageRegistry{
+							URL: "https://mirror-registry.io",
+							Credentials: &v1alpha1.ImageCredentials{
+								SecretRef: &corev1.ObjectReference{
+									Name: validSecretName,
+								},
+							},
+							Mirror: &v1alpha1.RegistryMirror{
+								SecretRef: &corev1.ObjectReference{
+									Name: validMirrorCASecretName,
+								},
+							},
+						},
+					},
+					variablePath...,
+				),
+				capitest.VariableWithValue(
+					"builtin",
+					map[string]any{
+						"machineDeployment": map[string]any{
+							"class": names.SimpleNameGenerator.GenerateName("worker-"),
+						},
+					},
+				),
+			},
+			RequestItem: request.NewKubeadmConfigTemplateRequest("", workerRegistryAsMirrorCreds),
+			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{
+				{
+					Operation: "add",
+					Path:      "/spec/template/spec/files",
+					ValueMatcher: gomega.ContainElements(
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/certs.d/_default/hosts.toml",
+						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/certs/mirror.pem",
+						),
+					),
+				},
+			},
+		},
+	)
+}
+
+func newMirrorSecret(name, namespace string) *corev1.Secret {
+	secretData := map[string][]byte{
+		"ca.crt": []byte("myCACert"),
+	}
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: secretData,
+		Type: corev1.SecretTypeOpaque,
+	}
+}


### PR DESCRIPTION
Stacked on https://github.com/d2iq-labs/capi-runtime-extensions/pull/292
Fixes flakes in unit tests for image registries: https://github.com/d2iq-labs/capi-runtime-extensions/actions/runs/7564146208/job/20597802432#step:5:68
```
 Message: failed to apply mutation: failed to apply Image Registry Credentials Secret: server-side apply failed: Operation cannot be fulfilled on secrets "test-kubeadmconfigtemplate-registry-config": object was modified
```
When a static credentials are provided for registry, the patch generator creates secret that contains static credentials provider configuration with `registry-config` suffix. This fix is created with server side apply. however Server side apply does not work with the fake client, hack around it by pre-creating empty Secrets. https://github.com/kubernetes-sigs/controller-runtime/issues/2341

When we added more test cases for mirror registry, two parallel running tests were changing the same secrets that resulted in above error intermittently.

Fix:
- ensure that the test secret name for static credentials provider is unique to avoid updating the same secret in parallel. 



