### PR TITLE
fix(caren): Change helm repo URL from nutanix-scratch to mesosphere repo

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/konnector-agent/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/konnector-agent/values-template.yaml
@@ -4,6 +4,7 @@ agent:
     privateRegistry: false
     repository: quay.io/karbon
     name: k8s-agent
+    tag: "1.4.0-rc.1"
 pc:
   port: {{ .PrismCentralPort }}
   insecure: {{ .PrismCentralInsecure }}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
@@ -37,7 +37,7 @@ data:
     RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://mesosphere.github.io/charts/stable/{{ end }}'
   konnector-agent: |
     ChartName: konnector-agent
-    ChartVersion: 1.4.0-rc.1
+    ChartVersion: 1.4.0
     RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://mesosphere.github.io/charts/stable/{{ end }}'
   local-path-provisioner-csi: |
     ChartName: local-path-provisioner

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
@@ -38,7 +38,7 @@ data:
   konnector-agent: |
     ChartName: konnector-agent
     ChartVersion: 1.4.0-rc.1
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://nutanix-scratch.github.io/helm/{{ end }}'
+    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://mesosphere.github.io/charts/stable/{{ end }}'
   local-path-provisioner-csi: |
     ChartName: local-path-provisioner
     ChartVersion: 0.0.36

--- a/hack/addons/helm-chart-bundler/repos.yaml
+++ b/hack/addons/helm-chart-bundler/repos.yaml
@@ -42,7 +42,7 @@ repositories:
       docker-registry:
       - 2.3.5
   konnector-agent:
-    repoURL: https://mesosphere.github.io/charts/stable
+    repoURL: https://mesosphere.github.io/charts/stable/
     charts:
       konnector-agent:
       - 1.4.0-rc.1

--- a/hack/addons/helm-chart-bundler/repos.yaml
+++ b/hack/addons/helm-chart-bundler/repos.yaml
@@ -45,7 +45,7 @@ repositories:
     repoURL: https://mesosphere.github.io/charts/stable/
     charts:
       konnector-agent:
-      - 1.4.0-rc.1
+      - 1.4.0
   local-path-provisioner:
     repoURL: https://charts.containeroo.ch
     charts:

--- a/hack/addons/helm-chart-bundler/repos.yaml
+++ b/hack/addons/helm-chart-bundler/repos.yaml
@@ -42,7 +42,7 @@ repositories:
       docker-registry:
       - 2.3.5
   konnector-agent:
-    repoURL: https://nutanix-scratch.github.io/helm/
+    repoURL: https://mesosphere.github.io/charts/stable
     charts:
       konnector-agent:
       - 1.4.0-rc.1

--- a/hack/addons/kustomize/konnector-agent/kustomization.yaml.tmpl
+++ b/hack/addons/kustomize/konnector-agent/kustomization.yaml.tmpl
@@ -10,7 +10,7 @@ metadata:
 helmCharts:
 - name: konnector-agent
   namespace: ntnx-system
-  repo: https://nutanix-scratch.github.io/helm/
+  repo: https://mesosphere.github.io/charts/stable/
   releaseName: konnector-agent
   version: ${KONNECTOR_AGENT_VERSION}
   includeCRDs: true

--- a/make/addons.mk
+++ b/make/addons.mk
@@ -143,7 +143,7 @@ export COSI_CONTROLLER_VERSION := 0.2.2
 #   App version:   v1.3.0
 #   Repo:          https://github.com/nutanix-core/k8s-agent
 #   Release:       https://github.com/nutanix-core/k8s-agent/releases/tag/1.3.0
-export KONNECTOR_AGENT_VERSION := 1.4.0-rc.1
+export KONNECTOR_AGENT_VERSION := 1.4.0
 
 # Multus
 #   Chart name: multus


### PR DESCRIPTION
**What problem does this PR solve?**:
Changing helm repo URL from nutanix-scratch to mesosphere repo.

**Which issue(s) this PR fixes**:
CAREN is an open source project and should not be released with references to scratch repo.

mesosphere chart PR: https://github.com/mesosphere/charts/pull/1650

**How Has This Been Tested?**:
- Created a cluster name `test-caren-2` with these changes.
- Verified that the `konnector-agent` pod is healthy and is in running state
```
kubectl get pods -n ntnx-system | grep konnector
konnector-agent-c799b77c5-nmg9p          1/1     Running   0          11m
```
- Logs [Connection with PC is getting established]
```
kubectl get pods -n ntnx-system | grep konnector
konnector-agent-c799b77c5-nmg9p          1/1     Running   0          11m
(devbox) priyadarshini.kumari@MW6XWF9XYV cluster-api-runtime-extensions-nutanix % kubectl logs konnector-agent-c799b77c5-nmg9p -n ntnx-system
Defaulted container "konnector-agent" out of: konnector-agent, onboarding-container (init)
2026/04/13 11:35:29 [/k8s-agent/k8s-agent --pc-endpoint=10.22.167.76 --pc-port=9440 --insecure=true --k8s-cluster-name=test-caren-2 --k8s-distribution=NKP --k8s-cluster-category= --update-config-in-min=5 --update-metrics-in-min=360 --kubeconfig-upload-enabled=false]
Using kubeconfig: 
2026/04/13 11:35:29 Additional trust bundle not provided. Error: open /ca-certificate/ca.crt: no such file or directory
2026/04/13 11:35:29 Connection with PC established.
```

<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
