### PR TITLE
fix: mirror credentials support in DynamicCredentialProviderConfig

### DIFF
--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files.go
@@ -53,6 +53,7 @@ type providerConfig struct {
 	URL      string
 	Username string
 	Password string
+	Mirror   bool
 }
 
 func (c providerConfig) isCredentialsEmpty() bool {
@@ -114,6 +115,7 @@ func templateDynamicCredentialProviderConfig(
 		ProviderBinary     string
 		ProviderArgs       []string
 		ProviderAPIVersion string
+		Mirror             bool
 	}
 
 	inputs := make([]templateInput, 0, len(configs))
@@ -154,6 +156,7 @@ func templateDynamicCredentialProviderConfig(
 			ProviderBinary:     providerBinary,
 			ProviderArgs:       providerArgs,
 			ProviderAPIVersion: providerAPIVersion,
+			Mirror:             config.Mirror,
 		})
 	}
 

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/templates/dynamic-credential-provider-config.yaml.gotmpl
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/templates/dynamic-credential-provider-config.yaml.gotmpl
@@ -1,5 +1,13 @@
 apiVersion: credentialprovider.d2iq.com/v1alpha1
 kind: DynamicCredentialProviderConfig
+{{- range .}}
+{{- if .Mirror }}
+mirror:
+  endpoint: {{ .RegistryHost }}
+  credentialsStrategy: MirrorCredentialsOnly
+{{- break }}
+{{- end }}
+{{- end }}
 credentialProviderPluginBinDir: /etc/kubernetes/image-credential-provider/
 credentialProviders:
   apiVersion: kubelet.config.k8s.io/v1

--- a/pkg/handlers/generic/mutation/mirrors/mirror.go
+++ b/pkg/handlers/generic/mutation/mirrors/mirror.go
@@ -54,7 +54,7 @@ func mirrorConfigForGlobalMirror(
 	)
 	if err != nil {
 		return &mirrorConfig{}, fmt.Errorf(
-			"error getting secret %s/%s from Image Registry variable: %w",
+			"error getting secret %s/%s from Global Image Registry Mirror variable: %w",
 			obj.GetNamespace(),
 			globalMirror.Credentials.SecretRef.Name,
 			err,


### PR DESCRIPTION
Fixes : https://github.com/d2iq-labs/capi-runtime-extensions/issues/329 (Support for mirror credentials for "globalImageRegistryMirror")
- Adds `mirror` configuration in DynamicCredentialsConfig
e.g.
```
apiVersion: credentialprovider.d2iq.com/v1alpha1
kind: DynamicCredentialProviderConfig
mirror:
  endpoint: mymirror.com
  credentialsStrategy: MirrorCredentialsOnly
credentialProviderPluginBinDir: /etc/kubernetes/image-credential-provider/
...
```
- reads mirror credentials from secret and add its provider configuration in DynamiCredentialsProviderConfig if provided
e.g.
```
apiVersion: credentialprovider.d2iq.com/v1alpha1
kind: DynamicCredentialProviderConfig
mirror:
  endpoint: mymirror.com
  credentialsStrategy: MirrorCredentialsOnly
credentialProviderPluginBinDir: /etc/kubernetes/image-credential-provider/
credentialProviders:
  apiVersion: kubelet.config.k8s.io/v1
  kind: CredentialProviderConfig
  providers:
  - name: static-credential-provider
    matchImages:
      - mymirror.com
    defaultCacheDuration: "0s"
    apiVersion: credentialprovider.kubelet.k8s.io/v1
  - name: static-credential-provider
    matchImages:
      - "docker.io"
    defaultCacheDuration: "0s"
    apiVersion: credentialprovider.kubelet.k8s.io/v1
```