### PR TITLE
build: Ensure release namespace is use in kustomize helm inflator

### DIFF
--- a/hack/addons/kustomize/aws-ebs-csi/kustomization.yaml.tmpl
+++ b/hack/addons/kustomize/aws-ebs-csi/kustomization.yaml.tmpl
@@ -17,6 +17,7 @@ helmCharts:
   valuesFile: helm-values.yaml
   includeCRDs: true
   skipTests: true
+  namespace: kube-system
 
 resources:
 - ../external-snapshotter

--- a/hack/addons/kustomize/cilium/kustomization.yaml.tmpl
+++ b/hack/addons/kustomize/cilium/kustomization.yaml.tmpl
@@ -18,5 +18,6 @@ helmCharts:
   valuesFile: helm-values.yaml
   includeCRDs: true
   skipTests: true
+  namespace: kube-system
 
 namespace: kube-system

--- a/hack/addons/kustomize/nfd/kustomization.yaml.tmpl
+++ b/hack/addons/kustomize/nfd/kustomization.yaml.tmpl
@@ -21,5 +21,6 @@ helmCharts:
       tag: "v${NODE_FEATURE_DISCOVERY_VERSION}-minimal"
   includeCRDs: true
   skipTests: true
+  namespace: node-feature-discovery
 
 namespace: node-feature-discovery

--- a/hack/addons/kustomize/tigera-operator/kustomization.yaml.tmpl
+++ b/hack/addons/kustomize/tigera-operator/kustomization.yaml.tmpl
@@ -21,5 +21,6 @@ helmCharts:
   valuesFile: helm-values.yaml
   includeCRDs: true
   skipTests: true
+  namespace: tigera-operator
 
 namespace: tigera-operator


### PR DESCRIPTION
Otherwise `{{.Release.Namespace}}` used in helm chart inflation is set
to `default` which can affect template output.