### PR TITLE
fix(deps): udpate CAPX to v1.7.0-beta.5

### DIFF
--- a/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1/nutanix_types.go
+++ b/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1/nutanix_types.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package v1beta1
 
+import "fmt"
+
 // NutanixIdentifierType is an enumeration of different resource identifier types.
 type NutanixIdentifierType string
 
@@ -84,12 +86,47 @@ func (nri NutanixResourceIdentifier) String() string {
 	return ""
 }
 
+// DisplayString returns a human-readable string representation of the NutanixResourceIdentifier
+// that includes both the type and value, suitable for error messages and logging.
+func (nri NutanixResourceIdentifier) DisplayString() string {
+	switch nri.Type {
+	case NutanixIdentifierUUID:
+		if nri.UUID != nil {
+			return fmt.Sprintf("uuid=%q", *nri.UUID)
+		}
+	case NutanixIdentifierName:
+		if nri.Name != nil {
+			return fmt.Sprintf("name=%q", *nri.Name)
+		}
+	}
+	return "unknown"
+}
+
 func (nri NutanixResourceIdentifier) IsUUID() bool {
 	return nri.Type == NutanixIdentifierUUID && nri.UUID != nil
 }
 
 func (nri NutanixResourceIdentifier) IsName() bool {
 	return nri.Type == NutanixIdentifierName && nri.Name != nil
+}
+
+// EqualTo checks if two NutanixResourceIdentifiers are equal based on their type and value.
+func (nri NutanixResourceIdentifier) EqualTo(other *NutanixResourceIdentifier) bool {
+	if other == nil {
+		return false
+	}
+	if nri.Type != other.Type {
+		return false
+	}
+
+	switch nri.Type {
+	case NutanixIdentifierName:
+		return nri.Name != nil && other.Name != nil && *nri.Name == *other.Name
+	case NutanixIdentifierUUID:
+		return nri.UUID != nil && other.UUID != nil && *nri.UUID == *other.UUID
+	}
+
+	return false
 }
 
 type NutanixCategoryIdentifier struct {

--- a/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1/nutanixfailuredomain_types.go
+++ b/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1/nutanixfailuredomain_types.go
@@ -56,6 +56,7 @@ type NutanixFailureDomainStatus struct {
 // +kubebuilder:resource:path=nutanixfailuredomains,shortName=nfd,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:metadata:labels=clusterctl.cluster.x-k8s.io/move=
 
 // NutanixFailureDomain is the Schema for the NutanixFailureDomain API.
 type NutanixFailureDomain struct {

--- a/hack/third-party/capx/go.mod
+++ b/hack/third-party/capx/go.mod
@@ -7,7 +7,7 @@ go 1.24.0
 
 toolchain go1.24.3
 
-require github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0-beta.4
+require github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0-beta.5
 
 require (
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect

--- a/hack/third-party/capx/go.sum
+++ b/hack/third-party/capx/go.sum
@@ -76,8 +76,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0-beta.4 h1:SNfZlG/AJ/RUpEij0Lu1XbrIoOxk+tZvzQktFdPkGYc=
-github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0-beta.4/go.mod h1:6AJwae8W/nGmITlnuTnvMxCxxztctEAUJulxC9z/jgU=
+github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0-beta.5 h1:P3GCQbY5zynEgQLEn8KwG8ZicXSoX2z8ShFUnwkgE1s=
+github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0-beta.5/go.mod h1:6AJwae8W/nGmITlnuTnvMxCxxztctEAUJulxC9z/jgU=
 github.com/nutanix-cloud-native/prism-go-client v0.5.0 h1:aSNuKDOK7+q676MQyetYXcySY41IjSvN2UmrDIU3+6s=
 github.com/nutanix-cloud-native/prism-go-client v0.5.0/go.mod h1:QhLX+sEep0cStzHVYU6mPgIlnA8U3DySskagrbDprRk=
 github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus=


### PR DESCRIPTION
includes fixes for reconciling failure domain status on nutanixmachine after clusterctl move.
