### PR TITLE
feat: Reserve time to return preflight results before webhook timeout

### DIFF
--- a/pkg/webhook/preflight/doc.go
+++ b/pkg/webhook/preflight/doc.go
@@ -3,3 +3,5 @@
 package preflight
 
 // +kubebuilder:webhook:path=/preflight-v1beta1-cluster,mutating=false,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create,versions=*,name=preflight.cluster.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None,timeoutSeconds=30
+
+// IMPORTANT Keep timeoutSeconds in sync with the `Timeout` constant defined in this package.


### PR DESCRIPTION
**What problem does this PR solve?**:
Assuming that preflight checks return within 2 seconds of context cancellation, the preflight checks webhook will return before the API server webhook timeout.

Some preflight checks already meet this criteria. I'm updating others to meet it in https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/1234
 
**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
