### PR TITLE
feat: Validate the configured failure domain(s) exist and valid

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	capxv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	caaphv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/server"
@@ -56,6 +57,7 @@ func main() {
 	utilruntime.Must(crsv1.AddToScheme(clientScheme))
 	utilruntime.Must(clusterv1.AddToScheme(clientScheme))
 	utilruntime.Must(caaphv1.AddToScheme(clientScheme))
+	utilruntime.Must(capxv1.AddToScheme(clientScheme))
 
 	webhookOptions := webhook.Options{
 		Port:    9444,

--- a/pkg/webhook/preflight/nutanix/clients.go
+++ b/pkg/webhook/preflight/nutanix/clients.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	clustermgmtv4 "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	netv4 "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
 	vmmv4 "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/content"
 
 	prismgoclient "github.com/nutanix-cloud-native/prism-go-client"
@@ -48,6 +49,16 @@ type client interface {
 		select_ *string,
 		args ...map[string]interface{},
 	) (*clustermgmtv4.ListStorageContainersApiResponse, error)
+	GetSubnetById(id *string) (*netv4.GetSubnetApiResponse, error)
+	ListSubnets(
+		page_ *int,
+		limit_ *int,
+		filter_ *string,
+		orderby_ *string,
+		expand_ *string,
+		select_ *string,
+		args ...map[string]interface{},
+	) (*netv4.ListSubnetsApiResponse, error)
 }
 
 // clientWrapper implements the client interface and wraps both v3 and v4 clients.
@@ -155,6 +166,38 @@ func (c *clientWrapper) ListStorageContainers(
 		limit_,
 		filter_,
 		orderby_,
+		select_,
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *clientWrapper) GetSubnetById(id *string) (*netv4.GetSubnetApiResponse, error) {
+	resp, err := c.v4client.SubnetsApiInstance.GetSubnetById(id)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *clientWrapper) ListSubnets(
+	page_ *int,
+	limit_ *int,
+	filter_ *string,
+	orderby_ *string,
+	expand_ *string,
+	select_ *string,
+	args ...map[string]interface{},
+) (*netv4.ListSubnetsApiResponse, error) {
+	resp, err := c.v4client.SubnetsApiInstance.ListSubnets(
+		page_,
+		limit_,
+		filter_,
+		orderby_,
+		expand_,
 		select_,
 		args...,
 	)

--- a/pkg/webhook/preflight/nutanix/clients_test.go
+++ b/pkg/webhook/preflight/nutanix/clients_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	clustermgmtv4 "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	netv4 "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
 	vmmv4 "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/content"
 
 	prismv3 "github.com/nutanix-cloud-native/prism-go-client/v3"
@@ -57,6 +58,18 @@ type mocknclient struct {
 		select_ *string,
 		args ...map[string]interface{},
 	) (*clustermgmtv4.ListStorageContainersApiResponse, error)
+
+	GetSubnetByIdFunc func(id *string) (*netv4.GetSubnetApiResponse, error)
+
+	ListSubnetsFunc func(
+		page_ *int,
+		limit_ *int,
+		filter_ *string,
+		orderby_ *string,
+		expand_ *string,
+		select_ *string,
+		args ...map[string]interface{},
+	) (*netv4.ListSubnetsApiResponse, error)
 }
 
 func (m *mocknclient) GetCurrentLoggedInUser(ctx context.Context) (*prismv3.UserIntentResponse, error) {
@@ -93,4 +106,20 @@ func (m *mocknclient) ListStorageContainers(
 	args ...map[string]interface{},
 ) (*clustermgmtv4.ListStorageContainersApiResponse, error) {
 	return m.listStorageContainersFunc(page, limit, filter, orderby, select_, args...)
+}
+
+func (m *mocknclient) GetSubnetById(id *string) (*netv4.GetSubnetApiResponse, error) {
+	return m.GetSubnetByIdFunc(id)
+}
+
+func (m *mocknclient) ListSubnets(
+	page_ *int,
+	limit_ *int,
+	filter_ *string,
+	orderby_ *string,
+	expand_ *string,
+	select_ *string,
+	args ...map[string]interface{},
+) (*netv4.ListSubnetsApiResponse, error) {
+	return m.ListSubnetsFunc(page_, limit_, filter_, orderby_, expand_, select_, args...)
 }

--- a/pkg/webhook/preflight/nutanix/failuredomain.go
+++ b/pkg/webhook/preflight/nutanix/failuredomain.go
@@ -1,0 +1,220 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nutanix
+
+import (
+	"context"
+	"fmt"
+
+	netv4 "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	capxv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/webhook/preflight"
+)
+
+type failureDomainCheck struct {
+	failureDomainName string
+	namespace         string
+	field             string
+	kclient           ctrlclient.Client
+	nclient           client
+}
+
+func (fdc *failureDomainCheck) Name() string {
+	return "NutanixFailureDomain"
+}
+
+func newFailureDomainChecks(cd *checkDependencies) []preflight.Check {
+	checks := []preflight.Check{}
+
+	if cd.nclient == nil || cd.kclient == nil {
+		return checks
+	}
+
+	// For the failure domains configured for control-plane nodes
+	if cd.nutanixClusterConfigSpec != nil &&
+		cd.nutanixClusterConfigSpec.ControlPlane != nil &&
+		cd.nutanixClusterConfigSpec.ControlPlane.Nutanix != nil {
+		for _, fdName := range cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.FailureDomains {
+			if fdName != "" {
+				checks = append(checks, &failureDomainCheck{
+					failureDomainName: fdName,
+					namespace:         cd.cluster.Namespace,
+					field:             "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.controlPlane.nutanix.failureDomains", //nolint:lll // field is long.
+					kclient:           cd.kclient,
+					nclient:           cd.nclient,
+				})
+			}
+		}
+	}
+
+	// For the failure domains configured for worker nodes
+	if cd.cluster != nil &&
+		cd.cluster.Spec.Topology != nil &&
+		cd.cluster.Spec.Topology.Workers != nil {
+		for i := range cd.cluster.Spec.Topology.Workers.MachineDeployments {
+			md := &cd.cluster.Spec.Topology.Workers.MachineDeployments[i]
+			if md.FailureDomain != nil && *md.FailureDomain != "" {
+				checks = append(checks, &failureDomainCheck{
+					failureDomainName: *md.FailureDomain,
+					namespace:         cd.cluster.Namespace,
+					field:             "$.spec.topology.workers.machineDeployments[?@.name==%q].failureDomain",
+					kclient:           cd.kclient,
+					nclient:           cd.nclient,
+				})
+			}
+		}
+	}
+
+	return checks
+}
+
+func (fdc *failureDomainCheck) Run(ctx context.Context) preflight.CheckResult {
+	result := preflight.CheckResult{
+		Allowed: true,
+	}
+
+	// Fetch the referent failure domain object
+	fdObj := &capxv1.NutanixFailureDomain{}
+	fdKey := ctrlclient.ObjectKey{Name: fdc.failureDomainName, Namespace: fdc.namespace}
+	if err := fdc.kclient.Get(ctx, fdKey, fdObj); err != nil {
+		if errors.IsNotFound(err) {
+			result.Allowed = false
+			result.Causes = append(result.Causes, preflight.Cause{
+				Message: fmt.Sprintf(
+					"NutanixFailureDomain %q referenced in cluster was not found in the management cluster. Please create it and retry.", //nolint:lll // Message is long.
+					fdc.failureDomainName,
+				),
+				Field: fdc.field,
+			})
+			return result
+		}
+
+		result.Allowed = false
+		result.InternalError = true
+		result.Causes = append(result.Causes, preflight.Cause{
+			Message: fmt.Sprintf(
+				"Failed to get NutanixFailureDomain %q: %v This is usually a temporary error. Please retry.", //nolint:lll // Message is long.
+				fdc.failureDomainName,
+				err,
+			),
+			Field: fdc.field,
+		})
+		return result
+	}
+
+	// Validate the failure domain configuration
+	// Validate spec.prismElementCluster configuration
+	peIdentifier := fdObj.Spec.PrismElementCluster
+	peClusters, err := getClusters(fdc.nclient, &peIdentifier)
+	if err != nil {
+		result.Allowed = false
+		result.InternalError = true
+		result.Causes = append(result.Causes, preflight.Cause{
+			Message: fmt.Sprintf(
+				"Failed to check if the Prism Element cluster %q, referenced by Failure Domain %q, exists: %v This is usually a temporary error. Please retry.", //nolint:lll // Message is long.
+				peIdentifier,
+				fdc.failureDomainName,
+				err,
+			),
+			Field: fdc.field,
+		})
+		return result
+	}
+	if len(peClusters) != 1 {
+		result.Allowed = false
+		result.Causes = append(result.Causes, preflight.Cause{
+			Message: fmt.Sprintf(
+				"Found %d Prism Element cluster(s) that match identifier %q. There must be exactly 1 Cluster that matches this identifier.", //nolint:lll // Message is long.
+				len(peClusters),
+				peIdentifier,
+			),
+			Field: fdc.field,
+		})
+		return result
+	}
+	peUUID := *peClusters[0].ExtId
+
+	// Validate spec.subnets configuration
+	for _, id := range fdObj.Spec.Subnets {
+		subnets, err := getSubnets(fdc.nclient, &id)
+		if err != nil {
+			result.Allowed = false
+			result.InternalError = true
+			result.Causes = append(result.Causes, preflight.Cause{
+				Message: fmt.Sprintf(
+					"Failed to get subnet %q referenced by the Failure Domain %q: %v This is usually a temporary error. Please retry.", //nolint:lll // Message is long.
+					id,
+					fdc.failureDomainName,
+					err,
+				),
+				Field: fdc.field,
+			})
+			continue
+		}
+
+		// Filter the subnets, the valid ones should either have clusterReference match peUUID
+		// or clusterReference being nil (for overlay subnets)
+		filteredSubnets := []netv4.Subnet{}
+		for i := range subnets {
+			if subnets[i].ClusterReference == nil || *subnets[i].ClusterReference == peUUID {
+				filteredSubnets = append(filteredSubnets, subnets[i])
+			}
+		}
+
+		if len(filteredSubnets) != 1 {
+			result.Allowed = false
+			result.Causes = append(result.Causes, preflight.Cause{
+				Message: fmt.Sprintf(
+					"Found %d Subnets that match identifier %q. There must be exactly 1 Subnet that matches this identifier.", //nolint:lll // Message is long.,
+					len(filteredSubnets),
+					id,
+				),
+				Field: fdc.field,
+			})
+			continue
+		}
+	}
+
+	return result
+}
+
+// getSubnets returns the subnets found in PC with the input identifier.
+func getSubnets(client client, subnetId *capxv1.NutanixResourceIdentifier) ([]netv4.Subnet, error) {
+	switch {
+	case subnetId.IsUUID():
+		resp, err := client.GetSubnetById(subnetId.UUID)
+		if err != nil {
+			return nil, err
+		}
+		if resp == nil {
+			// No subnet returned.
+			return []netv4.Subnet{}, nil
+		}
+		subnet, ok := resp.GetData().(netv4.Subnet)
+		if !ok {
+			return nil, fmt.Errorf("failed to get data returned by GetSubnetById")
+		}
+		return []netv4.Subnet{subnet}, nil
+	case subnetId.IsName():
+		filter_ := fmt.Sprintf("name eq '%s'", *subnetId.Name)
+		resp, err := client.ListSubnets(nil, nil, &filter_, nil, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		if resp == nil || resp.GetData() == nil {
+			// No subnets returned.
+			return []netv4.Subnet{}, nil
+		}
+		subnets, ok := resp.GetData().([]netv4.Subnet)
+		if !ok {
+			return nil, fmt.Errorf("failed to get data returned by ListSubnets")
+		}
+		return subnets, nil
+	default:
+		return nil, fmt.Errorf("subnet identifier is missing both name and uuid, identifier type: %s", subnetId.Type)
+	}
+}

--- a/pkg/webhook/preflight/nutanix/failuredomain_test.go
+++ b/pkg/webhook/preflight/nutanix/failuredomain_test.go
@@ -1,0 +1,356 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nutanix
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	clustermgmtv4 "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	netv4 "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	capxv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+	carenv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+)
+
+func TestInitFailureDomainChecks(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		nutanixClusterConfigSpec *carenv1.NutanixClusterConfigSpec
+		machineDeployments       []clusterv1.MachineDeploymentTopology
+		nclient                  client
+		kclient                  ctrlclient.Client
+		expectedChecksCount      int
+	}{
+		{
+			name:                     "client not initialized",
+			nutanixClusterConfigSpec: nil,
+			machineDeployments:       nil,
+			nclient:                  nil,
+			kclient:                  nil,
+			expectedChecksCount:      0,
+		},
+		{
+			name:                     "nil cluster config",
+			nutanixClusterConfigSpec: nil,
+			machineDeployments:       nil,
+			nclient:                  &mocknclient{},
+			kclient:                  getK8sClient(),
+			expectedChecksCount:      0,
+		},
+		{
+			name: "cluster config without controlPlane failureDomains",
+			nutanixClusterConfigSpec: &carenv1.NutanixClusterConfigSpec{
+				ControlPlane: &carenv1.NutanixControlPlaneSpec{
+					Nutanix: &carenv1.NutanixControlPlaneNodeSpec{},
+				},
+			},
+			machineDeployments:  []clusterv1.MachineDeploymentTopology{},
+			nclient:             &mocknclient{},
+			kclient:             getK8sClient(),
+			expectedChecksCount: 0,
+		},
+		{
+			name: "cluster config with controlPlane failureDomains",
+			nutanixClusterConfigSpec: &carenv1.NutanixClusterConfigSpec{
+				ControlPlane: &carenv1.NutanixControlPlaneSpec{
+					Nutanix: &carenv1.NutanixControlPlaneNodeSpec{
+						FailureDomains: []string{"fd-1", "fd-2", "fd-3"},
+					},
+				},
+			},
+			machineDeployments:  []clusterv1.MachineDeploymentTopology{},
+			nclient:             &mocknclient{},
+			kclient:             getK8sClient(),
+			expectedChecksCount: 3,
+		},
+		{
+			name:                     "worker machines with failureDomains",
+			nutanixClusterConfigSpec: nil,
+			machineDeployments: []clusterv1.MachineDeploymentTopology{{
+				Class:         "default-worker",
+				Name:          "md-1",
+				FailureDomain: ptr.To("fd-w1"),
+			}},
+			nclient:             &mocknclient{},
+			kclient:             getK8sClient(),
+			expectedChecksCount: 1,
+		},
+		{
+			name: "cluster config with controlPlane failureDomains and worker machines with failureDomains",
+			nutanixClusterConfigSpec: &carenv1.NutanixClusterConfigSpec{
+				ControlPlane: &carenv1.NutanixControlPlaneSpec{
+					Nutanix: &carenv1.NutanixControlPlaneNodeSpec{
+						FailureDomains: []string{"fd-1", "fd-2", "fd-3"},
+					},
+				},
+			},
+			machineDeployments: []clusterv1.MachineDeploymentTopology{{
+				Class:         "default-worker",
+				Name:          "md-1",
+				FailureDomain: ptr.To("fd-w1"),
+			}},
+			nclient:             &mocknclient{},
+			kclient:             getK8sClient(),
+			expectedChecksCount: 4,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cd := &checkDependencies{
+				nutanixClusterConfigSpec: tc.nutanixClusterConfigSpec,
+				cluster: &clusterv1.Cluster{
+					Spec: clusterv1.ClusterSpec{
+						Topology: &clusterv1.Topology{
+							Workers: &clusterv1.WorkersTopology{
+								MachineDeployments: tc.machineDeployments,
+							},
+						},
+					},
+				},
+				nclient: tc.nclient,
+				kclient: tc.kclient,
+			}
+
+			// Call the function under test
+			checks := newFailureDomainChecks(cd)
+
+			// Verify number of checks
+			assert.Len(t, checks, tc.expectedChecksCount, "Wrong number of checks created")
+		})
+	}
+}
+
+const (
+	failureDomainName = "fd-1"
+	namespace         = "default"
+	field             = "test.field.path"
+	peClusterName     = "pe-1"
+	peClusterUUID     = "pe-1-cluster-uuid"
+	subnetName        = "pe-1-subnet1"
+	subnetUUID        = "pe-1-subnet1-uuid"
+)
+
+func TestFailureDomainCheck(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		fdName                string
+		kclient               ctrlclient.Client
+		nclient               client
+		expectedAllowed       bool
+		expectedInternalError bool
+		expectedCauseMessage  string
+		field                 string
+	}{
+		{
+			name:                  "failureDomain object not found",
+			fdName:                failureDomainName,
+			kclient:               fake.NewFakeClient(),
+			nclient:               &mocknclient{},
+			expectedAllowed:       false,
+			expectedInternalError: true,
+			expectedCauseMessage:  "Failed to get NutanixFailureDomain",
+			field:                 field,
+		},
+		{
+			name:    "failureDomain check failed at PE cluster validation",
+			fdName:  failureDomainName,
+			kclient: getK8sClient(),
+			nclient: &mocknclient{
+				getClusterByIdFunc: func(id *string) (*clustermgmtv4.GetClusterApiResponse, error) {
+					return nil, nil
+				},
+				listClustersFunc: func(
+					page,
+					limit *int,
+					filter,
+					orderby,
+					apply,
+					select_ *string,
+					args ...map[string]interface{},
+				) (
+					*clustermgmtv4.ListClustersApiResponse,
+					error,
+				) {
+					return nil, fmt.Errorf("failed to list the prism element clusters")
+				},
+			},
+			expectedAllowed:       false,
+			expectedInternalError: true,
+			expectedCauseMessage:  "failed to list the prism element clusters",
+			field:                 field,
+		},
+		{
+			name:    "failureDomain check failed at subnets validation",
+			fdName:  failureDomainName,
+			kclient: getK8sClient(),
+			nclient: &mocknclient{
+				listClustersFunc: func(
+					page,
+					limit *int,
+					filter,
+					orderby,
+					apply,
+					select_ *string,
+					args ...map[string]interface{},
+				) (
+					*clustermgmtv4.ListClustersApiResponse,
+					error,
+				) {
+					resp := &clustermgmtv4.ListClustersApiResponse{
+						ObjectType_: ptr.To("clustermgmt.v4.config.ListClustersApiResponse"),
+					}
+					err := resp.SetData([]clustermgmtv4.Cluster{
+						{
+							Name:  ptr.To(peClusterName),
+							ExtId: ptr.To(peClusterUUID),
+						},
+					})
+					require.NoError(t, err)
+					return resp, nil
+				},
+				GetSubnetByIdFunc: func(id *string) (*netv4.GetSubnetApiResponse, error) {
+					return nil, nil
+				},
+				ListSubnetsFunc: func(
+					page_ *int,
+					limit_ *int,
+					filter_ *string,
+					orderby_ *string,
+					expand_ *string,
+					select_ *string,
+					args ...map[string]interface{},
+				) (*netv4.ListSubnetsApiResponse, error) {
+					return nil, fmt.Errorf("failed to list subnets")
+				},
+			},
+			expectedAllowed:       false,
+			expectedInternalError: true,
+			expectedCauseMessage:  "failed to list subnets",
+			field:                 field,
+		},
+		{
+			name:    "failureDomain check success",
+			fdName:  failureDomainName,
+			kclient: getK8sClient(),
+			nclient: &mocknclient{
+				listClustersFunc: func(
+					page,
+					limit *int,
+					filter,
+					orderby,
+					apply,
+					select_ *string,
+					args ...map[string]interface{},
+				) (
+					*clustermgmtv4.ListClustersApiResponse,
+					error,
+				) {
+					resp := &clustermgmtv4.ListClustersApiResponse{
+						ObjectType_: ptr.To("clustermgmt.v4.config.ListClustersApiResponse"),
+					}
+					err := resp.SetData([]clustermgmtv4.Cluster{
+						{
+							Name:  ptr.To(peClusterName),
+							ExtId: ptr.To(peClusterUUID),
+						},
+					})
+					require.NoError(t, err)
+					return resp, nil
+				},
+				GetSubnetByIdFunc: func(id *string) (*netv4.GetSubnetApiResponse, error) {
+					return nil, nil
+				},
+				ListSubnetsFunc: func(
+					page_ *int,
+					limit_ *int,
+					filter_ *string,
+					orderby_ *string,
+					expand_ *string,
+					select_ *string,
+					args ...map[string]interface{},
+				) (*netv4.ListSubnetsApiResponse, error) {
+					resp := &netv4.ListSubnetsApiResponse{
+						ObjectType_: ptr.To("networking.v4.config.ListSubnetsApiResponse"),
+					}
+					err := resp.SetData([]netv4.Subnet{
+						{
+							Name:  ptr.To(subnetName),
+							ExtId: ptr.To(subnetUUID),
+						},
+					})
+					require.NoError(t, err)
+					return resp, nil
+				},
+			},
+			expectedAllowed:       true,
+			expectedInternalError: false,
+			expectedCauseMessage:  "",
+			field:                 field,
+		},
+	}
+
+	ctx := context.TODO()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create the check function
+			check := failureDomainCheck{
+				failureDomainName: failureDomainName,
+				namespace:         namespace,
+				kclient:           tc.kclient,
+				nclient:           tc.nclient,
+				field:             field,
+			}
+
+			// Run the check
+			result := check.Run(ctx)
+
+			// Verify the result
+			assert.Equal(t, tc.expectedAllowed, result.Allowed)
+			assert.Equal(t, tc.expectedInternalError, result.InternalError)
+
+			if tc.expectedCauseMessage != "" {
+				require.NotEmpty(t, result.Causes)
+				assert.Contains(t, result.Causes[0].Message, tc.expectedCauseMessage)
+				assert.Equal(t, tc.field, result.Causes[0].Field)
+			} else {
+				assert.Empty(t, result.Causes)
+			}
+		})
+	}
+}
+
+func getK8sClient() ctrlclient.Client {
+	fdObj := &capxv1.NutanixFailureDomain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      failureDomainName,
+			Namespace: namespace,
+		},
+		Spec: capxv1.NutanixFailureDomainSpec{
+			PrismElementCluster: capxv1.NutanixResourceIdentifier{
+				Type: capxv1.NutanixIdentifierName,
+				Name: ptr.To(string(peClusterName)),
+			},
+			Subnets: []capxv1.NutanixResourceIdentifier{{
+				Type: capxv1.NutanixIdentifierName,
+				Name: ptr.To(subnetName),
+			}},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(capxv1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(fdObj).Build()
+}


### PR DESCRIPTION
https://jira.nutanix.com/browse/NCN-108173:
Validate the configured failure domain(s) exist and valid

Added preflight check validation for the Nutanix failureDomains configured using Cluster.spec.topology. 
Make sure the referenced NutanixFailureDomains objects in the Cluster.spec.topology exist and their spec configuration is valid.

Added unit tests and did the integration test. 