### PR TITLE
fix: Support Trust Bundle for Konnector Agent

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/konnector-agent/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/konnector-agent/values-template.yaml
@@ -9,6 +9,9 @@ pc:
   port: {{ .PrismCentralPort }}
   insecure: {{ .PrismCentralInsecure }}
   endpoint: {{ .PrismCentralHost }}
+{{- if .PrismCentralAdditionalTrustBundle }}
+  additionalTrustBundle: {{ .PrismCentralAdditionalTrustBundle }}
+{{- end }}
 
 k8sClusterName: {{ .ClusterName }}
 k8sDistribution: NKP
@@ -16,6 +19,11 @@ createSecret: false
 prismCredentialsSecretName: "{{ .PrismCredentialsSecretName }}"
 {{- if .CategoryMappings }}
 categoryMappings: {{ .CategoryMappings }}
+{{- end }}
+
+{{- if .CreateAdditionalTrustBundleConfigMap }}
+createAdditionalTrustBundleConfigMap: {{ .CreateAdditionalTrustBundleConfigMap }}
+additionalTrustBundleConfigMapName: "{{ .AdditionalTrustBundleConfigMapName }}"
 {{- end }}
 kubeconfigUpload:
   enabled: {{ .EnableKubeconfigUpload }}

--- a/hack/tools/fetch-images/main.go
+++ b/hack/tools/fetch-images/main.go
@@ -377,24 +377,30 @@ prismEndPoint: endpoint
 		}
 
 		templateInput := struct {
-			AgentName                  string
-			PrismCentralHost           string
-			PrismCentralPort           uint16
-			PrismCentralInsecure       bool
-			ClusterName                string
-			CategoryMappings           string
-			PrismCredentialsSecretName string
-			EnableKubeconfigUpload     bool
-			ControlPlaneEndpoint       string
+			AgentName                            string
+			PrismCentralHost                     string
+			PrismCentralPort                     uint16
+			PrismCentralInsecure                 bool
+			PrismCentralAdditionalTrustBundle    string
+			CreateAdditionalTrustBundleConfigMap bool
+			AdditionalTrustBundleConfigMapName   string
+			ClusterName                          string
+			CategoryMappings                     string
+			PrismCredentialsSecretName           string
+			EnableKubeconfigUpload               bool
+			ControlPlaneEndpoint                 string
 		}{
-			AgentName:                  "konnector-agent",
-			PrismCentralHost:           "prism-central.example.com",
-			PrismCentralPort:           9440,
-			PrismCentralInsecure:       true,
-			ClusterName:                "test-cluster",
-			CategoryMappings:           "",
-			PrismCredentialsSecretName: "konnector-agent",
-			EnableKubeconfigUpload:     false,
+			AgentName:                            "konnector-agent",
+			PrismCentralHost:                     "prism-central.example.com",
+			PrismCentralPort:                     9440,
+			PrismCentralInsecure:                 true,
+			PrismCentralAdditionalTrustBundle:    "",
+			CreateAdditionalTrustBundleConfigMap: false,
+			AdditionalTrustBundleConfigMapName:   "",
+			ClusterName:                          "test-cluster",
+			CategoryMappings:                     "",
+			PrismCredentialsSecretName:           "konnector-agent",
+			EnableKubeconfigUpload:               false,
 		}
 
 		err = template.Must(template.New(defaultHelmAddonFilename).ParseFiles(f)).Execute(tempFile, &templateInput)

--- a/pkg/handlers/lifecycle/konnectoragent/handler.go
+++ b/pkg/handlers/lifecycle/konnectoragent/handler.go
@@ -350,14 +350,24 @@ func templateValuesFunc(
 			controlPlaneEndpoint = fmt.Sprintf("https://%s:%d", cpHost, cpPort)
 		}
 
+		// Determine if we should use insecure connection to Prism Central.
+		// If insecure is false but no trust bundle is provided, fall back to insecure mode
+		// to maintain backward compatibility and avoid connection failures.
 		prismCentralInsecure := nutanixConfig.PrismCentralEndpoint.Insecure
+		hasTrustBundle := nutanixConfig.PrismCentralEndpoint.AdditionalTrustBundle != ""
+
+		if !prismCentralInsecure && !hasTrustBundle {
+			// Fallback: insecure=false but no trust bundle -> use insecure mode
+			prismCentralInsecure = true
+		}
 
 		// Handle additional trust bundle for Prism Central.
+		// Only configure trust bundle if insecure is false and trust bundle is provided.
 		var additionalTrustBundle string
 		createTrustBundleConfigMap := false
 		trustBundleConfigMapName := ""
 
-		if !prismCentralInsecure && nutanixConfig.PrismCentralEndpoint.AdditionalTrustBundle != "" {
+		if !prismCentralInsecure && hasTrustBundle {
 			additionalTrustBundle = nutanixConfig.PrismCentralEndpoint.AdditionalTrustBundle
 			createTrustBundleConfigMap = true
 			trustBundleConfigMapName = defaultTrustBundleConfigMapName

--- a/pkg/handlers/lifecycle/konnectoragent/handler.go
+++ b/pkg/handlers/lifecycle/konnectoragent/handler.go
@@ -43,10 +43,11 @@ import (
 )
 
 const (
-	defaultHelmReleaseName       = "konnector-agent"
-	defaultHelmReleaseNamespace  = "ntnx-system"
-	defaultK8sAgentName          = "konnector-agent"
-	defaultCredentialsSecretName = defaultK8sAgentName
+	defaultHelmReleaseName          = "konnector-agent"
+	defaultHelmReleaseNamespace     = "ntnx-system"
+	defaultK8sAgentName             = "konnector-agent"
+	defaultCredentialsSecretName    = defaultK8sAgentName
+	defaultTrustBundleConfigMapName = "ntnx-additional-trust-bundle-konnector-agent"
 
 	cleanupStatusCompleted  = "completed"
 	cleanupStatusInProgress = "in-progress"
@@ -306,15 +307,18 @@ func templateValuesFunc(
 		}
 
 		type input struct {
-			AgentName                  string
-			PrismCentralHost           string
-			PrismCentralPort           uint16
-			PrismCentralInsecure       bool
-			ClusterName                string
-			CategoryMappings           string
-			PrismCredentialsSecretName string
-			EnableKubeconfigUpload     bool
-			ControlPlaneEndpoint       string
+			AgentName                            string
+			PrismCentralHost                     string
+			PrismCentralPort                     uint16
+			PrismCentralInsecure                 bool
+			PrismCentralAdditionalTrustBundle    string
+			CreateAdditionalTrustBundleConfigMap bool
+			AdditionalTrustBundleConfigMapName   string
+			ClusterName                          string
+			CategoryMappings                     string
+			PrismCredentialsSecretName           string
+			EnableKubeconfigUpload               bool
+			ControlPlaneEndpoint                 string
 		}
 
 		address, port, err := nutanixConfig.PrismCentralEndpoint.ParseURL()
@@ -346,18 +350,32 @@ func templateValuesFunc(
 			controlPlaneEndpoint = fmt.Sprintf("https://%s:%d", cpHost, cpPort)
 		}
 
+		prismCentralInsecure := nutanixConfig.PrismCentralEndpoint.Insecure
+
+		// Handle additional trust bundle for Prism Central.
+		var additionalTrustBundle string
+		createTrustBundleConfigMap := false
+		trustBundleConfigMapName := ""
+
+		if !prismCentralInsecure && nutanixConfig.PrismCentralEndpoint.AdditionalTrustBundle != "" {
+			additionalTrustBundle = nutanixConfig.PrismCentralEndpoint.AdditionalTrustBundle
+			createTrustBundleConfigMap = true
+			trustBundleConfigMapName = defaultTrustBundleConfigMapName
+		}
+
 		templateInput := input{
-			AgentName:        defaultK8sAgentName,
-			PrismCentralHost: address,
-			PrismCentralPort: port,
-			// TODO: remove this once we have a way to set this.
-			// need to add support to accept PC's trust bundle in agent(it's not implemented currently)
-			PrismCentralInsecure:       true,
-			ClusterName:                clusterName,
-			CategoryMappings:           categoryMappings,
-			PrismCredentialsSecretName: defaultCredentialsSecretName,
-			EnableKubeconfigUpload:     enableKubeconfigUpload,
-			ControlPlaneEndpoint:       controlPlaneEndpoint,
+			AgentName:                            defaultK8sAgentName,
+			PrismCentralHost:                     address,
+			PrismCentralPort:                     port,
+			PrismCentralInsecure:                 prismCentralInsecure,
+			PrismCentralAdditionalTrustBundle:    additionalTrustBundle,
+			CreateAdditionalTrustBundleConfigMap: createTrustBundleConfigMap,
+			AdditionalTrustBundleConfigMapName:   trustBundleConfigMapName,
+			ClusterName:                          clusterName,
+			CategoryMappings:                     categoryMappings,
+			PrismCredentialsSecretName:           defaultCredentialsSecretName,
+			EnableKubeconfigUpload:               enableKubeconfigUpload,
+			ControlPlaneEndpoint:                 controlPlaneEndpoint,
 		}
 
 		var b bytes.Buffer

--- a/pkg/handlers/lifecycle/konnectoragent/variables_test.go
+++ b/pkg/handlers/lifecycle/konnectoragent/variables_test.go
@@ -1506,11 +1506,12 @@ additionalTrustBundleConfigMapName: "{{ .AdditionalTrustBundleConfigMapName }}"
 		)
 	})
 
-	t.Run("secure connection without trust bundle", func(t *testing.T) {
+	t.Run("secure connection without trust bundle falls back to insecure", func(t *testing.T) {
 		nutanixConfig := &v1alpha1.NutanixSpec{
 			PrismCentralEndpoint: v1alpha1.NutanixPrismCentralEndpointSpec{
 				URL:      "https://prism-central.example.com:9440",
 				Insecure: false,
+				// No trust bundle provided
 			},
 		}
 
@@ -1528,7 +1529,8 @@ additionalTrustBundleConfigMapName: "{{ .AdditionalTrustBundleConfigMapName }}"
 
 		result, err := templateFunc(cluster, valuesTemplate)
 		require.NoError(t, err)
-		assert.Contains(t, result, "insecure: false")
+		// Should fall back to insecure mode when no trust bundle is provided
+		assert.Contains(t, result, "insecure: true")
 		assert.NotContains(t, result, "additionalTrustBundle:")
 		assert.NotContains(t, result, "createAdditionalTrustBundleConfigMap:")
 	})

--- a/pkg/handlers/lifecycle/konnectoragent/variables_test.go
+++ b/pkg/handlers/lifecycle/konnectoragent/variables_test.go
@@ -5,6 +5,7 @@ package konnectoragent
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -1434,4 +1435,155 @@ func TestIsClusterRegisteredInPC_MissingPasswordInSecret(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, registered)
 	assert.Contains(t, err.Error(), "credentials secret does not contain 'password' key")
+}
+
+func TestTemplateValuesFunc_TrustBundleConfiguration(t *testing.T) {
+	cluster := &clusterv1beta2.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+	}
+
+	k8sAgentVar := apivariables.NutanixKonnectorAgent{}
+
+	testTrustBundle := "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURBRENDQWVpZ0F3SUJBZ0lKQUtL"
+
+	t.Run("insecure connection with no trust bundle", func(t *testing.T) {
+		nutanixConfig := &v1alpha1.NutanixSpec{
+			PrismCentralEndpoint: v1alpha1.NutanixPrismCentralEndpointSpec{
+				URL:      "https://prism-central.example.com:9440",
+				Insecure: true,
+			},
+		}
+
+		templateFunc := templateValuesFunc(nutanixConfig, cluster, k8sAgentVar)
+
+		valuesTemplate := `pc:
+  insecure: {{ .PrismCentralInsecure }}
+{{- if .PrismCentralAdditionalTrustBundle }}
+  additionalTrustBundle: {{ .PrismCentralAdditionalTrustBundle }}
+{{- end }}
+{{- if .CreateAdditionalTrustBundleConfigMap }}
+createAdditionalTrustBundleConfigMap: {{ .CreateAdditionalTrustBundleConfigMap }}
+additionalTrustBundleConfigMapName: "{{ .AdditionalTrustBundleConfigMapName }}"
+{{- end }}`
+
+		result, err := templateFunc(cluster, valuesTemplate)
+		require.NoError(t, err)
+		assert.Contains(t, result, "insecure: true")
+		assert.NotContains(t, result, "additionalTrustBundle:")
+		assert.NotContains(t, result, "createAdditionalTrustBundleConfigMap:")
+	})
+
+	t.Run("secure connection with trust bundle", func(t *testing.T) {
+		nutanixConfig := &v1alpha1.NutanixSpec{
+			PrismCentralEndpoint: v1alpha1.NutanixPrismCentralEndpointSpec{
+				URL:                   "https://prism-central.example.com:9440",
+				Insecure:              false,
+				AdditionalTrustBundle: testTrustBundle,
+			},
+		}
+
+		templateFunc := templateValuesFunc(nutanixConfig, cluster, k8sAgentVar)
+
+		valuesTemplate := `pc:
+  insecure: {{ .PrismCentralInsecure }}
+{{- if .PrismCentralAdditionalTrustBundle }}
+  additionalTrustBundle: {{ .PrismCentralAdditionalTrustBundle }}
+{{- end }}
+{{- if .CreateAdditionalTrustBundleConfigMap }}
+createAdditionalTrustBundleConfigMap: {{ .CreateAdditionalTrustBundleConfigMap }}
+additionalTrustBundleConfigMapName: "{{ .AdditionalTrustBundleConfigMapName }}"
+{{- end }}`
+
+		result, err := templateFunc(cluster, valuesTemplate)
+		require.NoError(t, err)
+		assert.Contains(t, result, "insecure: false")
+		assert.Contains(t, result, fmt.Sprintf("additionalTrustBundle: %s", testTrustBundle))
+		assert.Contains(t, result, "createAdditionalTrustBundleConfigMap: true")
+		assert.Contains(
+			t,
+			result,
+			"additionalTrustBundleConfigMapName: \"ntnx-additional-trust-bundle-konnector-agent\"",
+		)
+	})
+
+	t.Run("secure connection without trust bundle", func(t *testing.T) {
+		nutanixConfig := &v1alpha1.NutanixSpec{
+			PrismCentralEndpoint: v1alpha1.NutanixPrismCentralEndpointSpec{
+				URL:      "https://prism-central.example.com:9440",
+				Insecure: false,
+			},
+		}
+
+		templateFunc := templateValuesFunc(nutanixConfig, cluster, k8sAgentVar)
+
+		valuesTemplate := `pc:
+  insecure: {{ .PrismCentralInsecure }}
+{{- if .PrismCentralAdditionalTrustBundle }}
+  additionalTrustBundle: {{ .PrismCentralAdditionalTrustBundle }}
+{{- end }}
+{{- if .CreateAdditionalTrustBundleConfigMap }}
+createAdditionalTrustBundleConfigMap: {{ .CreateAdditionalTrustBundleConfigMap }}
+additionalTrustBundleConfigMapName: "{{ .AdditionalTrustBundleConfigMapName }}"
+{{- end }}`
+
+		result, err := templateFunc(cluster, valuesTemplate)
+		require.NoError(t, err)
+		assert.Contains(t, result, "insecure: false")
+		assert.NotContains(t, result, "additionalTrustBundle:")
+		assert.NotContains(t, result, "createAdditionalTrustBundleConfigMap:")
+	})
+
+	t.Run("insecure connection with trust bundle should not create configmap", func(t *testing.T) {
+		nutanixConfig := &v1alpha1.NutanixSpec{
+			PrismCentralEndpoint: v1alpha1.NutanixPrismCentralEndpointSpec{
+				URL:                   "https://prism-central.example.com:9440",
+				Insecure:              true,
+				AdditionalTrustBundle: testTrustBundle,
+			},
+		}
+
+		templateFunc := templateValuesFunc(nutanixConfig, cluster, k8sAgentVar)
+
+		valuesTemplate := `pc:
+  insecure: {{ .PrismCentralInsecure }}
+{{- if .PrismCentralAdditionalTrustBundle }}
+  additionalTrustBundle: {{ .PrismCentralAdditionalTrustBundle }}
+{{- end }}
+{{- if .CreateAdditionalTrustBundleConfigMap }}
+createAdditionalTrustBundleConfigMap: {{ .CreateAdditionalTrustBundleConfigMap }}
+additionalTrustBundleConfigMapName: "{{ .AdditionalTrustBundleConfigMapName }}"
+{{- end }}`
+
+		result, err := templateFunc(cluster, valuesTemplate)
+		require.NoError(t, err)
+		assert.Contains(t, result, "insecure: true")
+		// When insecure is true, trust bundle should be ignored
+		assert.NotContains(t, result, "additionalTrustBundle:")
+		assert.NotContains(t, result, "createAdditionalTrustBundleConfigMap:")
+	})
+
+	t.Run("trust bundle configmap uses default name", func(t *testing.T) {
+		nutanixConfig := &v1alpha1.NutanixSpec{
+			PrismCentralEndpoint: v1alpha1.NutanixPrismCentralEndpointSpec{
+				URL:                   "https://prism-central.example.com:9440",
+				Insecure:              false,
+				AdditionalTrustBundle: testTrustBundle,
+			},
+		}
+
+		templateFunc := templateValuesFunc(nutanixConfig, cluster, k8sAgentVar)
+
+		valuesTemplate := `{{- if .AdditionalTrustBundleConfigMapName }}
+additionalTrustBundleConfigMapName: "{{ .AdditionalTrustBundleConfigMapName }}"
+{{- end }}`
+
+		result, err := templateFunc(cluster, valuesTemplate)
+		require.NoError(t, err)
+		// The ConfigMap name should use the default constant
+		assert.Contains(
+			t,
+			result,
+			"additionalTrustBundleConfigMapName: \"ntnx-additional-trust-bundle-konnector-agent\"",
+		)
+	})
 }


### PR DESCRIPTION
**What problem does this PR solve?**:

This PR adds support for configuring TLS trust bundles for secure connections between the konnector agent and Prism Central. Previously, the insecure flag was hardcoded to true, forcing all connections to skip TLS verification. This change enables secure connections while maintaining backward compatibility.


Changes:
1. Handler Logic (pkg/handlers/lifecycle/konnectoragent/handler.go)
     Removed hardcoded insecure flag
2. Helm Values Template (values-template.yaml)
     Added conditional rendering for trust bundle configuration

Backward Compatibility

- Existing clusters with insecure: true continue to work unchanged
- Default behavior is secure (insecure: false) for new clusters
- No breaking API changes

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
1. new cluster 2.18 with trust bundle and insecure == false:
cluster config with trust bundle:
`

> nutanix:
>           controlPlaneEndpoint:
>             host: 10.23.129.9
>             port: 6443
>             virtualIP:
>               provider: KubeVIP
>           prismCentralEndpoint:
>             additionalTrustBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUU5RENDQTl5Z0F3SUJBZ0lTQnEzREcvMEU1OEZZUXpzYUNF...<removed remaining>
>             credentials:
>               secretRef:
>                 name: test-cluster-vijay-1604-pc-credentials
>             url: https://pc.dev.nkp.sh:9440
>     version: v1.35.2

`

hcp:

`

> spec:
>   chartName: konnector-agent
>   clusterSelector:
>     matchLabels:
>       cluster.x-k8s.io/cluster-name: test-cluster-vijay-1604
>   namespace: ntnx-system
>   options:
>     enableClientCache: false
>     install:
>       createNamespace: true
>     timeout: 10m0s
>     upgrade:
>       maxHistory: 10
>   releaseName: konnector-agent
>   repoURL: oci://helm-repository.default.svc/charts
>   tlsConfig:
>     caSecret:
>       name: helm-repository-tls
>       namespace: default
>   valuesTemplate: |-
>     agent:
>       name: konnector-agent
>       image:
>         privateRegistry: false
>         repository: quay.io/karbon
>         name: k8s-agent
>         tag: "1.4.0-rc.1"
>     pc:
>       port: 9440
>       insecure: false
>       endpoint: pc.dev.nkp.sh
>       additionalTrustBundle:<trustbundlevalue>
> 
>     k8sClusterName: test-cluster-vijay-1604
>     k8sDistribution: NKP
>     createSecret: false
>     prismCredentialsSecretName: "konnector-agent"
>     createAdditionalTrustBundleConfigMap: true
>     additionalTrustBundleConfigMapName: "ntnx-additional-trust-bundle-konnector-agent"
>     kubeconfigUpload:
>       enabled: true
>       controlPlaneEndpoint: "https://10.23.129.9:6443"
>   version: 1.4.0

`
pod description:
`

> Init Containers:
>   onboarding-container:
>     Container ID:    containerd://6112a109fec435ec84cecc649dd84961ef1504d150506d66b3d5b4aada732964
>     Image:           quay.io/karbon/k8s-agent:1.4.0-rc.1
>     Image ID:        quay.io/karbon/k8s-agent@sha256:2c538a288249f00b0ad9f301bda9aad11c87101e635ab497f2bedce59d7a6608
>     Port:            <none>
>     Host Port:       <none>
>     SeccompProfile:  RuntimeDefault
>     Command:
>       /k8s-agent/k8s-agent
>     Args:
>       --chart-hook=pre-install
>       --pc-endpoint=pc.dev.nkp.sh
>       --pc-port=9440
>       --insecure=false
>       --k8s-cluster-name=test-cluster-vijay-1604
>       --k8s-distribution=NKP

> Mounts:
>       /ca-certificate from additional-trust-bundle-volume (ro)
>       /certs from pc-creds-volume (ro)
>       /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-cf4m4 (ro)

`
logs:
`

> (devbox) vijayaraghavan.r@CQGK42CXL4 cluster-api-runtime-extensions-nutanix % kubectl logs konnector-agent-6fd5694fc-5hccr -n ntnx-system --kubeconfig clusterkubeconfig.conf
> Defaulted container "konnector-agent" out of: konnector-agent, onboarding-container (init)
> 2026/04/17 04:09:41 [/k8s-agent/k8s-agent --pc-endpoint=pc.dev.nkp.sh --pc-port=9440 --insecure=false --k8s-cluster-name=test-cluster-vijay-1604 --k8s-distribution=NKP --k8s-cluster-category= --update-config-in-min=5 --update-metrics-in-min=360 --kubeconfig-upload-enabled=true --control-plane-endpoint=https://10.23.129.9:6443 --flow-rbac-configmap-name=ntnx-flow-rbac-rules --flow-rbac-configmap-namespace=flow-cni-system --flow-rbac-label-selector=ntnx.rbac.source=flow --flow-rbac-clusterrole-key=clusterrole.yaml --flow-kubeconfig-sa-name=ntnx-flow-kubeconfig-sa]
> Using kubeconfig:
> 2026/04/17 04:09:41 Prism additional trust bundle provided, setting insecure to false
> 2026/04/17 04:09:42 Connection with PC established.
> 2026/04/17 04:09:42 Starting Server

`
2. 218 new cluster - insecure=true, without trustbundle:

cluster config:
`

> nutanix:
>           controlPlaneEndpoint:
>             host: 10.23.129.9
>             port: 6443
>             virtualIP:
>               provider: KubeVIP
>           prismCentralEndpoint:
>             credentials:
>               secretRef:
>                 name: test-cluster-vijay-1604-pc-credentials
>             insecure: true
>             url: https://pc.dev.nkp.sh:9440

`

hcp:

 `spec:
>   chartName: konnector-agent
>   clusterSelector:
>     matchLabels:
>       cluster.x-k8s.io/cluster-name: test-cluster-vijay-1604
>   namespace: ntnx-system
>   options:
>     enableClientCache: false
>     install:
>       createNamespace: true
>     timeout: 10m0s
>     upgrade:
>       maxHistory: 10
>   releaseName: konnector-agent
>   repoURL: oci://helm-repository.default.svc/charts
>   tlsConfig:
>     caSecret:
>       name: helm-repository-tls
>       namespace: default
>   valuesTemplate: |-
>     agent:
>       name: konnector-agent
>       image:
>         privateRegistry: false
>         repository: quay.io/karbon
>         name: k8s-agent
>         tag: "1.4.0-rc.1"
>     pc:
>       port: 9440
>       insecure: true
>       endpoint: pc.dev.nkp.sh
> 
>     k8sClusterName: test-cluster-vijay-1604
>     k8sDistribution: NKP
>     createSecret: false
>     prismCredentialsSecretName: "konnector-agent"
>     kubeconfigUpload:
>       enabled: true
>       controlPlaneEndpoint: "https://10.23.129.9:6443"
>   version: 1.4.0

`
pod description(secret not mounted):
`

> Init Containers:
>   onboarding-container:
>     Container ID:    containerd://6fed6c7866f96f5fbb8b1ddcc7784fb5619565faababe671613406c94983939f
>     Image:           quay.io/karbon/k8s-agent:1.4.0-rc.1
>     Image ID:        quay.io/karbon/k8s-agent@sha256:2c538a288249f00b0ad9f301bda9aad11c87101e635ab497f2bedce59d7a6608
>     Port:            <none>
>     Host Port:       <none>
>     SeccompProfile:  RuntimeDefault
>     Command:
>       /k8s-agent/k8s-agent
>     Args:
>       --chart-hook=pre-install
>       --pc-endpoint=pc.dev.nkp.sh
>       --pc-port=9440
>       --insecure=true
>       --k8s-cluster-name=test-cluster-vijay-1604
>       --k8s-distribution=NKP
>       --k8s-cluster-category=
>       --update-config-in-min=5
>       --update-metrics-in-min=360
>     State:          Terminated
>       Reason:       Completed
>       Exit Code:    0
>       Started:      Fri, 17 Apr 2026 13:34:44 +0530
>       Finished:     Fri, 17 Apr 2026 13:34:46 +0530
>     Ready:          True
>     Restart Count:  0
>     Environment:
>       POD_NAMESPACE:  ntnx-system (v1:metadata.namespace)
>     Mounts:
>       /certs from pc-creds-volume (ro)
>       /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-d5vqc (ro)

`
logs:

`

> kubectl logs konnector-agent-57665fbcdc-p7pkp -n ntnx-system --kubeconfig clusterkubeconfig.conf -c onboarding-container
> 2026/04/17 08:04:44 [/k8s-agent/k8s-agent --chart-hook=pre-install --pc-endpoint=pc.dev.nkp.sh --pc-port=9440 --insecure=true --k8s-cluster-name=test-cluster-vijay-1604 --k8s-distribution=NKP --k8s-cluster-category= --update-config-in-min=5 --update-metrics-in-min=360]
> Using kubeconfig:
> 2026/04/17 08:04:44 Additional trust bundle not provided. Error: open /ca-certificate/ca.crt: no such file or directory
> 2026/04/17 08:04:45 Connection with PC established.
> 2026/04/17 08:04:45 No category values provided, adding default values
> 2026/04/17 08:04:45 Deployment "nutanix-csi-controller" not found in any namespace
> 2026/04/17 08:04:45 Found CSI deployment: "nutanix-csi-controller" in namespaces: []
> 2026/04/17 08:04:45 Final category mapping: map[KubernetesClusterName:test-cluster-vijay-1604 KubernetesClusterUUID:k8s-eff36135-8a1f-42dd-9427-973933df9642]
> 2026/04/17 08:04:46 Cluster not found in Prism Central (will proceed with registration): error: map[Cluster Get:Failed to determine the cluster status]

`

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
