### PR TITLE
test(e2e): Resolve latest upstream provider releases in e2e config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	sigs.k8s.io/cluster-api-addon-provider-helm v0.1.1-alpha.1
 	sigs.k8s.io/cluster-api/test v1.6.1
 	sigs.k8s.io/controller-runtime v0.17.1
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -141,5 +142,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kind v0.20.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/test/e2e/config/cre.yaml
+++ b/test/e2e/config/cre.yaml
@@ -11,8 +11,8 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v1.6.1
-    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/core-components.yaml
+  - name: "{go://sigs.k8s.io/cluster-api@v1.6}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.6}/core-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -24,8 +24,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v1.6.1
-    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/bootstrap-components.yaml
+  - name: "{go://sigs.k8s.io/cluster-api@v1.6}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.6}/bootstrap-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -37,8 +37,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v1.6.1
-    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/control-plane-components.yaml
+  - name: "{go://sigs.k8s.io/cluster-api@v1.6}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.6}/control-plane-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -50,8 +50,8 @@ providers:
 - name: docker
   type: InfrastructureProvider
   versions:
-  - name: v1.6.1
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/infrastructure-components-development.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.6}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.6}/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     files:
@@ -73,8 +73,8 @@ providers:
 - name: helm
   type: AddonProvider
   versions:
-  - name: v0.1.1-alpha.1
-    value: "https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.1.1-alpha.1/addon-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api-addon-provider-helm@latest-v0.1}"
+    value: "https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/{go://sigs.k8s.io/cluster-api-addon-provider-helm@latest-v0.1}/addon-components.yaml"
     type: "url"
     contract: v1beta1
     files:
@@ -86,8 +86,8 @@ providers:
 - name: cre
   type: RuntimeExtensionProvider
   versions:
-  - name: v0.5.0
-    value: "https://github.com/d2iq-labs/capi-runtime-extensions/releases/download/v0.5.0/runtime-extension-components.yaml"
+  - name: "{go://github.com/d2iq-labs/capi-runtime-extensions@v0.5}"
+    value: "https://github.com/d2iq-labs/capi-runtime-extensions/releases/download/{go://github.com/d2iq-labs/capi-runtime-extensions@v0.5}/runtime-extension-components.yaml"
     type: "url"
     contract: v1beta1
     files:

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -26,6 +26,8 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	clusterctltemp "github.com/d2iq-labs/capi-runtime-extensions/test/framework/clusterctl"
 )
 
 func init() { //nolint:gochecknoinits // Idiomatically used to set up flags.
@@ -154,7 +156,7 @@ var _ = SynchronizedAfterSuite(func() {
 })
 
 func loadE2EConfig(configPath string) *clusterctl.E2EConfig {
-	config := clusterctl.LoadE2EConfig(
+	config := clusterctltemp.LoadE2EConfig(
 		context.TODO(),
 		clusterctl.LoadE2EConfigInput{ConfigPath: configPath},
 	)

--- a/test/framework/clusterctl/e2e_config.go
+++ b/test/framework/clusterctl/e2e_config.go
@@ -1,0 +1,161 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is a copy of the original file from the cluster-api repository, to allow resolving latest patch releases
+// versions. Once this is released upstream in CPAI v1.7, this file can be removed and code switched to use the upstream
+// config loader.
+
+package clusterctl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/yaml"
+
+	"github.com/d2iq-labs/capi-runtime-extensions/test/framework/goproxy"
+)
+
+// LoadE2EConfig loads the configuration for the e2e test environment.
+func LoadE2EConfig(ctx context.Context, input clusterctl.LoadE2EConfigInput) *clusterctl.E2EConfig {
+	configData, err := os.ReadFile(input.ConfigPath)
+	Expect(err).ToNot(HaveOccurred(), "Failed to read the e2e test config file")
+	Expect(configData).ToNot(BeEmpty(), "The e2e test config file should not be empty")
+
+	config := &clusterctl.E2EConfig{}
+	Expect(
+		yaml.Unmarshal(configData, config),
+	).To(Succeed(), "Failed to convert the e2e test config file to yaml")
+
+	Expect(
+		ResolveReleases(ctx, config),
+	).To(Succeed(), "Failed to resolve release markers in e2e test config file")
+	config.Defaults()
+	config.AbsPaths(filepath.Dir(input.ConfigPath))
+
+	Expect(config.Validate()).To(Succeed(), "The e2e test config file is not valid")
+
+	return config
+}
+
+// ResolveReleases converts release markers to release version.
+func ResolveReleases(ctx context.Context, config *clusterctl.E2EConfig) error {
+	for i := range config.Providers {
+		provider := &config.Providers[i]
+		for j := range provider.Versions {
+			version := &provider.Versions[j]
+			if version.Type != clusterctl.URLSource {
+				continue
+			}
+			// Skipping versions that are not a resolvable marker. Resolvable markers are surrounded by `{}`
+			if !strings.HasPrefix(version.Name, "{") || !strings.HasSuffix(version.Name, "}") {
+				continue
+			}
+			releaseMarker := strings.TrimLeft(strings.TrimRight(version.Name, "}"), "{")
+			ver, err := ResolveRelease(ctx, releaseMarker)
+			if err != nil {
+				return fmt.Errorf("failed resolving release url %q: %w", version.Name, err)
+			}
+			ver = "v" + ver
+			version.Value = strings.Replace(version.Value, version.Name, ver, 1)
+			version.Name = ver
+		}
+	}
+	return nil
+}
+
+func ResolveRelease(ctx context.Context, releaseMarker string) (string, error) {
+	scheme, host, err := goproxy.GetSchemeAndHost(os.Getenv("GOPROXY"))
+	if err != nil {
+		return "", err
+	}
+	if scheme == "" || host == "" {
+		return "", fmt.Errorf(
+			"releasemarker does not support disabling the go proxy: GOPROXY=%q",
+			os.Getenv("GOPROXY"),
+		)
+	}
+	goproxyClient := goproxy.NewClient(scheme, host)
+	return resolveReleaseMarker(ctx, releaseMarker, goproxyClient)
+}
+
+// resolveReleaseMarker resolves releaseMarker string to verion string e.g.
+// - Resolves "go://sigs.k8s.io/cluster-api@v1.0" to the latest stable patch release of v1.0.
+// - Resolves "go://sigs.k8s.io/cluster-api@latest-v1.0" to the latest patch release of v1.0 including rc and
+// pre releases.
+func resolveReleaseMarker(
+	ctx context.Context,
+	releaseMarker string,
+	goproxyClient *goproxy.Client,
+) (string, error) {
+	if !strings.HasPrefix(releaseMarker, "go://") {
+		return "", errors.New("unknown release marker scheme")
+	}
+
+	releaseMarker = strings.TrimPrefix(releaseMarker, "go://")
+	if releaseMarker == "" {
+		return "", errors.New("empty release url")
+	}
+
+	gomoduleParts := strings.Split(releaseMarker, "@")
+	if len(gomoduleParts) < 2 {
+		return "", errors.New("go module or version missing")
+	}
+	gomodule := gomoduleParts[0]
+
+	includePrereleases := false
+	if strings.HasPrefix(gomoduleParts[1], "latest-") {
+		includePrereleases = true
+	}
+	version := strings.TrimPrefix(gomoduleParts[1], "latest-") + ".0"
+	version = strings.TrimPrefix(version, "v")
+	semVersion, err := semver.Parse(version)
+	if err != nil {
+		return "", fmt.Errorf("parsing semver for %s: %w", version, err)
+	}
+
+	parsedTags, err := goproxyClient.GetVersions(ctx, gomodule)
+	if err != nil {
+		return "", err
+	}
+
+	var picked semver.Version
+	for i, tag := range parsedTags {
+		if !includePrereleases && len(tag.Pre) > 0 {
+			continue
+		}
+		if tag.Major == semVersion.Major && tag.Minor == semVersion.Minor {
+			picked = parsedTags[i]
+		}
+	}
+	if picked.Major == 0 && picked.Minor == 0 && picked.Patch == 0 {
+		return "", fmt.Errorf(
+			"no suitable release available for release marker %s",
+			releaseMarker,
+		)
+	}
+	return picked.String(), nil
+}

--- a/test/framework/goproxy/goproxy.go
+++ b/test/framework/goproxy/goproxy.go
@@ -1,0 +1,210 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/blang/semver/v4"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	defaultGoProxyHost = "proxy.golang.org"
+)
+
+var (
+	retryableOperationInterval = 10 * time.Second
+	retryableOperationTimeout  = 1 * time.Minute
+)
+
+// Client is a client to query versions from a goproxy instance.
+type Client struct {
+	scheme string
+	host   string
+}
+
+// NewClient returns a new goproxyClient instance.
+func NewClient(scheme, host string) *Client {
+	return &Client{
+		scheme: scheme,
+		host:   host,
+	}
+}
+
+// GetVersions returns the a sorted list of semantical versions which exist for a go module.
+func (g *Client) GetVersions(ctx context.Context, gomodulePath string) (semver.Versions, error) {
+	parsedVersions := semver.Versions{}
+
+	majorVersionNumber := 1
+	var majorVersion string
+	for {
+		if majorVersionNumber > 1 {
+			majorVersion = fmt.Sprintf("v%d", majorVersionNumber)
+		}
+		rawURL := url.URL{
+			Scheme: g.scheme,
+			Host:   g.host,
+			Path:   path.Join(gomodulePath, majorVersion, "@v", "/list"),
+		}
+		majorVersionNumber++
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL.String(), http.NoBody)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get versions: failed to create request: %w", err)
+		}
+
+		var rawResponse []byte
+		var responseStatusCode int
+		var retryError error
+		_ = wait.PollUntilContextTimeout(
+			ctx,
+			retryableOperationInterval,
+			retryableOperationTimeout,
+			true,
+			func(context.Context) (bool, error) {
+				retryError = nil
+
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					retryError = fmt.Errorf("failed to get versions: failed to do request: %w", err)
+					return false, nil
+				}
+				defer resp.Body.Close()
+
+				responseStatusCode = resp.StatusCode
+
+				// Status codes OK and NotFound are expected results:
+				// * OK indicates that we got a list of versions to read.
+				// * NotFound indicates that there are no versions for this module / modules major version.
+				if responseStatusCode != http.StatusOK &&
+					responseStatusCode != http.StatusNotFound {
+					retryError = fmt.Errorf(
+						"failed to get versions: response status code %d",
+						resp.StatusCode,
+					)
+					return false, nil
+				}
+
+				// only read the response for http.StatusOK
+				if responseStatusCode == http.StatusOK {
+					rawResponse, err = io.ReadAll(resp.Body)
+					if err != nil {
+						retryError = fmt.Errorf(
+							"failed to get versions: error reading goproxy response body: %w",
+							err,
+						)
+						return false, nil
+					}
+				}
+				return true, nil
+			},
+		)
+		if retryError != nil {
+			return nil, retryError
+		}
+
+		// Don't try to read the versions if status was not found.
+		if responseStatusCode == http.StatusNotFound {
+			break
+		}
+
+		for _, s := range strings.Split(string(rawResponse), "\n") {
+			if s == "" {
+				continue
+			}
+			parsedVersion, err := semver.ParseTolerant(s)
+			if err != nil {
+				// Discard releases with tags that are not a valid semantic versions (the user can point explicitly to such
+				// releases).
+				continue
+			}
+			parsedVersions = append(parsedVersions, parsedVersion)
+		}
+	}
+
+	if len(parsedVersions) == 0 {
+		return nil, fmt.Errorf("no versions found for go module %q", gomodulePath)
+	}
+
+	sort.Sort(parsedVersions)
+
+	return parsedVersions, nil
+}
+
+// GetSchemeAndHost detects and returns the scheme and host for goproxy requests.
+// It returns empty strings if goproxy is disabled via `off` or `direct` values.
+func GetSchemeAndHost(goproxy string) (scheme, host string, err error) {
+	// Fallback to default
+	if goproxy == "" {
+		return "https", defaultGoProxyHost, nil
+	}
+
+	var goproxyHost, goproxyScheme string
+	// xref https://github.com/golang/go/blob/master/src/cmd/go/internal/modfetch/proxy.go
+	for goproxy != "" {
+		var rawURL string
+		if i := strings.IndexAny(goproxy, ",|"); i >= 0 {
+			rawURL = goproxy[:i]
+			goproxy = goproxy[i+1:]
+		} else {
+			rawURL = goproxy
+			goproxy = ""
+		}
+
+		rawURL = strings.TrimSpace(rawURL)
+		if rawURL == "" {
+			continue
+		}
+		if rawURL == "off" || rawURL == "direct" {
+			// Return nothing to fallback to github repository client without an error.
+			return "", "", nil
+		}
+
+		// Single-word tokens are reserved for built-in behaviors, and anything
+		// containing the string ":/" or matching an absolute file path must be a
+		// complete URL. For all other paths, implicitly add "https://".
+		if strings.ContainsAny(rawURL, ".:/") && !strings.Contains(rawURL, ":/") &&
+			!filepath.IsAbs(rawURL) &&
+			!path.IsAbs(rawURL) {
+			rawURL = "https://" + rawURL
+		}
+
+		parsedURL, err := url.Parse(rawURL)
+		if err != nil {
+			return "", "", fmt.Errorf("parse GOPROXY url %q: %w", rawURL, err)
+		}
+		goproxyHost = parsedURL.Host
+		goproxyScheme = parsedURL.Scheme
+		// A host was found so no need to continue.
+		break
+	}
+
+	return goproxyScheme, goproxyHost, nil
+}


### PR DESCRIPTION
Copied functionality from cluster-api repo main branch until it is released
in next minor (v1.7) when we can remove this functionality and switch
back to upstream.

Depends on #383.

Temporary implementation for #386.