### PR TITLE
ci: Tag api module on release

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,13 +23,14 @@ jobs:
       - uses: actions/checkout@v4
         if: ${{ steps.release-please.outputs.release_created }}
 
-      - name: tag common module
+      - name: Tag common and api modules
         if: ${{ steps.release-please.outputs.release_created }}
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git tag -a common/${{ steps.release-please.outputs.tag_name }} -m "Release common/${{ steps.release-please.outputs.tag_name }}"
-          git push origin common/${{ steps.release-please.outputs.tag_name }}
+          git tag -a api/${{ steps.release-please.outputs.tag_name }} -m "Release api/${{ steps.release-please.outputs.tag_name }}"
+          git push origin {api,common}/${{ steps.release-please.outputs.tag_name }}
 
       - if: ${{ steps.release-please.outputs.release_created }}
         name: Run release workflow

--- a/capi-runtime-extensions.code-workspace
+++ b/capi-runtime-extensions.code-workspace
@@ -8,6 +8,9 @@
         },
         {
             "path": "./common"
+        },
+        {
+            "path": "./api"
         }
     ],
     "settings": {


### PR DESCRIPTION
This enables it to be imported directly into other Go projects.

Follow up to #331.