### PR TITLE
build: Use go 1.22.5 toolchain to fix CVE

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/ap
 
 go 1.21
 
-toolchain go1.22.4
+toolchain go1.22.5
 
 replace github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common => ../common
 

--- a/common/go.mod
+++ b/common/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/co
 
 go 1.21
 
-toolchain go1.22.4
+toolchain go1.22.5
 
 replace github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api => ../api
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix
 
 go 1.21
 
-toolchain go1.22.4
+toolchain go1.22.5
 
 replace (
 	github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api => ./api

--- a/make/go.mk
+++ b/make/go.mk
@@ -217,7 +217,24 @@ ifneq ($(words $(GO_SUBMODULES_NO_DOCS)),0)
 govulncheck: $(addprefix govulncheck.,$(GO_SUBMODULES_NO_DOCS:/go.mod=))
 endif
 
-.PHONY: ggovulncheck.%
+.PHONY: govulncheck.%
 govulncheck.%: ## Runs golangci-lint for a specific module
 govulncheck.%: ; $(info $(M) running govulncheck on $* module)
 	$(if $(filter-out root .,$*),cd $* && )govulncheck ./...
+
+.PHONY: go-mod-edit-toolchain
+go-mod-edit-toolchain: ## Edits the go.mod file of all modules in repository to use the toolchain version
+ifneq ($(wildcard $(REPO_ROOT)/go.mod),)
+go-mod-edit-toolchain: go-mod-edit-toolchain.root
+endif
+ifneq ($(words $(GO_SUBMODULES_NO_DOCS)),0)
+go-mod-edit-toolchain: $(addprefix go-mod-edit-toolchain.,$(GO_SUBMODULES_NO_DOCS:/go.mod=))
+endif
+
+.PHONY: go-mod-edit-toolchain.%
+go-mod-edit-toolchain.%: ## Edits the go.mod file of a specifc module in repository to use the toolchain version
+go-mod-edit-toolchain.%: ; $(info $(M) setting go toolchain for $* module)
+ifndef GO_TOOLCHAIN_VERSION
+	$(error GO_TOOLCHAIN_VERSION is not set: please set GO_TOOLCHAIN_VERSION to the desired version, e.g. go1.22.5)
+endif
+	$(if $(filter-out root .,$*),cd $* && )go mod edit -toolchain=$(GO_TOOLCHAIN_VERSION)


### PR DESCRIPTION
This was highlighted by failing govulncheck builds in
other PRs.

Fixes https://pkg.go.dev/vuln/GO-2024-2963.
