### PR TITLE
fix: AMI ID patch

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,7 +89,7 @@ issues:
     - path: "v1alpha1"
       linters:
         - gochecknoinits
-    # Idiomatic to use init functions to register APIs with scheme
+    # Idiomatic to use pass holderRef by value
     - text: "hugeParam: holderRef is heavy"
       linters:
         - gocritic

--- a/pkg/handlers/aws/mutation/ami/inject.go
+++ b/pkg/handlers/aws/mutation/ami/inject.go
@@ -88,7 +88,9 @@ func (h *awsAMISpecPatchHandler) Mutate(
 				"patchedObjectName", client.ObjectKeyFromObject(obj),
 			).Info("setting AMI in AWSMachineTemplate spec")
 
-			obj.Spec.Template.Spec.AMI = capav1.AMIReference{ID: &amiSpecVar.ID}
+			if amiSpecVar.ID != "" {
+				obj.Spec.Template.Spec.AMI = capav1.AMIReference{ID: &amiSpecVar.ID}
+			}
 			if amiSpecVar.Lookup != nil {
 				obj.Spec.Template.Spec.ImageLookupFormat = amiSpecVar.Lookup.Format
 				obj.Spec.Template.Spec.ImageLookupOrg = amiSpecVar.Lookup.Org

--- a/pkg/handlers/aws/mutation/ami/tests/generate_patches.go
+++ b/pkg/handlers/aws/mutation/ami/tests/generate_patches.go
@@ -78,6 +78,13 @@ func TestControlPlaneGeneratePatches(
 					ValueMatcher: gomega.Equal("testOS"),
 				},
 			},
+			UnexpectedPatchMatchers: []capitest.JSONPatchMatcher{
+				{
+					Operation:    "add",
+					Path:         "/spec/template/spec/ami/id",
+					ValueMatcher: gomega.Equal(""),
+				},
+			},
 		},
 	)
 }
@@ -155,6 +162,13 @@ func TestWorkerGeneratePatches(
 					Operation:    "add",
 					Path:         "/spec/template/spec/imageLookupBaseOS",
 					ValueMatcher: gomega.Equal("testOS"),
+				},
+			},
+			UnexpectedPatchMatchers: []capitest.JSONPatchMatcher{
+				{
+					Operation:    "add",
+					Path:         "/spec/template/spec/ami/id",
+					ValueMatcher: gomega.Equal(""),
 				},
 			},
 		},


### PR DESCRIPTION
If empty CAPA will fail with:
```
  failed to create AWSMachine instance: failed to run instance: MissingParameter: The request must contain the parameter ImageId
```