### PR TITLE
fix: restart Containerd when setting mirror config

### DIFF
--- a/pkg/handlers/generic/mutation/mirrors/inject.go
+++ b/pkg/handlers/generic/mutation/mirrors/inject.go
@@ -191,6 +191,10 @@ func generateFilesAndCommands(
 	}
 	files = append(files, applyPatchesFile...)
 	commands = append(commands, applyPatchesCommand)
+	// generate Containerd restart script and command
+	restartFile, restartCommand := generateContainerdRestartScript()
+	files = append(files, restartFile...)
+	commands = append(commands, restartCommand)
 
 	return files, commands, err
 }

--- a/pkg/handlers/generic/mutation/mirrors/mirror.go
+++ b/pkg/handlers/generic/mutation/mirrors/mirror.go
@@ -28,6 +28,9 @@ const (
 	containerdPatchesDirOnRemote                = "/etc/containerd/cre.d"
 	containerdApplyPatchesScriptOnRemote        = "/etc/containerd/apply-patches.sh"
 	containerdApplyPatchesScriptOnRemoteCommand = "/bin/bash " + containerdApplyPatchesScriptOnRemote
+
+	containerdRestartScriptOnRemote        = "/etc/containerd/restart.sh"
+	containerdRestartScriptOnRemoteCommand = "/bin/bash " + containerdRestartScriptOnRemote
 )
 
 var (
@@ -47,6 +50,9 @@ var (
 
 	//go:embed templates/containerd-apply-patches.sh.gotmpl
 	containerdApplyConfigPatchesScript []byte
+
+	//go:embed templates/containerd-restart.sh
+	containerdRestartScript []byte
 )
 
 type mirrorConfig struct {
@@ -219,4 +225,15 @@ func generateContainerdApplyPatchesScript() ([]cabpkv1.File, string, error) {
 			Permissions: "0700",
 		},
 	}, containerdApplyPatchesScriptOnRemoteCommand, nil
+}
+
+//nolint:gocritic // no need for named return values
+func generateContainerdRestartScript() ([]cabpkv1.File, string) {
+	return []cabpkv1.File{
+		{
+			Path:        containerdRestartScriptOnRemote,
+			Content:     string(containerdRestartScript),
+			Permissions: "0700",
+		},
+	}, containerdRestartScriptOnRemoteCommand
 }

--- a/pkg/handlers/generic/mutation/mirrors/templates/containerd-restart.sh
+++ b/pkg/handlers/generic/mutation/mirrors/templates/containerd-restart.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+systemctl restart containerd
+
+if ! command -v crictl; then
+  echo "Command crictl is not available, will not wait for Containerd to be running"
+  exit
+fi
+
+SECONDS=0
+until crictl info; do
+  if ((SECONDS > 60)); then
+    echo "Containerd is not running. Giving up..."
+    exit 1
+  fi
+  echo "Containerd is not running yet. Waiting..."
+  sleep 5
+done

--- a/pkg/handlers/generic/mutation/mirrors/tests/generate_patches.go
+++ b/pkg/handlers/generic/mutation/mirrors/tests/generate_patches.go
@@ -75,13 +75,17 @@ func TestGeneratePatches(
 						gomega.HaveKeyWithValue(
 							"path", "/etc/containerd/apply-patches.sh",
 						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/restart.sh",
+						),
 					),
 				},
 				{
 					Operation: "add",
 					Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
-					ValueMatcher: gomega.ContainElement(
+					ValueMatcher: gomega.ContainElements(
 						"/bin/bash /etc/containerd/apply-patches.sh",
+						"/bin/bash /etc/containerd/restart.sh",
 					),
 				},
 			},
@@ -120,13 +124,17 @@ func TestGeneratePatches(
 						gomega.HaveKeyWithValue(
 							"path", "/etc/containerd/apply-patches.sh",
 						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/restart.sh",
+						),
 					),
 				},
 				{
 					Operation: "add",
 					Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
-					ValueMatcher: gomega.ContainElement(
+					ValueMatcher: gomega.ContainElements(
 						"/bin/bash /etc/containerd/apply-patches.sh",
+						"/bin/bash /etc/containerd/restart.sh",
 					),
 				},
 			},
@@ -165,13 +173,17 @@ func TestGeneratePatches(
 						gomega.HaveKeyWithValue(
 							"path", "/etc/containerd/apply-patches.sh",
 						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/restart.sh",
+						),
 					),
 				},
 				{
 					Operation: "add",
 					Path:      "/spec/template/spec/preKubeadmCommands",
-					ValueMatcher: gomega.ContainElement(
+					ValueMatcher: gomega.ContainElements(
 						"/bin/bash /etc/containerd/apply-patches.sh",
+						"/bin/bash /etc/containerd/restart.sh",
 					),
 				},
 			},
@@ -218,13 +230,17 @@ func TestGeneratePatches(
 						gomega.HaveKeyWithValue(
 							"path", "/etc/containerd/apply-patches.sh",
 						),
+						gomega.HaveKeyWithValue(
+							"path", "/etc/containerd/restart.sh",
+						),
 					),
 				},
 				{
 					Operation: "add",
 					Path:      "/spec/template/spec/preKubeadmCommands",
-					ValueMatcher: gomega.ContainElement(
+					ValueMatcher: gomega.ContainElements(
 						"/bin/bash /etc/containerd/apply-patches.sh",
+						"/bin/bash /etc/containerd/restart.sh",
 					),
 				},
 			},


### PR DESCRIPTION
>Updates under this directory do not require restarting the containerd daemon.

Even-though [a restart is not required ](https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-configuration---introduction) on changes, it is still required initially after setting `config_path` in the Containerd config.

---

Tested locally with a CAPD cluster:
```
root@docker-quick-start-helm-addon-cilium-ng7q8-7xcrh:/# journalctl -u containerd | grep starting
Feb 16 01:42:07 docker-quick-start-helm-addon-cilium-ng7q8-7xcrh containerd[129]: time="2024-02-16T01:42:07.338020972Z" level=info msg="starting containerd" revision=1677a17964311325ed1c31e2c0a3589ce6d5c30d version=v1.7.1
Feb 16 01:42:17 docker-quick-start-helm-addon-cilium-ng7q8-7xcrh containerd[495]: time="2024-02-16T01:42:17.495879170Z" level=info msg="starting containerd" revision=1677a17964311325ed1c31e2c0a3589ce6d5c30d version=v1.7.1
```

Also tested in an AWS instance with a globalMirrorRegistry configuration and after restarting Containerd, the Kubelet was able to start Pods.
