### PR TITLE
test: add a Makefile target to update image

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ example), run:
 make SKIP_BUILD=true dev.run-on-kind
 ```
 
+You can just update the image in the webhook Deployment on an existing KIND cluster:
+
+```shell
+make KIND_CLUSTER_NAME=<> dev.update-webhook-image-on-kind
+```
+
 If creating an AWS cluster using the example files, you will also need to create a secret with your AWS credentials:
 
 ```shell

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -17,3 +17,13 @@ endif
 		--wait --wait-for-jobs
 	kubectl rollout restart deployment capi-runtime-extensions
 	kubectl rollout status deployment capi-runtime-extensions
+
+dev.update-webhook-image-on-kind:
+ifndef SKIP_BUILD
+	$(MAKE) release-snapshot
+endif
+	kind load docker-image --name $(KIND_CLUSTER_NAME) \
+		ko.local/capi-runtime-extensions:$$(gojq -r .version dist/metadata.json)
+	kubectl set image deployment capi-runtime-extensions webhook=ko.local/capi-runtime-extensions:$$(gojq -r .version dist/metadata.json)
+	kubectl rollout restart deployment capi-runtime-extensions
+	kubectl rollout status deployment capi-runtime-extensions


### PR DESCRIPTION
Added a new Makefile target to just build and redeploy the webhook on an existing kind cluster.
This target is useful when testing bug fixes in downstream projects. 