### PR TITLE
fix: Move preflight skip annotation constants to api module

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -39,6 +39,14 @@ const (
 	// DNSVariableName is the DNS external patch variable name.
 	DNSVariableName = "dns"
 
-	ClusterUUIDAnnotationKey                = APIGroup + "/cluster-uuid"
+	ClusterUUIDAnnotationKey = APIGroup + "/cluster-uuid"
+
 	SkipAutoEnablingWorkloadClusterRegistry = APIGroup + "/skip-auto-enabling-workload-cluster-registry"
+
+	// PreflightChecksSkipAnnotationKey is the key of the annotation on the Cluster used to skip preflight checks.
+	PreflightChecksSkipAnnotationKey = "preflight.cluster.caren.nutanix.com/skip"
+
+	// PreflightChecksSkipAllAnnotationValue is the value used in the cluster's annotations to indicate
+	// that all checks are skipped.
+	PreflightChecksSkipAllAnnotationValue = "all"
 )

--- a/pkg/webhook/preflight/preflight_test.go
+++ b/pkg/webhook/preflight/preflight_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	carenv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/webhook/preflight/skip"
 )
 
@@ -68,7 +69,7 @@ func topologyCluster(skippedCheckNames ...string) *clusterv1.Cluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster",
 			Annotations: map[string]string{
-				skip.AnnotationKey: strings.Join(skippedCheckNames, ","),
+				carenv1.PreflightChecksSkipAnnotationKey: strings.Join(skippedCheckNames, ","),
 			},
 		},
 		Spec: clusterv1.ClusterSpec{
@@ -147,7 +148,7 @@ func TestHandle(t *testing.T) {
 		},
 		{
 			name:    "if cluster skips all checks, then allowed, with a warning",
-			cluster: topologyCluster(skip.SkipAllChecksAnnotationValue),
+			cluster: topologyCluster(carenv1.PreflightChecksSkipAllAnnotationValue),
 			checkers: []Checker{
 				&mockChecker{
 					checks: []Check{},

--- a/pkg/webhook/preflight/skip/skip.go
+++ b/pkg/webhook/preflight/skip/skip.go
@@ -6,15 +6,8 @@ import (
 	"strings"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-)
 
-const (
-	// AnnotationKey is the key of the annotation on the Cluster used to skip preflight checks.
-	AnnotationKey = "preflight.cluster.caren.nutanix.com/skip"
-
-	// SkipAllChecksAnnotationValue is the value used in the cluster's annotations to indicate
-	// that all checks are skipped.
-	SkipAllChecksAnnotationValue = "all"
+	carenv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 )
 
 // Evaluator is used to determine which checks should be skipped, based on the cluster's annotations.
@@ -35,7 +28,7 @@ func New(cluster *clusterv1.Cluster) *Evaluator {
 		return o
 	}
 
-	value, exists := annotations[AnnotationKey]
+	value, exists := annotations[carenv1.PreflightChecksSkipAnnotationKey]
 	if !exists {
 		// If the annotation does not exist, return an Evaluator with no prefixes.
 		return o
@@ -49,7 +42,8 @@ func New(cluster *clusterv1.Cluster) *Evaluator {
 		normalizedCheckName := strings.TrimSpace(strings.ToLower(checkName))
 		o.normalizedCheckNames[normalizedCheckName] = struct{}{}
 	}
-	if _, exists := o.normalizedCheckNames[SkipAllChecksAnnotationValue]; exists && len(o.normalizedCheckNames) == 1 {
+	if _, exists := o.normalizedCheckNames[carenv1.PreflightChecksSkipAllAnnotationValue]; exists &&
+		len(o.normalizedCheckNames) == 1 {
 		o.all = true
 	}
 	return o

--- a/pkg/webhook/preflight/skip/skip_test.go
+++ b/pkg/webhook/preflight/skip/skip_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	carenv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 )
 
 func TestNew(t *testing.T) {
@@ -37,14 +39,14 @@ func TestNew(t *testing.T) {
 		{
 			name: "ignores empty skip annotation value",
 			annotations: map[string]string{
-				AnnotationKey: "",
+				carenv1.PreflightChecksSkipAnnotationKey: "",
 			},
 			expectCheckNames: map[string]struct{}{},
 		},
 		{
 			name: "ignores empty check names",
 			annotations: map[string]string{
-				AnnotationKey: "InfraVMImage,,InfraCredentials,",
+				carenv1.PreflightChecksSkipAnnotationKey: "InfraVMImage,,InfraCredentials,",
 			},
 			expectCheckNames: map[string]struct{}{
 				"infravmimage":     {},
@@ -54,14 +56,14 @@ func TestNew(t *testing.T) {
 		{
 			name: "ignores value of only commas",
 			annotations: map[string]string{
-				AnnotationKey: ",,,",
+				carenv1.PreflightChecksSkipAnnotationKey: ",,,",
 			},
 			expectCheckNames: map[string]struct{}{},
 		},
 		{
 			name: "accepts single check name",
 			annotations: map[string]string{
-				AnnotationKey: "InfraVMImage",
+				carenv1.PreflightChecksSkipAnnotationKey: "InfraVMImage",
 			},
 			expectCheckNames: map[string]struct{}{
 				"infravmimage": {},
@@ -70,7 +72,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "accepts multiple check names",
 			annotations: map[string]string{
-				AnnotationKey: "InfraVMImage,InfraCredentials",
+				carenv1.PreflightChecksSkipAnnotationKey: "InfraVMImage,InfraCredentials",
 			},
 			expectCheckNames: map[string]struct{}{
 				"infravmimage":     {},
@@ -80,7 +82,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "trims spaces from check names",
 			annotations: map[string]string{
-				AnnotationKey: " InfraVMImage , InfraCredentials ",
+				carenv1.PreflightChecksSkipAnnotationKey: " InfraVMImage , InfraCredentials ",
 			},
 			expectCheckNames: map[string]struct{}{
 				"infravmimage":     {},
@@ -125,7 +127,7 @@ func TestEvaluator_For(t *testing.T) {
 		{
 			name: "empty annotation value",
 			annotations: map[string]string{
-				AnnotationKey: "",
+				carenv1.PreflightChecksSkipAnnotationKey: "",
 			},
 			checkName:   "InfraVMImage",
 			expectMatch: false,
@@ -133,7 +135,7 @@ func TestEvaluator_For(t *testing.T) {
 		{
 			name: "skip InfraVMImage check",
 			annotations: map[string]string{
-				AnnotationKey: "InfraVMImage,InfraCredentials",
+				carenv1.PreflightChecksSkipAnnotationKey: "InfraVMImage,InfraCredentials",
 			},
 			checkName:   "InfraVMImage",
 			expectMatch: true,
@@ -141,7 +143,7 @@ func TestEvaluator_For(t *testing.T) {
 		{
 			name: "skip credentials, but not image",
 			annotations: map[string]string{
-				AnnotationKey: "InfraCredentials",
+				carenv1.PreflightChecksSkipAnnotationKey: "InfraCredentials",
 			},
 			checkName:   "InfraVMImage",
 			expectMatch: false,
@@ -149,7 +151,7 @@ func TestEvaluator_For(t *testing.T) {
 		{
 			name: "skip with spaces and case mixing",
 			annotations: map[string]string{
-				AnnotationKey: " infraVMImage , InfraCredentials ",
+				carenv1.PreflightChecksSkipAnnotationKey: " infraVMImage , InfraCredentials ",
 			},
 			checkName:   "InfraVMImage",
 			expectMatch: true,
@@ -157,7 +159,7 @@ func TestEvaluator_For(t *testing.T) {
 		{
 			name: "extra commas do not affect matching",
 			annotations: map[string]string{
-				AnnotationKey: "InfraVMImage,,InfraCredentials,",
+				carenv1.PreflightChecksSkipAnnotationKey: "InfraVMImage,,InfraCredentials,",
 			},
 			checkName:   "InfraVMImage",
 			expectMatch: true,
@@ -165,7 +167,7 @@ func TestEvaluator_For(t *testing.T) {
 		{
 			name: "skip all checks",
 			annotations: map[string]string{
-				AnnotationKey: "all",
+				carenv1.PreflightChecksSkipAnnotationKey: "all",
 			},
 			checkName:   "InfraVMImage",
 			expectMatch: true,
@@ -206,34 +208,34 @@ func TestEvaluator_ForAll(t *testing.T) {
 		{
 			name: "empty annotation value",
 			annotations: map[string]string{
-				AnnotationKey: "",
+				carenv1.PreflightChecksSkipAnnotationKey: "",
 			},
 		},
 		{
 			name: "skip all checks with spaces and case mixing",
 			annotations: map[string]string{
-				AnnotationKey: " aLL ",
+				carenv1.PreflightChecksSkipAnnotationKey: " aLL ",
 			},
 			expectMatch: true,
 		},
 		{
 			name: "skip all checks with extra commas",
 			annotations: map[string]string{
-				AnnotationKey: ",all,,",
+				carenv1.PreflightChecksSkipAnnotationKey: ",all,,",
 			},
 			expectMatch: true,
 		},
 		{
 			name: "skip all checks",
 			annotations: map[string]string{
-				AnnotationKey: "all",
+				carenv1.PreflightChecksSkipAnnotationKey: "all",
 			},
 			expectMatch: true,
 		},
 		{
 			name: "skip some checks, but not all",
 			annotations: map[string]string{
-				AnnotationKey: "OneCheck,AnotherCheck",
+				carenv1.PreflightChecksSkipAnnotationKey: "OneCheck,AnotherCheck",
 			},
 			expectMatch: false,
 		},


### PR DESCRIPTION
**What problem does this PR solve?**:
Makes it possible for CAREN api module consumers to reference these constants.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
