### PR TITLE
fix: Ensure registry credentials are namespace local to Cluster

### DIFF
--- a/api/v1alpha1/clusterconfig_types.go
+++ b/api/v1alpha1/clusterconfig_types.go
@@ -243,11 +243,11 @@ func (ExtraAPIServerCertSANs) VariableSchema() clusterv1.VariableSchema {
 }
 
 type RegistryCredentials struct {
-	// The Secret containing the registry credentials and optional CA certificate
+	// A reference to the Secret containing the registry credentials and optional CA certificate
 	// using the keys `username`, `password` and `ca.crt`.
 	// This credentials Secret is not required for some registries, e.g. ECR.
 	// +optional
-	SecretRef *corev1.ObjectReference `json:"secretRef,omitempty"`
+	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty"`
 }
 
 func (RegistryCredentials) VariableSchema() clusterv1.VariableSchema {
@@ -256,19 +256,14 @@ func (RegistryCredentials) VariableSchema() clusterv1.VariableSchema {
 			Type: "object",
 			Properties: map[string]clusterv1.JSONSchemaProps{
 				"secretRef": {
-					Description: "A reference to the Secret containing the registry credentials. " +
+					Description: "A reference to the Secret containing the registry credentials and optional CA certificate. " +
 						"The Secret should have keys 'username', 'password' and optional 'ca.crt'. " +
 						"This credentials Secret is not required for some registries, e.g. ECR.",
 					Type: "object",
 					Properties: map[string]clusterv1.JSONSchemaProps{
 						"name": {
-							Description: "The name of the Secret containing the registry credentials.",
-							Type:        "string",
-						},
-						"namespace": {
-							Description: "The namespace of the Secret containing the registry credentials. " +
-								"Defaults to the namespace of the Cluster. " +
-								"that reference this variable.",
+							Description: "The name of the Secret containing the registry credentials. This Secret must exist in " +
+								"the same namespace as the Cluster.",
 							Type: "string",
 						},
 					},

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -675,7 +675,7 @@ func (in *RegistryCredentials) DeepCopyInto(out *RegistryCredentials) {
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		*out = new(v1.ObjectReference)
+		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
 }

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/inject.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/inject.go
@@ -309,14 +309,9 @@ func secretForImageRegistryCredentials(
 		return nil, nil
 	}
 
-	namespace := objectNamespace
-	if registry.Credentials.SecretRef.Namespace != "" {
-		namespace = registry.Credentials.SecretRef.Namespace
-	}
-
 	key := ctrlclient.ObjectKey{
 		Name:      registry.Credentials.SecretRef.Name,
-		Namespace: namespace,
+		Namespace: objectNamespace,
 	}
 	secret := &corev1.Secret{}
 	err := c.Get(ctx, key, secret)

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/tests/generate_patches.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/tests/generate_patches.go
@@ -142,7 +142,7 @@ func TestGeneratePatches(
 						v1alpha1.ImageRegistry{
 							URL: "https://registry.example.com",
 							Credentials: &v1alpha1.RegistryCredentials{
-								SecretRef: &corev1.ObjectReference{
+								SecretRef: &corev1.LocalObjectReference{
 									Name: validSecretName,
 								},
 							},
@@ -260,7 +260,7 @@ func TestGeneratePatches(
 						v1alpha1.ImageRegistry{
 							URL: "https://registry.example.com",
 							Credentials: &v1alpha1.RegistryCredentials{
-								SecretRef: &corev1.ObjectReference{
+								SecretRef: &corev1.LocalObjectReference{
 									Name: validSecretName,
 								},
 							},

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/variables_test.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/variables_test.go
@@ -38,7 +38,7 @@ func TestVariableValidation(t *testing.T) {
 					{
 						URL: "https://a.b.c.example.com/a/b/c",
 						Credentials: &v1alpha1.RegistryCredentials{
-							SecretRef: &corev1.ObjectReference{
+							SecretRef: &corev1.LocalObjectReference{
 								Name: "a.b.c.example.com-creds",
 							},
 						},

--- a/pkg/handlers/generic/mutation/mirrors/mirror.go
+++ b/pkg/handlers/generic/mutation/mirrors/mirror.go
@@ -74,14 +74,9 @@ func secretForMirrorCACert(
 		return nil, nil
 	}
 
-	namespace := objectNamespace
-	if globalMirror.Credentials.SecretRef.Namespace != "" {
-		namespace = globalMirror.Credentials.SecretRef.Namespace
-	}
-
 	key := ctrlclient.ObjectKey{
 		Name:      globalMirror.Credentials.SecretRef.Name,
-		Namespace: namespace,
+		Namespace: objectNamespace,
 	}
 	secret := &corev1.Secret{}
 	err := c.Get(ctx, key, secret)

--- a/pkg/handlers/generic/mutation/mirrors/mirror_test.go
+++ b/pkg/handlers/generic/mutation/mirrors/mirror_test.go
@@ -99,7 +99,7 @@ func Test_generateMirrorCACertFile(t *testing.T) {
 				URL: "https://registry.example.com",
 
 				Credentials: &v1alpha1.RegistryCredentials{
-					SecretRef: &v1.ObjectReference{
+					SecretRef: &v1.LocalObjectReference{
 						Name: "my-registry-credentials-secret",
 					},
 				},

--- a/pkg/handlers/generic/mutation/mirrors/tests/generate_patches.go
+++ b/pkg/handlers/generic/mutation/mirrors/tests/generate_patches.go
@@ -81,7 +81,7 @@ func TestGeneratePatches(
 					v1alpha1.GlobalImageRegistryMirror{
 						URL: "https://registry.example.com",
 						Credentials: &v1alpha1.RegistryCredentials{
-							SecretRef: &corev1.ObjectReference{
+							SecretRef: &corev1.LocalObjectReference{
 								Name: validMirrorCASecretName,
 							},
 						},
@@ -145,7 +145,7 @@ func TestGeneratePatches(
 					v1alpha1.GlobalImageRegistryMirror{
 						URL: "https://registry.example.com",
 						Credentials: &v1alpha1.RegistryCredentials{
-							SecretRef: &corev1.ObjectReference{
+							SecretRef: &corev1.LocalObjectReference{
 								Name: validMirrorCASecretName,
 							},
 						},

--- a/pkg/handlers/generic/mutation/mirrors/variables_test.go
+++ b/pkg/handlers/generic/mutation/mirrors/variables_test.go
@@ -35,7 +35,7 @@ func TestVariableValidation(t *testing.T) {
 				GlobalImageRegistryMirror: &v1alpha1.GlobalImageRegistryMirror{
 					URL: "http://a.b.c.example.com",
 					Credentials: &v1alpha1.RegistryCredentials{
-						SecretRef: &corev1.ObjectReference{
+						SecretRef: &corev1.LocalObjectReference{
 							Name: "a.b.c.example.com-ca-cert-creds",
 						},
 					},


### PR DESCRIPTION
Using `LocalObjectReference` ensures user cannot override the secret namespace.

Fixes #322.
