### PR TITLE
fix: use correct AWS EBS CSI images

### DIFF
--- a/charts/capi-runtime-extensions/templates/csi/aws-ebs/manifests/aws-ebs-csi-configmap.yaml
+++ b/charts/capi-runtime-extensions/templates/csi/aws-ebs/manifests/aws-ebs-csi-configmap.yaml
@@ -1631,7 +1631,7 @@ data:
                   key: endpoint
                   name: aws-meta
                   optional: true
-            image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.24.1
+            image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.25.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 5
@@ -1847,7 +1847,7 @@ data:
           - args:
             - --v=5
             - --leader-election=true
-            image: registry.k8s.io/sig-storage/snapshot-controller:v6.2.1
+            image: registry.k8s.io/sig-storage/snapshot-controller:v6.3.0
             imagePullPolicy: IfNotPresent
             name: snapshot-controller
           nodeSelector: {}
@@ -1928,7 +1928,7 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.24.1
+            image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.25.0
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:

--- a/hack/addons/kustomize/aws-ebs-csi/kustomization.yaml.tmpl
+++ b/hack/addons/kustomize/aws-ebs-csi/kustomization.yaml.tmpl
@@ -37,3 +37,10 @@ patches:
     kind: DaemonSet
     name: ebs-csi-node
     namespace: kube-system
+
+# always override the images to match the version from the set envs
+images:
+- name: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
+  newTag: ${AWS_EBS_CSI_VERSION}
+- name: registry.k8s.io/sig-storage/snapshot-controller
+  newTag: ${AWS_CSI_SNAPSHOT_CONTROLLER_VERSION}


### PR DESCRIPTION
The manifests in the upstream CSI repos may not have the correct images set.
Override the image to match the expected version.

Because of the mismatch between the image and the specs, the EBS CSI deployment failed with:
```
kubectl logs -n kube-system ebs-csi-controller-5564c47bd7-wphl2 
Defaulted container "ebs-plugin" out of: ebs-plugin, csi-provisioner, csi-attacher, csi-snapshotter, csi-resizer, liveness-probe
unknown flag: --batching
```