### PR TITLE
docs: fix cluster name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,27 +66,27 @@ EOF
 To create a cluster, update `clusterConfig` variable and run:
 
 ```shell
-kubectl apply --server-side -f examples/capi-quick-start/docker-cluster.yaml
+kubectl apply --server-side -f examples/capi-quick-start/docker-cluster-calico-helm-addon.yaml
 ```
 
 Wait until control plane is ready:
 
 ```shell
-kubectl wait clusters/docker-quick-start --for=condition=ControlPlaneInitialized --timeout=5m
+kubectl wait clusters/docker-quick-start-helm-addon-calico --for=condition=ControlPlaneInitialized --timeout=5m
 ```
 
 To get the kubeconfig for the new cluster, run:
 
 ```shell
-clusterctl get kubeconfig docker-quick-start > docker-kubeconfig
+clusterctl get kubeconfig docker-quick-start-helm-addon-calico > docker-kubeconfig
 ```
 
 If you are not on Linux, you will also need to fix the generated kubeconfig's `server`, run:
 
 ```shell
-kubectl config set-cluster docker-quick-start \
+kubectl config set-cluster docker-quick-start-helm-addon-calico \
   --kubeconfig docker-kubeconfig \
-  --server=https://$(docker port docker-quick-start-lb 6443/tcp)
+  --server=https://$(docker port docker-quick-start-helm-addon-calico-lb 6443/tcp)
 ```
 
 Wait until all nodes are ready (this indicates that CNI has been deployed successfully):
@@ -151,7 +151,7 @@ watch -n 0.5 kubectl --kubeconfig docker-kubeconfig get service/traefik
 To delete the workload cluster, run:
 
 ```shell
-kubectl delete cluster docker-quick-start
+kubectl delete cluster docker-quick-start-helm-addon-calico
 ```
 
 Notice that the traefik service is deleted before the cluster is actually finally deleted.


### PR DESCRIPTION
Chose the CAAPH example as that is the one we want to eventually move to. Tested locally.
