### PR TITLE
fix: Update CoreDNS mapping file

### DIFF
--- a/api/versions/coredns.go
+++ b/api/versions/coredns.go
@@ -28,6 +28,7 @@ const (
 	Kubernetes_V1_33 = "v1.33"
 	Kubernetes_V1_34 = "v1.34"
 	Kubernetes_V1_35 = "v1.35"
+	Kubernetes_V1_36 = "v1.36"
 )
 
 // CoreDNS versions.
@@ -41,6 +42,7 @@ const (
 	CoreDNS_V1_12_0 = "v1.12.0"
 	CoreDNS_V1_12_1 = "v1.12.1"
 	CoreDNS_V1_13_1 = "v1.13.1"
+	CoreDNS_V1_14_2 = "v1.14.2"
 )
 
 // kubernetesToCoreDNSVersion maps Kubernetes versions to CoreDNS versions.
@@ -60,6 +62,7 @@ var kubernetesToCoreDNSVersion = map[string]string{
 	Kubernetes_V1_33: CoreDNS_V1_12_0,
 	Kubernetes_V1_34: CoreDNS_V1_12_1,
 	Kubernetes_V1_35: CoreDNS_V1_13_1,
+	Kubernetes_V1_36: CoreDNS_V1_14_2,
 }
 
 // GetCoreDNSVersion returns the CoreDNS version for a given Kubernetes version.

--- a/api/versions/coredns_test.go
+++ b/api/versions/coredns_test.go
@@ -33,24 +33,11 @@ func TestReturnsFalseForMalformedKubernetesVersion(t *testing.T) {
 	assert.Empty(t, version)
 }
 
-func TestReturnsCorrectMappingForGetKubernetesToCoreDNSVersionMap(t *testing.T) {
+func TestReturnsCopyForGetKubernetesToCoreDNSVersionMap(t *testing.T) {
 	mapping := GetKubernetesToCoreDNSVersionMap()
-	expected := map[string]string{
-		"v1.22": "v1.8.4",
-		"v1.23": "v1.8.6",
-		"v1.24": "v1.8.6",
-		"v1.25": "v1.9.3",
-		"v1.26": "v1.9.3",
-		"v1.27": "v1.10.1",
-		"v1.28": "v1.10.1",
-		"v1.29": "v1.11.1",
-		"v1.30": "v1.11.3",
-		"v1.31": "v1.11.3",
-		"v1.32": "v1.11.3",
-		"v1.33": "v1.12.0",
-		"v1.34": "v1.12.1",
-		"v1.35": "v1.13.1",
-		"v1.36": "v1.14.2",
-	}
-	assert.Equal(t, expected, mapping)
+	mapping["v1.27"] = "modified"
+
+	version, found := GetCoreDNSVersion("v1.27")
+	assert.True(t, found)
+	assert.Equal(t, "v1.10.1", version)
 }

--- a/api/versions/coredns_test.go
+++ b/api/versions/coredns_test.go
@@ -50,6 +50,7 @@ func TestReturnsCorrectMappingForGetKubernetesToCoreDNSVersionMap(t *testing.T) 
 		"v1.33": "v1.12.0",
 		"v1.34": "v1.12.1",
 		"v1.35": "v1.13.1",
+		"v1.36": "v1.14.2",
 	}
 	assert.Equal(t, expected, mapping)
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
The release of Kubernetes v1.36.0 a couple of days ago made the current mapping out of date. 

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
