### PR TITLE
fix: set default tolerations on Deployment

### DIFF
--- a/charts/capi-runtime-extensions/README.md
+++ b/charts/capi-runtime-extensions/README.md
@@ -66,4 +66,4 @@ A Helm chart for capi-runtime-extensions
 | service.annotations | object | `{}` |  |
 | service.port | int | `443` |  |
 | service.type | string | `"ClusterIP"` |  |
-| tolerations | list | `[]` |  |
+| tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Equal"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Equal"}]` | Kubernetes pod tolerations |

--- a/charts/capi-runtime-extensions/values.yaml
+++ b/charts/capi-runtime-extensions/values.yaml
@@ -93,8 +93,14 @@ nodeSelector: {}
   # Allow scheduling of Deployment on linux nodes only
   # kubernetes.io/os: linux
 
-tolerations: []
-  # -- Kubernetes pod tolerations
+# -- Kubernetes pod tolerations
+tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Equal
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Equal
+    effect: NoSchedule
   # Allow scheduling of Deployment on all nodes
   # - operator: "Exists"
 


### PR DESCRIPTION
This webhook is on the critical path of all cluster lifecycle operations. Add tolerations to allow it to run on the control-plane Nodes, and be able to recover the cluster if all workers were deleted.