### PR TITLE
feat: Enable kube-vip CP load-balancer in masquerade mode

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
@@ -194,20 +194,21 @@ spec:
                       value: "10"
                     - name: vip_retryperiod
                       value: "2"
+                    - name: lb_enable
+                      value: "true"
+                    - name: lb_port
+                      value: "6443"
+                    - name: lb_fwdmethod
+                      value: masquerade
                     - name: address
                       value: '{{ .Address }}'
                     - name: prometheus_server
-                  image: ghcr.io/kube-vip/kube-vip:v0.9.1
+                  image: ghcr.io/kube-vip/kube-vip-iptables:v0.9.1
                   imagePullPolicy: IfNotPresent
                   name: kube-vip
                   resources: {}
                   securityContext:
-                    capabilities:
-                      add:
-                        - NET_ADMIN
-                        - NET_RAW
-                      drop:
-                        - ALL
+                    privileged: true
                   volumeMounts:
                     - mountPath: /etc/kubernetes/admin.conf
                       name: kubeconfig

--- a/hack/addons/update-kube-vip-manifests.sh
+++ b/hack/addons/update-kube-vip-manifests.sh
@@ -22,17 +22,20 @@ docker container run --rm ghcr.io/kube-vip/kube-vip:"${KUBE_VIP_VERSION}" \
   --arp \
   --address='127.0.0.1' \
   --controlplane \
+  --enableLoadBalancer \
+  --lbForwardingMethod=masquerade \
   --leaderElection \
   --leaseDuration=15 \
   --leaseRenewDuration=10 \
   --leaseRetry=2 \
   --prometheusHTTPServer='' |
   gojq --yaml-input --yaml-output \
-    'del(.metadata.creationTimestamp, .status) |
-     .spec.containers[].imagePullPolicy |= "IfNotPresent" |
-     (.spec.containers[0].env[] | select(.name == "port").value) |= "{{ .Port }}" |
-     (.spec.containers[0].env[] | select(.name == "address").value) |= "{{ .Address }}"
-    ' >"${ASSETS_DIR}/${FILE_NAME}"
+    "del(.metadata.creationTimestamp, .status) |
+     .spec.containers[].imagePullPolicy |= \"IfNotPresent\" |
+     (.spec.containers[0].env[] | select(.name == \"port\").value) |= \"{{ .Port }}\" |
+     (.spec.containers[0].env[] | select(.name == \"address\").value) |= \"{{ .Address }}\" |
+     .spec.containers[0].image |= \"ghcr.io/kube-vip/kube-vip-iptables:${KUBE_VIP_VERSION}\"
+    " >"${ASSETS_DIR}/${FILE_NAME}"
 
 # add 8 spaces to each line so that the kustomize template can be properly indented
 sed -i -e 's/^/        /' "${ASSETS_DIR}/${FILE_NAME}"

--- a/hack/examples/files/kube-vip.yaml
+++ b/hack/examples/files/kube-vip.yaml
@@ -34,20 +34,21 @@
                   value: "10"
                 - name: vip_retryperiod
                   value: "2"
+                - name: lb_enable
+                  value: "true"
+                - name: lb_port
+                  value: "6443"
+                - name: lb_fwdmethod
+                  value: masquerade
                 - name: address
                   value: '{{ .Address }}'
                 - name: prometheus_server
-              image: ghcr.io/kube-vip/kube-vip:v0.9.1
+              image: ghcr.io/kube-vip/kube-vip-iptables:v0.9.1
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}
               securityContext:
-                capabilities:
-                  add:
-                    - NET_ADMIN
-                    - NET_RAW
-                  drop:
-                    - ALL
+                privileged: true
               volumeMounts:
                 - mountPath: /etc/kubernetes/admin.conf
                   name: kubeconfig


### PR DESCRIPTION
This enables actual load balancing across CP nodes, an improvement on the
current configuration that only routes traffic to the API server running on
the CP node where kube-vip leader is running.

With this new configuration, the ipvs service is created on the node where the
current leader is running and will be created on new leader when the VIP moves.
This means there will be minimal downtime when the leader is reelected, which
usually happens only when a node is rolled out (e.g. for CP upgrade). This is the
same behaviour as previously with no ipvs, just adding the details here
to align on expected behaviour.