### PR TITLE
fix: set default priorityClassName on Deployment

### DIFF
--- a/charts/capi-runtime-extensions/README.md
+++ b/charts/capi-runtime-extensions/README.md
@@ -57,7 +57,7 @@ A Helm chart for capi-runtime-extensions
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the container image |
 | nodeSelector | object | `{}` |  |
-| priorityClassName | string | `""` | Optional priority class to be used for the pod. |
+| priorityClassName | string | `"system-cluster-critical"` | Priority class to be used for the pod. |
 | resources.limits.cpu | string | `"100m"` |  |
 | resources.limits.memory | string | `"256Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |

--- a/charts/capi-runtime-extensions/templates/deployment.yaml
+++ b/charts/capi-runtime-extensions/templates/deployment.yaml
@@ -74,6 +74,7 @@ spec:
             port: probes
             scheme: HTTP
             path: /readyz
+      priorityClassName: {{ .Values.priorityClassName }}
       securityContext:
         {{ with .Values.securityContext }}
         {{- toYaml . | nindent 8}}

--- a/charts/capi-runtime-extensions/values.yaml
+++ b/charts/capi-runtime-extensions/values.yaml
@@ -98,5 +98,5 @@ tolerations: []
   # Allow scheduling of Deployment on all nodes
   # - operator: "Exists"
 
-# -- Optional priority class to be used for the pod.
-priorityClassName: ""
+# -- Priority class to be used for the pod.
+priorityClassName: system-cluster-critical


### PR DESCRIPTION
This webhook is on the critical path of all cluster lifecycle operations. Setting default priorityClassName to system-cluster-critical, to increase the chances of this Deployment running when there is resource contention.