### PR TITLE
test: Temporarily disable GOPROXY to workaround dodgy CAPA release

### DIFF
--- a/make/clusterctl.mk
+++ b/make/clusterctl.mk
@@ -3,7 +3,8 @@
 
 .PHONY: clusterctl.init
 clusterctl.init:
-	env CLUSTER_TOPOLOGY=true \
+	env GOPROXY=off \
+	    CLUSTER_TOPOLOGY=true \
 	    EXP_RUNTIME_SDK=true \
 	    EXP_CLUSTER_RESOURCE_SET=true \
 	    EXP_MACHINE_POOL=true \


### PR DESCRIPTION
v2.3.4 release was partially done and then rolled back. This has broken the
discovery mechanism built in to clusterctl which uses go mod proxy to
discover latest releases of providers. Seeing errors in other builds, e.g.
https://github.com/d2iq-labs/capi-runtime-extensions/actions/runs/8029367117/job/21942031279?pr=390#step:9:10

```
Error: failed to get provider components for the "aws" provider: failed to
get repository client for the InfrastructureProvider with name aws: error
creating the GitHub repository client: failed to get latest release:
release not found for version v2.3.4, please retry later or set "GOPROXY=off"
to get the current stable release: 404 Not Found
```

Disabling GOPROXY temporarily until CAPA release is fixed.
