### PR TITLE
fix: don't use an SSH key in AWS clusters

### DIFF
--- a/charts/capi-runtime-extensions/defaultclusterclasses/aws-cluster-class.yaml
+++ b/charts/capi-runtime-extensions/defaultclusterclasses/aws-cluster-class.yaml
@@ -107,6 +107,7 @@ spec:
     spec:
       iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
       instanceType: m5.xlarge
+      sshKeyName: ""
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
@@ -119,6 +120,7 @@ spec:
     spec:
       iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
       instanceType: m5.2xlarge
+      sshKeyName: ""
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/hack/examples/bases/aws/kustomization.yaml.tmpl
+++ b/hack/examples/bases/aws/kustomization.yaml.tmpl
@@ -123,6 +123,22 @@ patches:
       path: "/spec/template/spec/instanceType"
       value: "m5.xlarge"
 - target:
+    group: infrastructure.cluster.x-k8s.io
+    kind: AWSMachineTemplate
+    name: quick-start-worker-machinetemplate
+  patch: |-
+    - op: "add"
+      path: "/spec/template/spec/sshKeyName"
+      value: ""
+- target:
+    group: infrastructure.cluster.x-k8s.io
+    kind: AWSMachineTemplate
+    name: quick-start-control-plane
+  patch: |-
+    - op: "add"
+      path: "/spec/template/spec/sshKeyName"
+      value: ""
+- target:
     kind: ConfigMap
   patch: |
     $$patch: delete


### PR DESCRIPTION
When `sshKeyName` is nil CAPA will default the instance to using an SSH key-pair named `default`. We don't this behavior by default, so setting it to an empty string and CAPA won't set a key-pair.