### PR TITLE
fix: set config_path in Containerd config

### DIFF
--- a/pkg/handlers/generic/mutation/mirrors/mirror_test.go
+++ b/pkg/handlers/generic/mutation/mirrors/mirror_test.go
@@ -156,3 +156,58 @@ func Test_generateMirrorCACertFile(t *testing.T) {
 		})
 	}
 }
+
+func Test_generateContainerdRegistryConfigDropInFile(t *testing.T) {
+	want := []cabpkv1.File{
+		{
+			Path:        "/etc/containerd/cre.d/registry-config.toml",
+			Owner:       "",
+			Permissions: "0600",
+			Encoding:    "",
+			Append:      false,
+			Content: `[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
+`,
+		},
+	}
+	file := generateContainerdRegistryConfigDropInFile()
+	assert.Equal(t, want, file)
+}
+
+func Test_generateContainerdApplyPatchesScript(t *testing.T) {
+	wantFile := []cabpkv1.File{
+		{
+			Path:        "/etc/containerd/apply-patches.sh",
+			Owner:       "",
+			Permissions: "0700",
+			Encoding:    "",
+			Append:      false,
+			//nolint:lll // just a long string
+			Content: `#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+declare -r TOML_MERGE_IMAGE="ghcr.io/mesosphere/toml-merge:v0.2.0"
+
+if ! ctr --namespace k8s.io images check "name==${TOML_MERGE_IMAGE}" | grep "${TOML_MERGE_IMAGE}" >/dev/null; then
+  ctr --namespace k8s.io images pull "${TOML_MERGE_IMAGE}"
+fi
+
+cleanup() {
+  ctr images unmount "${tmp_ctr_mount_dir}" || true
+}
+
+trap 'cleanup' EXIT
+
+readonly tmp_ctr_mount_dir="$(mktemp -d)"
+
+ctr --namespace k8s.io images mount "${TOML_MERGE_IMAGE}" "${tmp_ctr_mount_dir}"
+"${tmp_ctr_mount_dir}/usr/local/bin/toml-merge" -i --patch-file "/etc/containerd/cre.d/*.toml" /etc/containerd/config.toml
+`,
+		},
+	}
+	wantCmd := "/bin/bash /etc/containerd/apply-patches.sh"
+	file, cmd, _ := generateContainerdApplyPatchesScript()
+	assert.Equal(t, wantFile, file)
+	assert.Equal(t, wantCmd, cmd)
+}

--- a/pkg/handlers/generic/mutation/mirrors/templates/containerd-apply-patches.sh.gotmpl
+++ b/pkg/handlers/generic/mutation/mirrors/templates/containerd-apply-patches.sh.gotmpl
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+declare -r TOML_MERGE_IMAGE="{{ .TOMLMergeImage }}"
+
+if ! ctr --namespace k8s.io images check "name==${TOML_MERGE_IMAGE}" | grep "${TOML_MERGE_IMAGE}" >/dev/null; then
+  ctr --namespace k8s.io images pull "${TOML_MERGE_IMAGE}"
+fi
+
+cleanup() {
+  ctr images unmount "${tmp_ctr_mount_dir}" || true
+}
+
+trap 'cleanup' EXIT
+
+readonly tmp_ctr_mount_dir="$(mktemp -d)"
+
+ctr --namespace k8s.io images mount "${TOML_MERGE_IMAGE}" "${tmp_ctr_mount_dir}"
+"${tmp_ctr_mount_dir}/usr/local/bin/toml-merge" -i --patch-file "{{ .PatchDir }}/*.toml" /etc/containerd/config.toml

--- a/pkg/handlers/generic/mutation/mirrors/templates/containerd-registry-config-drop-in.toml
+++ b/pkg/handlers/generic/mutation/mirrors/templates/containerd-registry-config-drop-in.toml
@@ -1,0 +1,2 @@
+[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"

--- a/pkg/handlers/generic/mutation/mirrors/tests/generate_patches.go
+++ b/pkg/handlers/generic/mutation/mirrors/tests/generate_patches.go
@@ -69,6 +69,19 @@ func TestGeneratePatches(
 						gomega.HaveKeyWithValue(
 							"path", "/etc/containerd/certs.d/_default/hosts.toml",
 						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/cre.d/registry-config.toml",
+						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/apply-patches.sh",
+						),
+					),
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
+					ValueMatcher: gomega.ContainElement(
+						"/bin/bash /etc/containerd/apply-patches.sh",
 					),
 				},
 			},
@@ -101,6 +114,19 @@ func TestGeneratePatches(
 						gomega.HaveKeyWithValue(
 							"path", "/etc/certs/mirror.pem",
 						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/cre.d/registry-config.toml",
+						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/apply-patches.sh",
+						),
+					),
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
+					ValueMatcher: gomega.ContainElement(
+						"/bin/bash /etc/containerd/apply-patches.sh",
 					),
 				},
 			},
@@ -133,6 +159,19 @@ func TestGeneratePatches(
 						gomega.HaveKeyWithValue(
 							"path", "/etc/containerd/certs.d/_default/hosts.toml",
 						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/cre.d/registry-config.toml",
+						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/apply-patches.sh",
+						),
+					),
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/template/spec/preKubeadmCommands",
+					ValueMatcher: gomega.ContainElement(
+						"/bin/bash /etc/containerd/apply-patches.sh",
 					),
 				},
 			},
@@ -173,6 +212,19 @@ func TestGeneratePatches(
 						gomega.HaveKeyWithValue(
 							"path", "/etc/certs/mirror.pem",
 						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/cre.d/registry-config.toml",
+						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/apply-patches.sh",
+						),
+					),
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/template/spec/preKubeadmCommands",
+					ValueMatcher: gomega.ContainElement(
+						"/bin/bash /etc/containerd/apply-patches.sh",
 					),
 				},
 			},


### PR DESCRIPTION
Set `config_path ` in the Containerd config as described in https://github.com/containerd/containerd/blob/main/docs/hosts.md#cri

~This is not enough, we also need to remove `registry.mirrors` from the config file, opening in case @jimmidyson you have some ideas on how we can do this, [TOML doesn't have a nil value](https://github.com/toml-lang/toml/issues/30)~:
```
Feb 15 05:59:13 docker-quick-start-helm-addon-cilium-rjfjv-hn9m7 containerd[7127]: time="2024-02-15T05:59:13.663662461Z" level=warning msg="failed to load plugin io.containerd.grpc.v1.cri" error="invalid plugin config: `mirrors` cannot be set when `config_path` is provided"
```

No additional changes are needed, the unnecessary mirror configuration will be removed from the OS image instead.