### PR TITLE
fix: allow http registries by disabling TLS check

### DIFF
--- a/pkg/webhook/preflight/generic/registry_test.go
+++ b/pkg/webhook/preflight/generic/registry_test.go
@@ -343,7 +343,7 @@ func TestRegistryCheck(t *testing.T) {
 				InternalError: false,
 				Causes: []preflight.Cause{
 					{
-						Message: "failed to parse registry url must be http or https tcp://some-registry.lol",
+						Message: "Registry URL scheme \"tcp\" is not supported. Use http or https.",
 						Field:   "cluster.spec.topology.variables[.name=clusterConfig].value.imageRegistries[0].url",
 					},
 				},


### PR DESCRIPTION
**What problem does this PR solve?**:
Disables TLS if the registry is HTTP 

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
