### PR TITLE
fix: [OSS-711] Replace busybox cp with uutils coreutils

### DIFF
--- a/hack/addons/helm-chart-bundler/Dockerfile
+++ b/hack/addons/helm-chart-bundler/Dockerfile
@@ -1,13 +1,20 @@
 ARG MINDTHEGAP_VERSION=v1.24.0
+ARG UUTILS_COREUTILS_VERSION=0.8.0
 
-FROM --platform=${BUILDPLATFORM} ghcr.io/mesosphere/mindthegap:${MINDTHEGAP_VERSION} as bundle_builder
+FROM --platform=${BUILDPLATFORM} ghcr.io/mesosphere/mindthegap:${MINDTHEGAP_VERSION} AS bundle_builder
 # This gets called by goreleaser so the copy source has to be the path relative to the repo root.
 RUN --mount=source=./hack/addons/helm-chart-bundler/repos.yaml,target=/repos.yaml \
     ["/ko-app/mindthegap", "create", "bundle", "--helm-charts-file=/repos.yaml", "--output-file=/tmp/helm-charts.tar"]
 
-FROM --platform=${TARGETPLATFORM} busybox:1.37.0-musl as static-busybox
+FROM --platform=${BUILDPLATFORM} alpine:3.21 AS uutils-downloader
+ARG TARGETARCH
+ARG UUTILS_COREUTILS_VERSION
+RUN ARCH=$(case "${TARGETARCH}" in amd64) echo x86_64;; arm64) echo aarch64;; *) echo "${TARGETARCH}";; esac) && \
+    wget -q -O - \
+      "https://github.com/uutils/coreutils/releases/download/${UUTILS_COREUTILS_VERSION}/coreutils-${UUTILS_COREUTILS_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" | \
+    tar xz -C /tmp --strip-components=1
 
-FROM --platform=${TARGETPLATFORM} scratch
+FROM scratch
 # Add helm charts for the current version
 ARG VERSION
 COPY --from=bundle_builder /tmp/helm-charts.tar /charts/helm-charts-${VERSION}.tar
@@ -15,5 +22,6 @@ COPY --from=bundle_builder /tmp/helm-charts.tar /charts/helm-charts-${VERSION}.t
 COPY --from=ghcr.io/nutanix-cloud-native/caren-helm-reg:v0.14.6 /tmp/helm-charts.tar /charts/helm-charts-v0.14.6.tar
 COPY --from=ghcr.io/nutanix-cloud-native/caren-helm-reg:v0.14.9 /tmp/helm-charts.tar /charts/helm-charts-v0.14.9.tar
 
-# Add statically compiled cp to the image used to copy bundles to the mounted PVC at runtime.
-COPY --from=static-busybox /bin/cp /bin/cp
+# Add statically compiled cp to copy bundles to the mounted PVC at runtime.
+# The uutils multicall binary dispatches based on argv[0], so naming it "cp" is sufficient.
+COPY --from=uutils-downloader /tmp/coreutils /bin/cp


### PR DESCRIPTION
**What problem does this PR solve?**:

The `helm-chart-bundle-initializer` container image ships a GPL-2.0-licensed
`cp` binary extracted from `busybox:1.37.0-musl`. This triggers Black Duck
license policy violations during CAREN release approval.

This PR replaces it with the MIT-licensed [uutils coreutils](https://github.com/uutils/coreutils)
v0.8.0 static musl binary. A new `uutils-downloader` build stage downloads the
prebuilt binary from GitHub releases for the target architecture. The multicall
binary is copied directly as `/bin/cp` (it dispatches based on `argv[0]`), so
the existing init container command works unchanged.

**Which issue(s) this PR fixes**:
Fixes OSS-711

**How Has This Been Tested?**:

- Verified the uutils coreutils prebuilt static musl tarball downloads and extracts
  correctly for x86_64 (confirmed: ELF 64-bit, static-pie linked, stripped, ~14 MB)
- Confirmed uutils `cp` supports all required flags: `--recursive`, `--no-target-directory`, `--verbose`
- No changes to Helm templates, goreleaser config, or init container command

**Special notes for your reviewer**:

- The only file changed is `hack/addons/helm-chart-bundler/Dockerfile`
- Image size increases from ~1.5 MB (busybox cp) to ~14 MB (uutils multicall binary).
  Acceptable since this is an init container that runs once at pod startup.
- Also fixed two pre-existing Dockerfile lint warnings: `as` -> `AS` casing and
  redundant `--platform=${TARGETPLATFORM}` on stages that default to target platform.