### PR TITLE
fix: Correct placementGroup variable name in API

### DIFF
--- a/api/v1alpha1/aws_node_types.go
+++ b/api/v1alpha1/aws_node_types.go
@@ -41,7 +41,7 @@ type AWSGenericNodeSpec struct {
 
 	// PlacementGroup specifies the placement group in which to launch the instance.
 	// +kubebuilder:validation:Optional
-	PlacementGroup *PlacementGroup `json:"placementGroupName,omitempty"`
+	PlacementGroup *PlacementGroup `json:"placementGroup,omitempty"`
 }
 
 type AdditionalSecurityGroup []SecurityGroup

--- a/api/v1alpha1/crds/caren.nutanix.com_awsclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_awsclusterconfigs.yaml
@@ -390,7 +390,7 @@ spec:
                         instanceType:
                           default: m5.xlarge
                           type: string
-                        placementGroupName:
+                        placementGroup:
                           description: PlacementGroup specifies the placement group in which to launch the instance.
                           properties:
                             name:

--- a/api/v1alpha1/crds/caren.nutanix.com_awsworkernodeconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_awsworkernodeconfigs.yaml
@@ -89,7 +89,7 @@ spec:
                     default: m5.2xlarge
                     description: The AWS instance type to use for the cluster Machines.
                     type: string
-                  placementGroupName:
+                  placementGroup:
                     description: PlacementGroup specifies the placement group in which
                       to launch the instance.
                     properties:


### PR DESCRIPTION
This was a typo from the PR which introduced `placementGroup`.
