### PR TITLE
build: Ignore controller-runtime upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
         patterns:
           - "k8s.io*"
           - "sigs.k8s.io*"
+    # Remove this ignore once #402 is resolved.
+    ignore:
+      - dependency-name: "sigs.k8s.io/controller-runtime"
 
   - package-ecosystem: "gomod"
     directory: "/common"
@@ -27,6 +30,9 @@ updates:
         patterns:
           - "k8s.io*"
           - "sigs.k8s.io*"
+    # Remove this ignore once #402 is resolved.
+    ignore:
+      - dependency-name: "sigs.k8s.io/controller-runtime"
 
   - package-ecosystem: "gomod"
     directory: "/hack/third-party/capa"


### PR DESCRIPTION
SSA is now explicitly broken in fake client so prevent upgrades
until #402 is implemented to use envtest in unit tests.