### PR TITLE
fix: Correct control plane field in NutanixVMImage preflight check

### DIFF
--- a/pkg/webhook/preflight/nutanix/image.go
+++ b/pkg/webhook/preflight/nutanix/image.go
@@ -90,7 +90,7 @@ func newVMImageChecks(
 		checks = append(checks,
 			&imageCheck{
 				machineDetails: &cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.MachineDetails,
-				field:          "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.controlPlane.machineDetails", ///nolint:lll // Field is long.
+				field:          "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.controlPlane.nutanix.machineDetails", ///nolint:lll // Field is long.
 				nclient:        cd.nclient,
 			},
 		)

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
@@ -149,7 +149,7 @@ func newVMImageKubernetesVersionChecks(
 		checks = append(checks,
 			&imageKubernetesVersionCheck{
 				machineDetails:    &cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.MachineDetails,
-				field:             "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.controlPlane.machineDetails", ///nolint:lll // Field is long.
+				field:             "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.controlPlane.nutanix.machineDetails", ///nolint:lll // Field is long.
 				nclient:           cd.nclient,
 				clusterK8sVersion: clusterK8sVersion,
 			},


### PR DESCRIPTION
**What problem does this PR solve?**:
Fixes a transposed path in the NutanixVMImage control plane field.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
