### PR TITLE
fix: generate config with only globalImageRegistryMirror set

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -9,7 +9,7 @@ package v1alpha1
 
 import (
 	"github.com/d2iq-labs/capi-runtime-extensions/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files.go
@@ -6,7 +6,6 @@ package credentials
 import (
 	"bytes"
 	_ "embed"
-	"errors"
 	"fmt"
 	"net/url"
 	"path"
@@ -47,8 +46,6 @@ var (
 	)
 )
 
-var ErrCredentialsNotFound = errors.New("registry credentials not found")
-
 type providerConfig struct {
 	URL      string
 	Username string
@@ -59,6 +56,42 @@ type providerConfig struct {
 func (c providerConfig) isCredentialsEmpty() bool {
 	return c.Username == "" &&
 		c.Password == ""
+}
+
+func (c providerConfig) isSupportedProvider() (bool, error) {
+	registryHostWithPath, err := c.registryHostWithPath()
+	if err != nil {
+		return false, fmt.Errorf(
+			"failed to get registry host with path: %w",
+			err,
+		)
+	}
+
+	supportedProvider, err := credentialprovider.URLMatchesSupportedProvider(
+		registryHostWithPath,
+	)
+	if err != nil {
+		return false, fmt.Errorf(
+			"failed to check if registry matches a supported provider: %w",
+			err,
+		)
+	}
+
+	return supportedProvider, nil
+}
+
+func (c providerConfig) registryHostWithPath() (string, error) {
+	registryURL, err := url.ParseRequestURI(c.URL)
+	if err != nil {
+		return "", fmt.Errorf("failed parsing registry URL: %w", err)
+	}
+
+	registryHostWithPath := registryURL.Host
+	if registryURL.Path != "" {
+		registryHostWithPath = path.Join(registryURL.Host, registryURL.Path)
+	}
+
+	return registryHostWithPath, nil
 }
 
 func templateFilesForImageCredentialProviderConfigs(
@@ -121,27 +154,9 @@ func templateDynamicCredentialProviderConfig(
 	inputs := make([]templateInput, 0, len(configs))
 
 	for _, config := range configs {
-		registryURL, err := url.ParseRequestURI(config.URL)
+		registryHostWithPath, err := config.registryHostWithPath()
 		if err != nil {
-			return nil, fmt.Errorf("failed parsing registry URL: %w", err)
-		}
-
-		registryHostWithPath := registryURL.Host
-		if registryURL.Path != "" {
-			registryHostWithPath = path.Join(registryURL.Host, registryURL.Path)
-		}
-
-		supportedProvider, err := credentialprovider.URLMatchesSupportedProvider(
-			registryHostWithPath,
-		)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"failed to check if registry matches a supported provider: %w",
-				err,
-			)
-		}
-		if config.isCredentialsEmpty() && !supportedProvider {
-			return nil, ErrCredentialsNotFound
+			return nil, err
 		}
 
 		providerBinary, providerArgs, providerAPIVersion, err := dynamicCredentialProvider(

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files.go
@@ -58,7 +58,7 @@ func (c providerConfig) isCredentialsEmpty() bool {
 		c.Password == ""
 }
 
-func (c providerConfig) isSupportedProvider() (bool, error) {
+func (c providerConfig) requiresStaticCredentials() (bool, error) {
 	registryHostWithPath, err := c.registryHostWithPath()
 	if err != nil {
 		return false, fmt.Errorf(
@@ -67,17 +67,18 @@ func (c providerConfig) isSupportedProvider() (bool, error) {
 		)
 	}
 
-	supportedProvider, err := credentialprovider.URLMatchesSupportedProvider(
+	knowRegistryProvider, err := credentialprovider.URLMatchesKnownRegistryProvider(
 		registryHostWithPath,
 	)
 	if err != nil {
 		return false, fmt.Errorf(
-			"failed to check if registry matches a supported provider: %w",
+			"failed to check if registry matches a known registry provider: %w",
 			err,
 		)
 	}
 
-	return supportedProvider, nil
+	// require static credentials if the registry provider is not known
+	return !knowRegistryProvider, nil
 }
 
 func (c providerConfig) registryHostWithPath() (string, error) {

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files.go
@@ -67,7 +67,7 @@ func (c providerConfig) requiresStaticCredentials() (bool, error) {
 		)
 	}
 
-	knowRegistryProvider, err := credentialprovider.URLMatchesKnownRegistryProvider(
+	knownRegistryProvider, err := credentialprovider.URLMatchesKnownRegistryProvider(
 		registryHostWithPath,
 	)
 	if err != nil {
@@ -78,7 +78,7 @@ func (c providerConfig) requiresStaticCredentials() (bool, error) {
 	}
 
 	// require static credentials if the registry provider is not known
-	return !knowRegistryProvider, nil
+	return !knownRegistryProvider, nil
 }
 
 func (c providerConfig) registryHostWithPath() (string, error) {

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files_test.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files_test.go
@@ -185,13 +185,6 @@ credentialProviders:
 			},
 		},
 		{
-			name: "error for a registry with no credentials",
-			credentials: []providerConfig{{
-				URL: "https://registry.example.com",
-			}},
-			wantErr: ErrCredentialsNotFound,
-		},
-		{
 			name: "multiple registries",
 			credentials: []providerConfig{{
 				URL:      "https://registry-1.docker.io",

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credentialprovider/matcher.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credentialprovider/matcher.go
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-func URLMatchesSupportedProvider(target string) (bool, error) {
+func URLMatchesKnownRegistryProvider(target string) (bool, error) {
 	urlGlobs := make([]string, 0, len(ecrURLGlobs)+len(gcrURLGlobs)+len(acrURLGlobs))
 	urlGlobs = append(urlGlobs, ecrURLGlobs...)
 	urlGlobs = append(urlGlobs, gcrURLGlobs...)

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/inject_test.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/inject_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_needImageRegistryCredentials(t *testing.T) {
+func Test_needImageRegistryCredentialsConfiguration(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -94,7 +94,7 @@ func Test_needImageRegistryCredentials(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			need, err := needImageRegistryCredentials(tt.configs)
+			need, err := needImageRegistryCredentialsConfiguration(tt.configs)
 			assert.ErrorIs(t, err, tt.wantErr)
 			assert.Equal(t, tt.need, need)
 		})

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/inject_test.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/inject_test.go
@@ -1,0 +1,102 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package credentials
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_needImageRegistryCredentials(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		configs []providerConfig
+		need    bool
+		wantErr error
+	}{
+		{
+			name: "ECR credentials",
+			configs: []providerConfig{
+				{URL: "https://123456789.dkr.ecr.us-east-1.amazonaws.com"},
+			},
+			need: true,
+		},
+		{
+			name: "registry with static credentials",
+			configs: []providerConfig{{
+				URL:      "https://myregistry.com",
+				Username: "myuser",
+				Password: "mypassword",
+			}},
+			need: true,
+		},
+		{
+			name: "ECR mirror",
+			configs: []providerConfig{
+				{
+					URL:    "https://123456789.dkr.ecr.us-east-1.amazonaws.com",
+					Mirror: true,
+				},
+			},
+			need: true,
+		},
+		{
+			name: "mirror with static credentials",
+			configs: []providerConfig{{
+				URL:      "https://myregistry.com",
+				Username: "myuser",
+				Password: "mypassword",
+				Mirror:   true,
+			}},
+			need: true,
+		},
+		{
+			name: "mirror with no credentials",
+			configs: []providerConfig{{
+				URL:    "https://myregistry.com",
+				Mirror: true,
+			}},
+			need: false,
+		},
+		{
+			name: "a registry with static credentials and a mirror with no credentials",
+			configs: []providerConfig{
+				{
+					URL:      "https://myregistry.com",
+					Username: "myuser",
+					Password: "mypassword",
+					Mirror:   true,
+				},
+				{
+					URL:    "https://myregistry.com",
+					Mirror: true,
+				},
+			},
+			need: true,
+		},
+		{
+			name: "registry with missing credentials",
+			configs: []providerConfig{{
+				URL: "https://myregistry.com",
+			}},
+			need:    false,
+			wantErr: ErrCredentialsNotFound,
+		},
+	}
+
+	for idx := range testCases {
+		tt := testCases[idx]
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			need, err := needImageRegistryCredentials(tt.configs)
+			assert.ErrorIs(t, err, tt.wantErr)
+			assert.Equal(t, tt.need, need)
+		})
+	}
+}


### PR DESCRIPTION
Follow up to https://github.com/d2iq-labs/capi-runtime-extensions/pull/359

I noticed that when the only setting `globalImageRegistryMirror` without `imageRegistries` that the credential provider configs were not being generated.

Tested locally and verified in the Docker container :
```
kubectl get kubeadmconfig.bootstrap.cluster.x-k8s.io/docker-quick-start-helm-addon-cilium-dgz8d-dk7c5 -o yaml | grep "path:"
        audit-log-path: /var/log/audit/kube-apiserver-audit.log
    path: /etc/kubernetes/audit-policy/apiserver-audit-policy.yaml
    path: /etc/konvoy/install-kubelet-credential-providers.sh
    path: /etc/kubernetes/image-credential-provider-config.yaml
    path: /etc/kubernetes/dynamic-credential-provider-config.yaml
    path: /etc/kubernetes/static-image-credentials.json
    path: /etc/containerd/certs.d/_default/hosts.toml
```

```
root@docker-quick-start-helm-addon-cilium-md-0-7zv45-plbrx-wv86j:/# ls -lat /etc/kubernetes/
total 44
drwxr-xr-x 1 root root 4096 Feb 14 23:02 ..
drwxr-xr-x 1 root root 4096 Feb 14 22:59 .
drwxr-xr-x 4 root root 4096 Feb 14 22:59 node-feature-discovery
-rw------- 1 root root 1911 Feb 14 22:59 kubelet.conf
drwxr-xr-x 2 root root 4096 Feb 14 22:59 pki
drwxr-xr-x 2 root root 4096 Feb 14 22:59 image-credential-provider
-rw------- 1 root root  248 Feb 14 22:59 static-image-credentials.json
-rw------- 1 root root  694 Feb 14 22:59 dynamic-credential-provider-config.yaml
-rw------- 1 root root  383 Feb 14 22:59 image-credential-provider-config.yaml
drwxr-xr-x 2 root root 4096 May 25  2023 manifests
```