### PR TITLE
revert: Temporary lint config fix until next golangci-lint release (#629)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,10 +101,6 @@ issues:
     - source: "// \\+kubebuilder:"
       linters:
         - lll
-    # Temporary workaround until https://github.com/golangci/golangci-lint/pull/4698 is
-    # available in released version of golangci-lint
-    - path: "(test/e2e/e2e_suite_test.go|v1alpha1)"
-      text: "don't use `init` function"
     # Idiomatic to use pass holderRef by value
     - text: "hugeParam: holderRef is heavy"
       linters:

--- a/api/v1alpha1/clusterconfig_types.go
+++ b/api/v1alpha1/clusterconfig_types.go
@@ -304,6 +304,7 @@ type AESConfiguration struct{}
 
 type SecretboxConfiguration struct{}
 
+//nolint:gochecknoinits // Idiomatic to use init functions to register APIs with scheme.
 func init() {
 	SchemeBuilder.Register(
 		&AWSClusterConfig{},

--- a/api/v1alpha1/nodeconfig_types.go
+++ b/api/v1alpha1/nodeconfig_types.go
@@ -102,6 +102,7 @@ type NutanixNodeConfigSpec struct {
 	Nutanix *NutanixNodeSpec `json:"nutanix,omitempty"`
 }
 
+//nolint:gochecknoinits // Idiomatic to use init functions to register APIs with scheme.
 func init() {
 	SchemeBuilder.Register(&AWSWorkerNodeConfig{}, &DockerNodeConfig{}, &NutanixNodeConfig{})
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -33,6 +33,7 @@ import (
 	clusterctltemp "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/framework/clusterctl"
 )
 
+//nolint:gochecknoinits // Idiomatically used to set up flags.
 func init() {
 	flag.StringVar(&configPath, "e2e.config", "", "path to the e2e config file")
 	flag.StringVar(


### PR DESCRIPTION
This reverts commit 4d0fa6533ce867719ddcacdb9df341579c62554d.
