### PR TITLE
fix: require Prism Central 7.5 in preflight

### DIFF
--- a/pkg/webhook/preflight/nutanix/prismcentralversion.go
+++ b/pkg/webhook/preflight/nutanix/prismcentralversion.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	prismCentralEndpointFieldPath    = "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.prismCentralEndpoint" ///nolint:lll // Field path is intentionally long.
-	minSupportedPrismCentralVersion  = "7.3"
+	minSupportedPrismCentralVersion  = "7.5"
 	internalPrismCentralVersionLabel = "master"
 )
 

--- a/pkg/webhook/preflight/nutanix/prismcentralversion_test.go
+++ b/pkg/webhook/preflight/nutanix/prismcentralversion_test.go
@@ -16,12 +16,6 @@ func TestPrismCentralVersionCheck_AllowsSupportedVersionsAndInternalBuilds(t *te
 	t.Parallel()
 
 	supportedVersions := []string{
-		"7.3",
-		"7.3.1",
-		"7.3.1.2",
-		"pc.7.3",
-		"pc.7.3.1",
-		"pc.7.3.1.2",
 		"7.5",
 		"7.5.3",
 		"7.5.3.4",
@@ -61,6 +55,10 @@ func TestPrismCentralVersionCheck_FailsUnsupportedVersions(t *testing.T) {
 		name    string
 		version string
 	}{
+		{
+			name:    "Older supported minor release",
+			version: "pc.7.3.1.2",
+		},
 		{
 			name:    "Older 7.x release",
 			version: "pc.7.2.0.0",

--- a/pkg/webhook/preflight/nutanix/prismcentralversion_test.go
+++ b/pkg/webhook/preflight/nutanix/prismcentralversion_test.go
@@ -22,6 +22,12 @@ func TestPrismCentralVersionCheck_AllowsSupportedVersionsAndInternalBuilds(t *te
 		"pc.7.5",
 		"pc.7.5.3",
 		"pc.7.5.3.4",
+		"7.6",
+		"7.6.1",
+		"7.6.1.2",
+		"pc.7.6",
+		"pc.7.6.1",
+		"pc.7.6.1.2",
 		"master",
 		"pc.master",
 	}


### PR DESCRIPTION
## Summary
- raise the CAREN Prism Central preflight minimum from 7.3 to 7.5
- update the Prism Central version tests so 7.3.x is rejected and 7.5.x remains allowed
- align the public preflight gate with support expectations based on API call usage

## Test plan
- [x] `go test ./pkg/webhook/preflight/nutanix/...`

Made with [Cursor](https://cursor.com)