### PR TITLE
fix: properly handle v1beta1 types in webhooks

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/webhooks.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/webhooks.yaml
@@ -14,14 +14,14 @@ webhooks:
       service:
         name: '{{ include "chart.name" . }}-admission'
         namespace: '{{ .Release.Namespace }}'
-        path: /mutate-v1beta1-addons
+        path: /mutate-v1beta2-addons
     failurePolicy: Fail
     name: addons-defaulter.caren.nutanix.com
     rules:
       - apiGroups:
           - cluster.x-k8s.io
         apiVersions:
-          - '*'
+          - v1beta2
         operations:
           - CREATE
         resources:
@@ -36,14 +36,14 @@ webhooks:
       service:
         name: '{{ include "chart.name" . }}-admission'
         namespace: '{{ .Release.Namespace }}'
-        path: /mutate-v1beta1-cluster
+        path: /mutate-v1beta2-cluster
     failurePolicy: Fail
     name: cluster-defaulter.caren.nutanix.com
     rules:
       - apiGroups:
           - cluster.x-k8s.io
         apiVersions:
-          - '*'
+          - v1beta2
         operations:
           - CREATE
           - UPDATE
@@ -67,14 +67,14 @@ webhooks:
       service:
         name: '{{ include "chart.name" . }}-admission'
         namespace: '{{ .Release.Namespace }}'
-        path: /validate-v1beta1-cluster
+        path: /validate-v1beta2-cluster
     failurePolicy: Fail
     name: cluster-validator.caren.nutanix.com
     rules:
       - apiGroups:
           - cluster.x-k8s.io
         apiVersions:
-          - '*'
+          - v1beta2
         operations:
           - CREATE
           - UPDATE
@@ -90,14 +90,14 @@ webhooks:
       service:
         name: '{{ include "chart.name" . }}-admission'
         namespace: '{{ .Release.Namespace }}'
-        path: /preflight-v1beta1-cluster
+        path: /preflight-v1beta2-cluster
     failurePolicy: Fail
     name: preflight.cluster.caren.nutanix.com
     rules:
       - apiGroups:
           - cluster.x-k8s.io
         apiVersions:
-          - '*'
+          - v1beta2
         operations:
           - CREATE
           - UPDATE

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/webhooks.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/webhooks.yaml
@@ -30,6 +30,7 @@ webhooks:
     matchConditions:
       - name: has-topology
         expression: has(object.spec.topology)
+    matchPolicy: Equivalent
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -53,6 +54,7 @@ webhooks:
     matchConditions:
       - name: has-topology
         expression: has(object.spec.topology)
+    matchPolicy: Equivalent
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -84,6 +86,7 @@ webhooks:
     matchConditions:
       - name: has-topology
         expression: has(object.spec.topology)
+    matchPolicy: Equivalent
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -108,3 +111,4 @@ webhooks:
     matchConditions:
       - name: has-topology
         expression: has(object.spec.topology)
+    matchPolicy: Equivalent

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/webhooks.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/webhooks.yaml
@@ -14,7 +14,7 @@ webhooks:
       service:
         name: '{{ include "chart.name" . }}-admission'
         namespace: '{{ .Release.Namespace }}'
-        path: /mutate-v1beta2-addons
+        path: /mutate-addons
     failurePolicy: Fail
     name: addons-defaulter.caren.nutanix.com
     rules:
@@ -36,7 +36,7 @@ webhooks:
       service:
         name: '{{ include "chart.name" . }}-admission'
         namespace: '{{ .Release.Namespace }}'
-        path: /mutate-v1beta2-cluster
+        path: /mutate-cluster
     failurePolicy: Fail
     name: cluster-defaulter.caren.nutanix.com
     rules:
@@ -67,7 +67,7 @@ webhooks:
       service:
         name: '{{ include "chart.name" . }}-admission'
         namespace: '{{ .Release.Namespace }}'
-        path: /validate-v1beta2-cluster
+        path: /validate-cluster
     failurePolicy: Fail
     name: cluster-validator.caren.nutanix.com
     rules:
@@ -90,7 +90,7 @@ webhooks:
       service:
         name: '{{ include "chart.name" . }}-admission'
         namespace: '{{ .Release.Namespace }}'
-        path: /preflight-v1beta2-cluster
+        path: /preflight-cluster
     failurePolicy: Fail
     name: preflight.cluster.caren.nutanix.com
     rules:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -288,18 +288,18 @@ func main() {
 		}
 	}
 
-	mgr.GetWebhookServer().Register("/mutate-v1beta1-cluster", &webhook.Admission{
+	mgr.GetWebhookServer().Register("/mutate-v1beta2-cluster", &webhook.Admission{
 		Handler: cluster.NewDefaulter(mgr.GetClient(), admission.NewDecoder(mgr.GetScheme())),
 	})
-	mgr.GetWebhookServer().Register("/validate-v1beta1-cluster", &webhook.Admission{
+	mgr.GetWebhookServer().Register("/validate-v1beta2-cluster", &webhook.Admission{
 		Handler: cluster.NewValidator(mgr.GetClient(), admission.NewDecoder(mgr.GetScheme())),
 	})
 
-	mgr.GetWebhookServer().Register("/mutate-v1beta1-addons", &webhook.Admission{
+	mgr.GetWebhookServer().Register("/mutate-v1beta2-addons", &webhook.Admission{
 		Handler: addons.NewDefaulter(mgr.GetClient(), admission.NewDecoder(mgr.GetScheme())),
 	})
 
-	mgr.GetWebhookServer().Register("/preflight-v1beta1-cluster", &webhook.Admission{
+	mgr.GetWebhookServer().Register("/preflight-v1beta2-cluster", &webhook.Admission{
 		Handler: preflight.New(mgr.GetClient(), admission.NewDecoder(mgr.GetScheme()),
 			[]preflight.Checker{
 				// Add your preflight checkers here.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -288,18 +288,18 @@ func main() {
 		}
 	}
 
-	mgr.GetWebhookServer().Register("/mutate-v1beta2-cluster", &webhook.Admission{
+	mgr.GetWebhookServer().Register("/mutate-cluster", &webhook.Admission{
 		Handler: cluster.NewDefaulter(mgr.GetClient(), admission.NewDecoder(mgr.GetScheme())),
 	})
-	mgr.GetWebhookServer().Register("/validate-v1beta2-cluster", &webhook.Admission{
+	mgr.GetWebhookServer().Register("/validate-cluster", &webhook.Admission{
 		Handler: cluster.NewValidator(mgr.GetClient(), admission.NewDecoder(mgr.GetScheme())),
 	})
 
-	mgr.GetWebhookServer().Register("/mutate-v1beta2-addons", &webhook.Admission{
+	mgr.GetWebhookServer().Register("/mutate-addons", &webhook.Admission{
 		Handler: addons.NewDefaulter(mgr.GetClient(), admission.NewDecoder(mgr.GetScheme())),
 	})
 
-	mgr.GetWebhookServer().Register("/preflight-v1beta2-cluster", &webhook.Admission{
+	mgr.GetWebhookServer().Register("/preflight-cluster", &webhook.Admission{
 		Handler: preflight.New(mgr.GetClient(), admission.NewDecoder(mgr.GetScheme()),
 			[]preflight.Checker{
 				// Add your preflight checkers here.

--- a/hack/update-webhook-configurations.yq
+++ b/hack/update-webhook-configurations.yq
@@ -18,5 +18,6 @@ with(.webhooks[];
       "name": "has-topology",
       "expression": "has(object.spec.topology)"
     }
-  ]
+  ],
+  .matchPolicy = "Equivalent"
 )

--- a/pkg/webhook/addons/doc.go
+++ b/pkg/webhook/addons/doc.go
@@ -1,5 +1,5 @@
 // Copyright 2025 Nutanix. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// +kubebuilder:webhook:path=/mutate-v1beta2-addons,mutating=true,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create,versions=v1beta2,name=addons-defaulter.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None
+// +kubebuilder:webhook:path=/mutate-addons,mutating=true,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create,versions=v1beta2,name=addons-defaulter.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None
 package addons

--- a/pkg/webhook/addons/doc.go
+++ b/pkg/webhook/addons/doc.go
@@ -1,5 +1,5 @@
 // Copyright 2025 Nutanix. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// +kubebuilder:webhook:path=/mutate-v1beta1-addons,mutating=true,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create,versions=*,name=addons-defaulter.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None
+// +kubebuilder:webhook:path=/mutate-v1beta2-addons,mutating=true,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create,versions=v1beta2,name=addons-defaulter.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None
 package addons

--- a/pkg/webhook/addons/registry/webhook_suite_test.go
+++ b/pkg/webhook/addons/registry/webhook_suite_test.go
@@ -33,7 +33,7 @@ func TestMain(m *testing.M) {
 				Name: "registry-defaulter.caren.nutanix.com",
 				ClientConfig: admissionv1.WebhookClientConfig{
 					Service: &admissionv1.ServiceReference{
-						Path: ptr.To("/mutate-v1beta1-registry-addon"),
+						Path: ptr.To("/mutate-v1beta2-registry-addon"),
 					},
 				},
 				Rules: []admissionv1.RuleWithOperations{{
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 					},
 					Rule: admissionv1.Rule{
 						APIGroups:   []string{"cluster.x-k8s.io"},
-						APIVersions: []string{"*"},
+						APIVersions: []string{"v1beta2"},
 						Resources:   []string{"clusters"},
 					},
 				}},
@@ -61,7 +61,7 @@ func TestMain(m *testing.M) {
 			},
 		},
 		SetupEnv: func(e *envtest.Environment) {
-			e.GetWebhookServer().Register("/mutate-v1beta1-registry-addon", &webhook.Admission{
+			e.GetWebhookServer().Register("/mutate-v1beta2-registry-addon", &webhook.Admission{
 				Handler: NewWorkloadClusterAutoEnabler(e.GetClient(), admission.NewDecoder(e.GetScheme())).Defaulter(),
 			})
 

--- a/pkg/webhook/cluster/doc.go
+++ b/pkg/webhook/cluster/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2024 Nutanix. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// +kubebuilder:webhook:path=/mutate-v1beta1-cluster,mutating=true,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create;update,versions=*,name=cluster-defaulter.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None
-// +kubebuilder:webhook:path=/validate-v1beta1-cluster,mutating=false,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create;update,versions=*,name=cluster-validator.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None
+// +kubebuilder:webhook:path=/mutate-v1beta2-cluster,mutating=true,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create;update,versions=v1beta2,name=cluster-defaulter.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None
+// +kubebuilder:webhook:path=/validate-v1beta2-cluster,mutating=false,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create;update,versions=v1beta2,name=cluster-validator.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None
 package cluster

--- a/pkg/webhook/cluster/doc.go
+++ b/pkg/webhook/cluster/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2024 Nutanix. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// +kubebuilder:webhook:path=/mutate-v1beta2-cluster,mutating=true,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create;update,versions=v1beta2,name=cluster-defaulter.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None
-// +kubebuilder:webhook:path=/validate-v1beta2-cluster,mutating=false,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create;update,versions=v1beta2,name=cluster-validator.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None
+// +kubebuilder:webhook:path=/mutate-cluster,mutating=true,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create;update,versions=v1beta2,name=cluster-defaulter.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None
+// +kubebuilder:webhook:path=/validate-cluster,mutating=false,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create;update,versions=v1beta2,name=cluster-validator.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None
 package cluster

--- a/pkg/webhook/cluster/webhook_suite_test.go
+++ b/pkg/webhook/cluster/webhook_suite_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 				Name: "cluster-defaulter.caren.nutanix.com",
 				ClientConfig: admissionv1.WebhookClientConfig{
 					Service: &admissionv1.ServiceReference{
-						Path: ptr.To("/mutate-v1beta2-cluster"),
+						Path: ptr.To("/mutate-cluster"),
 					},
 				},
 				Rules: []admissionv1.RuleWithOperations{{
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 				Name: "cluster-validator.caren.nutanix.com",
 				ClientConfig: admissionv1.WebhookClientConfig{
 					Service: &admissionv1.ServiceReference{
-						Path: ptr.To("/validate-v1beta2-cluster"),
+						Path: ptr.To("/validate-cluster"),
 					},
 				},
 				Rules: []admissionv1.RuleWithOperations{{
@@ -130,10 +130,10 @@ func TestMain(m *testing.M) {
 			},
 		},
 		SetupEnv: func(e *envtest.Environment) {
-			e.GetWebhookServer().Register("/mutate-v1beta2-cluster", &webhook.Admission{
+			e.GetWebhookServer().Register("/mutate-cluster", &webhook.Admission{
 				Handler: NewDefaulter(e.GetClient(), admission.NewDecoder(e.GetScheme())),
 			})
-			e.GetWebhookServer().Register("/validate-v1beta2-cluster", &webhook.Admission{
+			e.GetWebhookServer().Register("/validate-cluster", &webhook.Admission{
 				Handler: NewValidator(e.GetClient(), admission.NewDecoder(e.GetScheme())),
 			})
 

--- a/pkg/webhook/cluster/webhook_suite_test.go
+++ b/pkg/webhook/cluster/webhook_suite_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 				Name: "cluster-defaulter.caren.nutanix.com",
 				ClientConfig: admissionv1.WebhookClientConfig{
 					Service: &admissionv1.ServiceReference{
-						Path: ptr.To("/mutate-v1beta1-cluster"),
+						Path: ptr.To("/mutate-v1beta2-cluster"),
 					},
 				},
 				Rules: []admissionv1.RuleWithOperations{{
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 					},
 					Rule: admissionv1.Rule{
 						APIGroups:   []string{"cluster.x-k8s.io"},
-						APIVersions: []string{"*"},
+						APIVersions: []string{"v1beta2"},
 						Resources:   []string{"clusters"},
 					},
 				}},
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 				Name: "cluster-validator.caren.nutanix.com",
 				ClientConfig: admissionv1.WebhookClientConfig{
 					Service: &admissionv1.ServiceReference{
-						Path: ptr.To("/validate-v1beta1-cluster"),
+						Path: ptr.To("/validate-v1beta2-cluster"),
 					},
 				},
 				Rules: []admissionv1.RuleWithOperations{{
@@ -76,7 +76,7 @@ func TestMain(m *testing.M) {
 					},
 					Rule: admissionv1.Rule{
 						APIGroups:   []string{"cluster.x-k8s.io"},
-						APIVersions: []string{"*"},
+						APIVersions: []string{"v1beta2"},
 						Resources:   []string{"clusters"},
 					},
 				}},
@@ -130,10 +130,10 @@ func TestMain(m *testing.M) {
 			},
 		},
 		SetupEnv: func(e *envtest.Environment) {
-			e.GetWebhookServer().Register("/mutate-v1beta1-cluster", &webhook.Admission{
+			e.GetWebhookServer().Register("/mutate-v1beta2-cluster", &webhook.Admission{
 				Handler: NewDefaulter(e.GetClient(), admission.NewDecoder(e.GetScheme())),
 			})
-			e.GetWebhookServer().Register("/validate-v1beta1-cluster", &webhook.Admission{
+			e.GetWebhookServer().Register("/validate-v1beta2-cluster", &webhook.Admission{
 				Handler: NewValidator(e.GetClient(), admission.NewDecoder(e.GetScheme())),
 			})
 

--- a/pkg/webhook/preflight/doc.go
+++ b/pkg/webhook/preflight/doc.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package preflight
 
-// +kubebuilder:webhook:path=/preflight-v1beta1-cluster,mutating=false,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create;update,versions=*,name=preflight.cluster.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None,timeoutSeconds=30
+// +kubebuilder:webhook:path=/preflight-v1beta2-cluster,mutating=false,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create;update,versions=v1beta2,name=preflight.cluster.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None,timeoutSeconds=30
 
 // NOTE The webhook is not configured to handle the status subresource. This means that update
 // operations on the status subresource will not trigger the webhook.

--- a/pkg/webhook/preflight/doc.go
+++ b/pkg/webhook/preflight/doc.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package preflight
 
-// +kubebuilder:webhook:path=/preflight-v1beta2-cluster,mutating=false,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create;update,versions=v1beta2,name=preflight.cluster.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None,timeoutSeconds=30
+// +kubebuilder:webhook:path=/preflight-cluster,mutating=false,failurePolicy=fail,groups="cluster.x-k8s.io",resources=clusters,verbs=create;update,versions=v1beta2,name=preflight.cluster.caren.nutanix.com,admissionReviewVersions=v1,sideEffects=None,timeoutSeconds=30
 
 // NOTE The webhook is not configured to handle the status subresource. This means that update
 // operations on the status subresource will not trigger the webhook.


### PR DESCRIPTION
**What problem does this PR solve?**:
By setting apiVersions: v1beta2 in the WebhookConfiguration, the API server will do the conversion before sending the request.

See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy

Doing this while v1beta1 in a transitional period and is not yet removed.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
Tested by creating a v1beta1 cluster and no longer seeing

```
Warning: cluster.x-k8s.io/v1beta1 Cluster is deprecated; use cluster.x-k8s.io/v1beta2 Cluster
Error from server: error when creating "/Users/dimitri.koshkin/Downloads/input-v1b1.json": admission webhook "addons-defaulter.caren.nutanix.com" denied the request: no kind "Cluster" is registered for version "cluster.x-k8s.io/v1beta1" in scheme "pkg/runtime/scheme.go:110"

Warning: cluster.x-k8s.io/v1beta1 Cluster is deprecated; use cluster.x-k8s.io/v1beta2 Cluster
Error from server: error when creating "/Users/dimitri.koshkin/Downloads/input-v1b1.json": admission webhook "addons-defaulter.caren.nutanix.com" denied the request: unable to decode cluster.x-k8s.io/v1beta1, Kind=Cluster into *v1beta2.Cluster
```

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
