### PR TITLE
fix: registry mirror configuration for containerd config version 3

### DIFF
--- a/pkg/handlers/generic/mutation/generic/mirrors/containerd_files_test.go
+++ b/pkg/handlers/generic/mutation/generic/mirrors/containerd_files_test.go
@@ -255,6 +255,8 @@ func Test_generateContainerdRegistryConfigDropInFile(t *testing.T) {
 			Permissions: "0600",
 			Content: `[plugins."io.containerd.grpc.v1.cri".registry]
   config_path = "/etc/containerd/certs.d"
+[plugins."io.containerd.cri.v1.images".registry]
+  config_path = "/etc/containerd/certs.d"
 `,
 		},
 	}

--- a/pkg/handlers/generic/mutation/generic/mirrors/templates/containerd-registry-config-drop-in.toml
+++ b/pkg/handlers/generic/mutation/generic/mirrors/templates/containerd-registry-config-drop-in.toml
@@ -1,2 +1,4 @@
 [plugins."io.containerd.grpc.v1.cri".registry]
   config_path = "/etc/containerd/certs.d"
+[plugins."io.containerd.cri.v1.images".registry]
+  config_path = "/etc/containerd/certs.d"


### PR DESCRIPTION
**What problem does this PR solve?**:
We recently moved to containerd 2.1.6. containred 2.1.6 support two configuration versions: `version:2` and `version: 3` 

So we decided to keep default and all the configuration with `version: 2`. This works in most of the usecases. However We have Nvidia GPU operator and possibly other application dynamically detecting contaienrd version and dropping containerd configuration for GPUs with `Version: 3` 

Containerd tries to merge default `version: 2` file (`/etc/containerd/config.toml`) and merge the drop-ins (ex. the nvidia gpu dropin) and create final configuration file with `version: 3`

However because of version compatibilities, containerd ends up dropping some original configuration (ex. registry mirror config). This causes gpu nodepools in airgap environments to not pull images from the mirrors.

We decided to move the default configuration to `version: 3`  ( https://github.com/mesosphere/dkp-image-builder/pull/743 and https://jira.nutanix.com/browse/NCN-113960 ) to cover all the usecases.

However this caused issue with current mirror configuration that is only compatible with `version: 2`. We also want to support previous kubernetes version (1.34.x) with containerd 1.7.28  
see details at: https://github.com/containerd/containerd/blob/main/docs/cri/registry.md 

So this PR will drop mirror configuration compatible with both version. Containerd will ignore incompatible version with warning and ingest correct compatible configuration. 

see the warning in containerd
```
WARN[0000] Ignoring unknown key in TOML for plugin       error="strict mode: fields in the document are missing in the target struct" key=registry plugin=io.containerd.grpc.v1.cri
```
We tested this configuration with both containerd 2.x and containerd 1.x and verified that containerd correctly drops incompatible configuration and pull images with correct configuration.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
