### PR TITLE
fix: hardcode the kubectl tag in registry syncer Pods

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/registry-syncer/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/registry-syncer/values-template.yaml
@@ -3,7 +3,7 @@ initContainers:
   # In the case when it runs as a Job, it will prematurely exit.
   # This init container will wait for the destination registry to be ready.
   - name: wait-for-registry
-    image: ghcr.io/d2iq-labs/kubectl-betterwait:{{ .KubernetesVersion }}
+    image: ghcr.io/d2iq-labs/kubectl-betterwait:v1.33.3
     args:
       - --for=condition=Ready
       - --timeout=-1s # a negative number here means wait forever
@@ -17,7 +17,7 @@ initContainers:
         name: kubeconfig
         readOnly: true
   - name: port-forward-registry
-    image: ghcr.io/d2iq-labs/kubectl-betterwait:{{ .KubernetesVersion }}
+    image: ghcr.io/d2iq-labs/kubectl-betterwait:v1.33.3
     command:
       - /bin/kubectl
     args:

--- a/pkg/handlers/generic/lifecycle/registry/syncer/syncer.go
+++ b/pkg/handlers/generic/lifecycle/registry/syncer/syncer.go
@@ -211,8 +211,6 @@ func templateValues(cluster *clusterv1.Cluster, text string) (string, error) {
 	type input struct {
 		CusterName string
 
-		KubernetesVersion string
-
 		SourceRegistryAddress string
 
 		DestinationRegistryAnyPodName               string
@@ -224,8 +222,7 @@ func templateValues(cluster *clusterv1.Cluster, text string) (string, error) {
 	}
 
 	templateInput := input{
-		CusterName:        cluster.Name,
-		KubernetesVersion: cluster.Spec.Topology.Version,
+		CusterName: cluster.Name,
 		// FIXME: This assumes that the source and destination registry names are the same.
 		// This is true now with a single registry addon provider, but may not be true in the future.
 		SourceRegistryAddress:                       registryMetadata.AddressFromClusterNetwork,

--- a/pkg/handlers/generic/lifecycle/registry/syncer/testdata/registry-syncer-template.yaml.tmpl
+++ b/pkg/handlers/generic/lifecycle/registry/syncer/testdata/registry-syncer-template.yaml.tmpl
@@ -3,7 +3,7 @@ initContainers:
   # In the case when it runs as a Job, it will prematurely exit.
   # This init container will wait for the destination registry to be ready.
   - name: wait-for-registry
-    image: ghcr.io/d2iq-labs/kubectl-betterwait:{{ .KubernetesVersion }}
+    image: ghcr.io/d2iq-labs/kubectl-betterwait:v1.30.100
     args:
       - --for=condition=Ready
       - --timeout=-1s # a negative number here means wait forever
@@ -17,7 +17,7 @@ initContainers:
         name: kubeconfig
         readOnly: true
   - name: port-forward-registry
-    image: ghcr.io/d2iq-labs/kubectl-betterwait:{{ .KubernetesVersion }}
+    image: ghcr.io/d2iq-labs/kubectl-betterwait:v1.30.100
     command:
       - /bin/kubectl
     args:


### PR DESCRIPTION
**What problem does this PR solve?**:
Supersedes https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/1261 

Hardcode a version of the kubectl images so that its not dependent on the Cluster version which can be a pre-release or have additional build metadata.

We will periodically update this version.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
