### PR TITLE
revert: Temporarily disable GOPROXY to workaround dodgy CAPA release (#395)

### DIFF
--- a/make/clusterctl.mk
+++ b/make/clusterctl.mk
@@ -3,8 +3,7 @@
 
 .PHONY: clusterctl.init
 clusterctl.init:
-	env GOPROXY=off \
-	    CLUSTER_TOPOLOGY=true \
+	env CLUSTER_TOPOLOGY=true \
 	    EXP_RUNTIME_SDK=true \
 	    EXP_CLUSTER_RESOURCE_SET=true \
 	    EXP_MACHINE_POOL=true \


### PR DESCRIPTION
This reverts commit 41a6cb9d49a4f163b8524414de857955c747c6e3.

CAPA release v2.3.5 has successfully released so we can revert this now.