### PR TITLE
build: update Go toolchain to 1.26.2 to fix CVEs

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/ap
 
 go 1.25.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 replace github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common => ../common
 

--- a/common/go.mod
+++ b/common/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/co
 
 go 1.24.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	github.com/evanphx/json-patch/v5 v5.9.11

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -5,6 +5,6 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/do
 
 go 1.20
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require github.com/google/docsy v0.14.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix
 
 go 1.25.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 replace (
 	github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api => ./api

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/ha
 
 go 1.24.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
## Summary

- Updates Go toolchain directive from `go1.26.1` to `go1.26.2` in all project-owned modules (excluding `hack/third-party/*`)
- Fixes 7 stdlib CVEs discovered via `govulncheck`

### Fixed CVEs

| ID | Package | Description |
|----|---------|-------------|
| GO-2026-4947 | crypto/x509 | Unexpected work during chain building |
| GO-2026-4946 | crypto/x509 | Inefficient policy validation |
| GO-2026-4870 | crypto/tls | Unauthenticated TLS 1.3 KeyUpdate DoS |
| GO-2026-4869 | archive/tar | Unbounded allocation for old GNU sparse |
| GO-2026-4866 | crypto/x509 | Case-sensitive excludedSubtrees auth bypass |
| GO-2026-4865 | html/template | JsBraceDepth context tracking XSS |
| GO-2026-4864 | internal/syscall/unix | TOCTOU root escape via Root.Chmod (Linux) |

## Test plan

- [x] All pre-commit hooks pass
- [x] CI passes