### PR TITLE
feat: Bump up konnector to 1.4.0-rc.2

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/konnector-agent/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/konnector-agent/values-template.yaml
@@ -4,7 +4,7 @@ agent:
     privateRegistry: false
     repository: quay.io/karbon
     name: k8s-agent
-    tag: "1.4.0-rc.1"
+    tag: "1.4.0-rc.2"
 pc:
   port: {{ .PrismCentralPort }}
   insecure: {{ .PrismCentralInsecure }}

--- a/make/addons.mk
+++ b/make/addons.mk
@@ -142,7 +142,7 @@ export COSI_CONTROLLER_VERSION := 0.2.2
 #   Chart version: 1.3.0
 #   App version:   v1.3.0
 #   Repo:          https://github.com/nutanix-core/k8s-agent
-#   Release:       https://github.com/nutanix-core/k8s-agent/releases/tag/1.3.0
+#   Release:       https://github.com/nutanix-core/k8s-agent/releases/tag/1.4.0
 export KONNECTOR_AGENT_VERSION := 1.4.0
 
 # Multus


### PR DESCRIPTION
**What problem does this PR solve?**:
- Bump up konnector agent to 1.4.0-rc.2

**How Has This Been Tested?**:

- Ran make dev.run-on-kind which generated cluster-api-runtime-extensions-nutanix-dev
- Deployed a cluster named `caren-2` in dry-run mode and applied the yaml.
- The pod is in healthy state:
```
kubectl get pods -n ntnx-system | grep konnector
konnector-agent-5c75f979db-nckq6         1/1     Running   0               10m
```
- logs:
```
kubectl logs konnector-agent-5c75f979db-nckq6 -n ntnx-system | grep KubeconfigReconciler
Defaulted container "konnector-agent" out of: konnector-agent, onboarding-container (init)
2026/04/17 10:52:40 [KubeconfigReconciler] Starting Flow ConfigMap controller (agentNamespace=ntnx-system, configMapNamespace=flow-cni-system, configMapName="ntnx-flow-rbac-rules", labelSelector="ntnx.rbac.source=flow")
2026/04/17 10:52:40 [KubeconfigReconciler] Flow ConfigMap flow-cni-system/ntnx-flow-rbac-rules not found; cleaning up managed resources
2026/04/17 10:52:41 [KubeconfigReconciler] [cluster=8133650e-253e-4f9a-a454-4eae4612eb8e] Kubeconfig already absent in PC; skipping delete
2026/04/17 10:52:41 [KubeconfigReconciler] No owned RBAC resources found for cleanup
```
No noisy logs when the flow configmap is not there.
- verified that the rc2 image is being pulled from quay.io
```
kubectl describe pod -n ntnx-system konnector-agent-5c75f979db-nckq6
Controlled By:  ReplicaSet/konnector-agent-5c75f979db
Init Containers:
  onboarding-container:
    Container ID:    containerd://f51531ce2ceba1bedc8ff7f406266818b7c6d601ad16f7ce3d2ec9cf1d9748b1
    Image:           quay.io/karbon/k8s-agent:1.4.0-rc.2
    Image ID:        quay.io/karbon/k8s-agent@sha256:ba889e2a28a3d3bc2e46d563826654997098d89e1b3d5d09a68152d096676b5b
    Port:            <none>
    Host Port:       <none>
    SeccompProfile:  RuntimeDefault
    Command:
      /k8s-agent/k8s-agent

Events:
  Type     Reason            Age    From               Message
  ----     ------            ----   ----               -------
  Warning  FailedScheduling  8m52s  default-scheduler  0/1 nodes are available: 1 node(s) had untolerated taint(s). no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.
  Normal   Scheduled         7m30s  default-scheduler  Successfully assigned ntnx-system/konnector-agent-5c75f979db-nckq6 to caren-2-md-0-b6xwn-gx5jb-ff2sw
  Normal   Pulling           7m27s  kubelet            Pulling image "quay.io/karbon/k8s-agent:1.4.0-rc.2"
  Normal   Pulled            7m     kubelet            Successfully pulled image "quay.io/karbon/k8s-agent:1.4.0-rc.2" in 297ms (27.61s including waiting). Image size: 20778312 bytes.
  Normal   Created           7m     kubelet            Created container: onboarding-container
  Normal   Started           6m59s  kubelet            Started container onboarding-container
  Normal   Pulled            6m58s  kubelet            Container image "quay.io/karbon/k8s-agent:1.4.0-rc.2" already present on machine
  Normal   Created           6m57s  kubelet            Created container: konnector-agent
  Normal   Started           6m57s  kubelet            Started container konnector-agent
```


<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
