### PR TITLE
build: [NCN-113496] Upgrade CAAPH to v0.6.2, remove fork

### DIFF
--- a/clusterctl.yaml
+++ b/clusterctl.yaml
@@ -5,5 +5,5 @@ providers:
     url: "https://github.com/nutanix-cloud-native/cluster-api-provider-aws/releases/${CAPA_VERSION}/infrastructure-components.yaml"
     type: "InfrastructureProvider"
   - name: "helm"
-    url: "https://github.com/mesosphere/cluster-api-addon-provider-helm/releases/${CAAPH_VERSION}/addon-components.yaml"
+    url: "https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/${CAAPH_VERSION}/addon-components.yaml"
     type: "AddonProvider"

--- a/hack/third-party/caaph/go.mod
+++ b/hack/third-party/caaph/go.mod
@@ -7,9 +7,7 @@ go 1.24.0
 
 toolchain go1.26.1
 
-require sigs.k8s.io/cluster-api-addon-provider-helm v0.6.1
-
-replace sigs.k8s.io/cluster-api-addon-provider-helm => github.com/mesosphere/cluster-api-addon-provider-helm v0.6.1-d2iq.2
+require sigs.k8s.io/cluster-api-addon-provider-helm v0.6.2
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/hack/third-party/caaph/go.sum
+++ b/hack/third-party/caaph/go.sum
@@ -67,8 +67,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mesosphere/cluster-api-addon-provider-helm v0.6.1-d2iq.2 h1:+2jbKb2jB5B4SeQEqyw/jyITXkmVPXkruW+ZVpJgpDU=
-github.com/mesosphere/cluster-api-addon-provider-helm v0.6.1-d2iq.2/go.mod h1:Ncjql2BzXEThldHIahJuRCbnardv+/ECjt8r5emt/e0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -196,6 +194,8 @@ k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8
 k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/cluster-api v1.12.4 h1:usvoZ+Nblfu//l31hm1B1WUdigb6OnGAJqwt8qWq/iA=
 sigs.k8s.io/cluster-api v1.12.4/go.mod h1:ePDeVCVaW6SGxRgDeLt5+KK4TigEnF0LPV6ztEzRzlI=
+sigs.k8s.io/cluster-api-addon-provider-helm v0.6.2 h1:EUgfvrVMWtQXULhfJZv3R8VtEBrx26vA5RlSK8z/P4s=
+sigs.k8s.io/cluster-api-addon-provider-helm v0.6.2/go.mod h1:V9gvy1o0bg+8u2RyIf6G4DVnG1AcFl2LXWCtcCab8zg=
 sigs.k8s.io/controller-runtime v0.22.5 h1:v3nfSUMowX/2WMp27J9slwGFyAt7IV0YwBxAkrUr0GE=
 sigs.k8s.io/controller-runtime v0.22.5/go.mod h1:pc5SoYWnWI6I+cBHYYdZ7B6YHZVY5xNfll88JB+vniI=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=

--- a/make/clusterctl.mk
+++ b/make/clusterctl.mk
@@ -5,7 +5,7 @@ export CAPI_VERSION := $(shell GOWORK=off go list -m -f '{{ .Version }}' sigs.k8
 export CAPD_VERSION := $(shell GOWORK=off go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api/test)
 export CAPA_VERSION := $(shell cd hack/third-party/capa && GOWORK=off go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api-provider-aws/v2)-ncn.1
 export CAPX_VERSION := $(shell cd hack/third-party/capx && GOWORK=off go list -m -f '{{ .Version }}' github.com/nutanix-cloud-native/cluster-api-provider-nutanix)
-export CAAPH_VERSION := $(shell cd hack/third-party/caaph && GOWORK=off go list -m -f '{{ .Replace.Version }}' sigs.k8s.io/cluster-api-addon-provider-helm)
+export CAAPH_VERSION := $(shell cd hack/third-party/caaph && GOWORK=off go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api-addon-provider-helm)
 
 # Leave Nutanix credentials empty here and set it when creating the clusters
 .PHONY: clusterctl.init

--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -128,7 +128,7 @@ providers:
   type: AddonProvider
   versions:
   - name: "${CAAPH_VERSION}"
-    value: "https://github.com/mesosphere/cluster-api-addon-provider-helm/releases/download/${CAAPH_VERSION}/addon-components.yaml"
+    value: "https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/${CAAPH_VERSION}/addon-components.yaml"
     type: "url"
     contract: v1beta1
     files:


### PR DESCRIPTION
## Summary
- Upgrade CAAPH from the mesosphere fork (`v0.6.1-d2iq.2`) to the upstream `sigs.k8s.io/cluster-api-addon-provider-helm` v0.6.2 release
- Remove the `replace` directive in `hack/third-party/caaph/go.mod` that pointed to the mesosphere fork
- Update all provider URLs (`clusterctl.yaml`, e2e config) from `github.com/mesosphere/...` to `github.com/kubernetes-sigs/...`
- Update `make/clusterctl.mk` to use `{{ .Version }}` instead of `{{ .Replace.Version }}` since there is no longer a replace directive

## Test plan
- [x] CI passes (pre-commit hooks, linting, go mod tidy all verified locally)
- [x] Verify CAAPH version resolves correctly: `cd hack/third-party/caaph && GOWORK=off go list -m sigs.k8s.io/cluster-api-addon-provider-helm` returns `v0.6.2`
- [x] Verify no references to mesosphere fork remain in the repo
- [ ] E2E tests pass with upstream CAAPH provider

Jira: [NCN-113496](https://jira.nutanix.com/browse/NCN-113496)