### PR TITLE
ci: install Nix via devbox action on self-hosted runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,18 +39,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
-        if: inputs.runs-on != 'ubuntu-24.04'
-        with:
-          logger: pretty
-          extra-conf: experimental-features = ca-derivations fetch-closure
-
       - name: Install devbox
-        uses: jetify-com/devbox-install-action@v0.15.0
+        # Pin to main until a release includes the `installer-init-system` input
+        # (https://github.com/jetify-com/devbox-install-action/commit/1af623155b1203817421a7efe5574f59f4a055c6).
+        uses: jetify-com/devbox-install-action@1af623155b1203817421a7efe5574f59f4a055c6
         with:
           enable-cache: ${{ inputs.runs-on == 'ubuntu-24.04' }}
-          skip-nix-installation: ${{ inputs.runs-on != 'ubuntu-24.04' }}
+          installer-init-system: ${{ inputs.runs-on == 'ubuntu-24.04' && 'systemd' || 'none' }}
 
       - name: Export go version and mod cache path
         id: export-go-version-and-mod-cache-path


### PR DESCRIPTION
**What problem does this PR solve?**:

The e2e workflow currently installs Nix twice over: via
`DeterminateSystems/nix-installer-action` on self-hosted runners and via
`jetify-com/devbox-install-action` on GitHub-hosted runners. The DeterminateSystems
installer is no longer needed now that `devbox-install-action` supports configuring
the init system used by the experimental Nix installer (the self-hosted runners
don't have/want systemd).

This PR drops the separate `Install Nix` step and lets `devbox-install-action`
handle Nix on both runner types, using `installer-init-system: none` on
self-hosted runners and the default `systemd` on `ubuntu-24.04`.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:

- `actionlint` (the project's configured pre-commit hook) passes on the modified
  `e2e.yml` and across all workflows.
- Pre-commit check-yaml and gitlint pass.
- Runtime behaviour will be validated by the e2e workflow itself on this PR.

**Special notes for your reviewer**:

- The `devbox-install-action` version is pinned to commit
  [`1af62315`](https://github.com/jetify-com/devbox-install-action/commit/1af623155b1203817421a7efe5574f59f4a055c6)
  on `main` because no tagged release yet includes the new `installer-init-system`
  input. We should move back to a version tag once a release is cut.
- The rest of the repo pins third-party actions by version tag rather than SHA;
  the SHA here is a deliberate, temporary exception and is called out in a comment
  next to the `uses:` line.
- Self-hosted runners previously ran the DeterminateSystems installer; they will
  now run the experimental Nix installer via the devbox action instead. If the
  self-hosted runners already have Nix pre-installed, a follow-up could switch
  them to `skip-nix-installation: true` instead.