### PR TITLE
fix: v2/ in Containerd mirror path

### DIFF
--- a/pkg/handlers/generic/mutation/mirrors/mirror_test.go
+++ b/pkg/handlers/generic/mutation/mirrors/mirror_test.go
@@ -31,8 +31,31 @@ func Test_generateDefaultRegistryMirrorFile(t *testing.T) {
 					Permissions: "0600",
 					Encoding:    "",
 					Append:      false,
-					Content: `[host."https://123456789.dkr.ecr.us-east-1.amazonaws.com"]
+					Content: `[host."https://123456789.dkr.ecr.us-east-1.amazonaws.com/v2"]
   capabilities = ["pull", "resolve"]
+  # don't rely on Containerd to add the v2/ suffix
+  # there is a bug where it is added incorrectly for mirrors with a path
+  override_path = true
+`,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name:   "ECR image registry with a path and no CA certificate",
+			config: &mirrorConfig{URL: "https://123456789.dkr.ecr.us-east-1.amazonaws.com/myproject"},
+			want: []cabpkv1.File{
+				{
+					Path:        "/etc/containerd/certs.d/_default/hosts.toml",
+					Owner:       "",
+					Permissions: "0600",
+					Encoding:    "",
+					Append:      false,
+					Content: `[host."https://123456789.dkr.ecr.us-east-1.amazonaws.com/v2/myproject"]
+  capabilities = ["pull", "resolve"]
+  # don't rely on Containerd to add the v2/ suffix
+  # there is a bug where it is added incorrectly for mirrors with a path
+  override_path = true
 `,
 				},
 			},
@@ -51,9 +74,12 @@ func Test_generateDefaultRegistryMirrorFile(t *testing.T) {
 					Permissions: "0600",
 					Encoding:    "",
 					Append:      false,
-					Content: `[host."https://myregistry.com"]
+					Content: `[host."https://myregistry.com/v2"]
   capabilities = ["pull", "resolve"]
   ca = "/etc/certs/mirror.pem"
+  # don't rely on Containerd to add the v2/ suffix
+  # there is a bug where it is added incorrectly for mirrors with a path
+  override_path = true
 `,
 				},
 			},

--- a/pkg/handlers/generic/mutation/mirrors/templates/hosts.toml.gotmpl
+++ b/pkg/handlers/generic/mutation/mirrors/templates/hosts.toml.gotmpl
@@ -3,3 +3,6 @@
   {{- if .CACertPath }}
   ca = "{{ .CACertPath }}"
   {{- end }}
+  # don't rely on Containerd to add the v2/ suffix
+  # there is a bug where it is added incorrectly for mirrors with a path
+  override_path = true


### PR DESCRIPTION
Found a bug(?) in how Containerd handles mirrors with a path and it incorrectly appends `/v2` to the end of mirror, and not between the provided host and path.

See https://github.com/containerd/containerd/issues/6634#issuecomment-1944899130 for a longer explanation and example output.