### PR TITLE
feat: Preflight check for control plane endpoint

### DIFF
--- a/pkg/webhook/preflight/nutanix/checker.go
+++ b/pkg/webhook/preflight/nutanix/checker.go
@@ -28,6 +28,7 @@ var Checker = &nutanixChecker{
 	vmImageKubernetesVersionChecksFactory: newVMImageKubernetesVersionChecks,
 	cidrValidationChecksFactory:           newCIDRValidationChecks,
 	storageContainerChecksFactory:         newStorageContainerChecks,
+	controlPlaneEndpointChecksFactory:     newControlPlaneEndpointChecks,
 	metroChecksFactory:                    newMetroChecks,
 }
 
@@ -68,6 +69,10 @@ type nutanixChecker struct {
 	) []preflight.Check
 
 	storageContainerChecksFactory func(
+		cd *checkDependencies,
+	) []preflight.Check
+
+	controlPlaneEndpointChecksFactory func(
 		cd *checkDependencies,
 	) []preflight.Check
 
@@ -123,6 +128,7 @@ func (n *nutanixChecker) Init(
 		n.vmImageKubernetesVersionChecksFactory(cd),
 		n.cidrValidationChecksFactory(cd),
 		n.storageContainerChecksFactory(cd),
+		n.controlPlaneEndpointChecksFactory(cd),
 		n.metroChecksFactory(cd),
 	)
 

--- a/pkg/webhook/preflight/nutanix/checker_test.go
+++ b/pkg/webhook/preflight/nutanix/checker_test.go
@@ -46,6 +46,7 @@ func TestNutanixChecker_Init(t *testing.T) {
 		cidrValidationCheckCount           int
 		storageContainerCheckCount         int
 		failureDomainCheckCount            int
+		controlPlaneEndpointCheckCount     int
 		metroCheckCount                    int
 	}{
 		{
@@ -61,16 +62,23 @@ func TestNutanixChecker_Init(t *testing.T) {
 			cidrValidationCheckCount:           0,
 			storageContainerCheckCount:         0,
 			failureDomainCheckCount:            0,
+			controlPlaneEndpointCheckCount:     0,
 		},
 		{
 			name: "initialization with control plane config",
 			nutanixConfig: &carenv1.NutanixClusterConfigSpec{
+				Nutanix: &carenv1.NutanixSpec{
+					ControlPlaneEndpoint: carenv1.ControlPlaneEndpointSpec{
+						Host: "192.168.1.1",
+						Port: 6443,
+					},
+				},
 				ControlPlane: &carenv1.NutanixControlPlaneSpec{
 					Nutanix: &carenv1.NutanixControlPlaneNodeSpec{},
 				},
 			},
 			workerNodeConfigs:                  nil,
-			expectedCheckCount:                 8, //nolint:lll // config check, credentials check, Prism Central version check, 1 VM image check, 1 VM image Kubernetes version check, 1 CIDR validation check, 1 storage container check, 1 failure domain check
+			expectedCheckCount:                 9, //nolint:lll // config check, credentials check, Prism Central version check, 1 VM image check, 1 VM image Kubernetes version check, 1 CIDR validation check, 1 storage container check, 1 failure domain check, 1 control plane endpoint check
 			expectedFirstCheckName:             "NutanixConfiguration",
 			expectedSecondCheckName:            "NutanixCredentials",
 			expectedThirdCheckName:             "NutanixPrismCentralVersion",
@@ -79,10 +87,18 @@ func TestNutanixChecker_Init(t *testing.T) {
 			cidrValidationCheckCount:           1,
 			storageContainerCheckCount:         1,
 			failureDomainCheckCount:            1,
+			controlPlaneEndpointCheckCount:     1,
 		},
 		{
-			name:          "initialization with worker node configs",
-			nutanixConfig: nil,
+			name: "initialization with worker node configs",
+			nutanixConfig: &carenv1.NutanixClusterConfigSpec{
+				Nutanix: &carenv1.NutanixSpec{
+					ControlPlaneEndpoint: carenv1.ControlPlaneEndpointSpec{
+						Host: "192.168.1.1",
+						Port: 6443,
+					},
+				},
+			},
 			workerNodeConfigs: map[string]*carenv1.NutanixWorkerNodeConfigSpec{
 				"worker-1": {
 					Nutanix: &carenv1.NutanixWorkerNodeSpec{},
@@ -91,7 +107,7 @@ func TestNutanixChecker_Init(t *testing.T) {
 					Nutanix: &carenv1.NutanixWorkerNodeSpec{},
 				},
 			},
-			expectedCheckCount:                 13, //nolint:lll // config check, credentials check, Prism Central version check, 2 VM image checks, 2 VM image Kubernetes version checks, 2 CIDR validation checks, 2 storage container checks, 2 failure domain checks
+			expectedCheckCount:                 14, //nolint:lll // config check, credentials check, Prism Central version check, 2 VM image checks, 2 VM image Kubernetes version checks, 2 CIDR validation checks, 2 storage container checks, 2 failure domain checks, 1 control plane endpoint check
 			expectedFirstCheckName:             "NutanixConfiguration",
 			expectedSecondCheckName:            "NutanixCredentials",
 			expectedThirdCheckName:             "NutanixPrismCentralVersion",
@@ -100,12 +116,16 @@ func TestNutanixChecker_Init(t *testing.T) {
 			cidrValidationCheckCount:           2,
 			storageContainerCheckCount:         2,
 			failureDomainCheckCount:            2,
+			controlPlaneEndpointCheckCount:     1,
 		},
 		{
 			name: "initialization with both control plane and worker node configs",
 			nutanixConfig: &carenv1.NutanixClusterConfigSpec{
-				ControlPlane: &carenv1.NutanixControlPlaneSpec{
-					Nutanix: &carenv1.NutanixControlPlaneNodeSpec{},
+				Nutanix: &carenv1.NutanixSpec{
+					ControlPlaneEndpoint: carenv1.ControlPlaneEndpointSpec{
+						Host: "192.168.1.1",
+						Port: 6443,
+					},
 				},
 			},
 			workerNodeConfigs: map[string]*carenv1.NutanixWorkerNodeConfigSpec{
@@ -113,7 +133,7 @@ func TestNutanixChecker_Init(t *testing.T) {
 					Nutanix: &carenv1.NutanixWorkerNodeSpec{},
 				},
 			},
-			expectedCheckCount:                 13, //nolint:lll // config check, credentials check, Prism Central version check, 2 VM image checks (1 CP + 1 worker), 2 VM image Kubernetes version checks, 2 CIDR validation checks, 2 storage container checks (1 CP + 1 worker), 2 failure domain checks
+			expectedCheckCount:                 14, //nolint:lll // config check, credentials check, Prism Central version check, 2 VM image checks (1 CP + 1 worker), 2 VM image Kubernetes version checks, 2 CIDR validation checks, 2 storage container checks (1 CP + 1 worker), 2 failure domain checks, 1 control plane endpoint check
 			expectedFirstCheckName:             "NutanixConfiguration",
 			expectedSecondCheckName:            "NutanixCredentials",
 			expectedThirdCheckName:             "NutanixPrismCentralVersion",
@@ -122,6 +142,7 @@ func TestNutanixChecker_Init(t *testing.T) {
 			cidrValidationCheckCount:           2,
 			storageContainerCheckCount:         2,
 			failureDomainCheckCount:            2,
+			controlPlaneEndpointCheckCount:     1,
 		},
 	}
 
@@ -139,6 +160,7 @@ func TestNutanixChecker_Init(t *testing.T) {
 			vmImageKubernetesVersionCheckCount := 0
 			cidrValidationCheckCount := 0
 			failureDomainCheckCount := 0
+			controlPlaneEndpointCheckCount := 0
 			metroCheckCount := 0
 
 			checker.configurationCheckFactory = func(cd *checkDependencies) preflight.Check {
@@ -241,6 +263,22 @@ func TestNutanixChecker_Init(t *testing.T) {
 					checks = append(checks,
 						&mockCheck{
 							name: fmt.Sprintf("NutanixFailureDomain-%d", i),
+							result: preflight.CheckResult{
+								Allowed: true,
+							},
+						},
+					)
+				}
+				return checks
+			}
+
+			checker.controlPlaneEndpointChecksFactory = func(cd *checkDependencies) []preflight.Check {
+				checks := []preflight.Check{}
+				for i := 0; i < tt.controlPlaneEndpointCheckCount; i++ {
+					controlPlaneEndpointCheckCount++
+					checks = append(checks,
+						&mockCheck{
+							name: fmt.Sprintf("NutanixControlPlaneEndpoint-%d", i),
 							result: preflight.CheckResult{
 								Allowed: true,
 							},
@@ -420,6 +458,9 @@ func TestNutanixChecker_PrismCentralVersionGating(t *testing.T) {
 					return nil
 				},
 				storageContainerChecksFactory: func(cd *checkDependencies) []preflight.Check {
+					return nil
+				},
+				controlPlaneEndpointChecksFactory: func(cd *checkDependencies) []preflight.Check {
 					return nil
 				},
 				metroChecksFactory: func(cd *checkDependencies) []preflight.Check {

--- a/pkg/webhook/preflight/nutanix/controlplane.go
+++ b/pkg/webhook/preflight/nutanix/controlplane.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Nutanix. All rights reserved.
+// Copyright 2026 Nutanix. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package nutanix
@@ -36,16 +36,22 @@ func (c *controlPlaneEndpointCheck) Name() string {
 }
 
 func (c *controlPlaneEndpointCheck) Run(ctx context.Context) preflight.CheckResult {
-	result := preflight.CheckResult{
-		Allowed: true,
+	if !c.cluster.Spec.ControlPlaneRef.IsDefined() {
+		// The control plane reference is defined, so the control plane has been initialized,
+		// and the endpoint may establish a TCP connection.
+		return preflight.CheckResult{
+			Allowed: true,
+		}
 	}
 
-	if !c.cluster.Spec.ControlPlaneRef.IsDefined() {
-		result.Allowed = true
-		return result
-	}
+	// The control plane reference is not defined, so the control plane has not been initialized,
+	// and if the endpoint establishes a TCP connection, then the most likely conclusion is that the
+	// endpoint is in use by another cluster. It is possible that the endpoint is a load balancer or
+	// proxy that accepts connections even if the control plane is not initialized, but in that
+	// case, the user can skip this check.
 
 	dialer := &net.Dialer{
+		// The default TCP timeout is 60 seconds, which is too long for this check.
 		Timeout: 3 * time.Second,
 	}
 	addr := net.JoinHostPort(
@@ -54,20 +60,22 @@ func (c *controlPlaneEndpointCheck) Run(ctx context.Context) preflight.CheckResu
 	)
 	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
-		result.Allowed = true
-		return result
-	}
-	if conn != nil {
-		conn.Close()
-		result.Allowed = false
-		result.Causes = append(result.Causes, preflight.Cause{
-			//nolint:lll // Message is long.
-			Message: fmt.Sprintf(
-				"The control plane endpoint %s established a TCP connection, before any control plane nodes have been created. The endpoint is in use, possibly by another cluster.",
-				addr,
-			),
-		})
+		return preflight.CheckResult{
+			Allowed: true,
+		}
 	}
 
-	return result
+	conn.Close()
+	return preflight.CheckResult{
+		Allowed: false,
+		Causes: []preflight.Cause{
+			{
+				//nolint:lll // Message is long.
+				Message: fmt.Sprintf(
+					"The control plane endpoint %s established a TCP connection, before any control plane nodes have been created. The endpoint is in use, possibly by another cluster.",
+					addr,
+				),
+			},
+		},
+	}
 }

--- a/pkg/webhook/preflight/nutanix/controlplane.go
+++ b/pkg/webhook/preflight/nutanix/controlplane.go
@@ -27,6 +27,10 @@ func newControlPlaneEndpointChecks(
 	}
 }
 
+// controlPlaneEndpointCheck is a check that verifies that the control plane
+// endpoint is not in use, before any control plane nodes have been created. If
+// the endpoint is in use, the check should fail, to prevent the cluster from
+// being created.
 type controlPlaneEndpointCheck struct {
 	cluster *clusterv1.Cluster
 }
@@ -36,22 +40,30 @@ func (c *controlPlaneEndpointCheck) Name() string {
 }
 
 func (c *controlPlaneEndpointCheck) Run(ctx context.Context) preflight.CheckResult {
-	if !c.cluster.Spec.ControlPlaneRef.IsDefined() {
-		// The control plane reference is defined, so the control plane has been initialized,
-		// and the endpoint may establish a TCP connection.
+	if c.cluster.Spec.ControlPlaneRef.IsDefined() {
+		// If the control plane reference is defined, then control plane nodes
+		// are already being created, and it is too late to prevent the cluster
+		// from being created, so this check is not relevant.
 		return preflight.CheckResult{
 			Allowed: true,
 		}
 	}
 
-	// The control plane reference is not defined, so the control plane has not been initialized,
-	// and if the endpoint establishes a TCP connection, then the most likely conclusion is that the
-	// endpoint is in use by another cluster. It is possible that the endpoint is a load balancer or
-	// proxy that accepts connections even if the control plane is not initialized, but in that
-	// case, the user can skip this check.
+	// If the control plane reference is not defined, then no control plane
+	// nodes have been created.
+	//
+	// We need to check if the endpoint establishes a TCP connection. If it
+	// does, then the most likely conclusion is that the endpoint is in use by
+	// another cluster.
+	//
+	// If the endpoint is a load balancer or proxy that accepts connections even
+	// before any control plane nodes have been created, then the user should
+	// skip this check.
 
 	dialer := &net.Dialer{
-		// The default TCP timeout is 60 seconds, which is too long for this check.
+		// The default TCP timeout is 60 seconds. We use a shorter timeout
+		// because we want checks to return quickly. Most checks complete in
+		// less than a few seconds. All checks run in parallel.
 		Timeout: 3 * time.Second,
 	}
 	addr := net.JoinHostPort(

--- a/pkg/webhook/preflight/nutanix/controlplane.go
+++ b/pkg/webhook/preflight/nutanix/controlplane.go
@@ -1,0 +1,73 @@
+// Copyright 2024 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nutanix
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/webhook/preflight"
+)
+
+func newControlPlaneEndpointChecks(
+	cd *checkDependencies,
+) []preflight.Check {
+	if cd == nil || cd.cluster == nil {
+		return []preflight.Check{}
+	}
+
+	return []preflight.Check{
+		&controlPlaneEndpointCheck{cluster: cd.cluster},
+	}
+}
+
+type controlPlaneEndpointCheck struct {
+	cluster *clusterv1.Cluster
+}
+
+func (c *controlPlaneEndpointCheck) Name() string {
+	return "NutanixControlPlaneEndpoint"
+}
+
+func (c *controlPlaneEndpointCheck) Run(ctx context.Context) preflight.CheckResult {
+	result := preflight.CheckResult{
+		Allowed: true,
+	}
+
+	if !c.cluster.Spec.ControlPlaneRef.IsDefined() {
+		result.Allowed = true
+		return result
+	}
+
+	dialer := &net.Dialer{
+		Timeout: 3 * time.Second,
+	}
+	addr := net.JoinHostPort(
+		c.cluster.Spec.ControlPlaneEndpoint.Host,
+		strconv.Itoa(int(c.cluster.Spec.ControlPlaneEndpoint.Port)),
+	)
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		result.Allowed = true
+		return result
+	}
+	if conn != nil {
+		conn.Close()
+		result.Allowed = false
+		result.Causes = append(result.Causes, preflight.Cause{
+			//nolint:lll // Message is long.
+			Message: fmt.Sprintf(
+				"The control plane endpoint %s established a TCP connection, before any control plane nodes have been created. The endpoint is in use, possibly by another cluster.",
+				addr,
+			),
+		})
+	}
+
+	return result
+}

--- a/pkg/webhook/preflight/nutanix/controlplane_test.go
+++ b/pkg/webhook/preflight/nutanix/controlplane_test.go
@@ -28,11 +28,6 @@ func listenTCP(t *testing.T) *net.TCPListener {
 func clusterWithControlPlaneEndpoint(host string, port int32) *clusterv1beta2.Cluster {
 	return &clusterv1beta2.Cluster{
 		Spec: clusterv1beta2.ClusterSpec{
-			ControlPlaneRef: clusterv1beta2.ContractVersionedObjectReference{
-				Name:     "test-kcp",
-				Kind:     "KubeadmControlPlane",
-				APIGroup: "controlplane.cluster.x-k8s.io",
-			},
 			ControlPlaneEndpoint: clusterv1beta2.APIEndpoint{
 				Host: host,
 				Port: port,
@@ -41,19 +36,15 @@ func clusterWithControlPlaneEndpoint(host string, port int32) *clusterv1beta2.Cl
 	}
 }
 
-func TestControlPlaneEndpointCheck_ControlPlaneRefNotDefined(t *testing.T) {
+func TestControlPlaneEndpointCheck_ControlPlaneRefDefined(t *testing.T) {
 	t.Parallel()
 
-	// ControlPlaneRef with all zero-value fields is not considered defined.
-	cluster := &clusterv1beta2.Cluster{
-		Spec: clusterv1beta2.ClusterSpec{
-			ControlPlaneEndpoint: clusterv1beta2.APIEndpoint{
-				Host: "127.0.0.1",
-				Port: 6443,
-			},
-		},
+	cluster := clusterWithControlPlaneEndpoint("127.0.0.1", 6443)
+	cluster.Spec.ControlPlaneRef = clusterv1beta2.ContractVersionedObjectReference{
+		Name:     "test-kcp",
+		Kind:     "KubeadmControlPlane",
+		APIGroup: "controlplane.cluster.x-k8s.io",
 	}
-
 	check := &controlPlaneEndpointCheck{cluster: cluster}
 	result := check.Run(context.Background())
 
@@ -93,6 +84,19 @@ func TestControlPlaneEndpointCheck_EndpointRefusesConnection(t *testing.T) {
 
 	check := &controlPlaneEndpointCheck{cluster: cluster}
 	result := check.Run(context.Background())
+
+	assert.Equal(t, preflight.CheckResult{Allowed: true}, result)
+}
+
+func TestControlPlaneEndpointCheck_EndpointTimeout(t *testing.T) {
+	t.Parallel()
+
+	cluster := clusterWithControlPlaneEndpoint("127.0.0.1", 6443)
+
+	check := &controlPlaneEndpointCheck{cluster: cluster}
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel the context immediately to simulate a timeout.
+	result := check.Run(cancelledCtx)
 
 	assert.Equal(t, preflight.CheckResult{Allowed: true}, result)
 }

--- a/pkg/webhook/preflight/nutanix/controlplane_test.go
+++ b/pkg/webhook/preflight/nutanix/controlplane_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nutanix
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/webhook/preflight"
+)
+
+// listenTCP starts a TCP listener on a random port and returns it.
+// The caller is responsible for closing the listener.
+func listenTCP(t *testing.T) *net.TCPListener {
+	t.Helper()
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
+	return l
+}
+
+func clusterWithControlPlaneEndpoint(host string, port int32) *clusterv1beta2.Cluster {
+	return &clusterv1beta2.Cluster{
+		Spec: clusterv1beta2.ClusterSpec{
+			ControlPlaneRef: clusterv1beta2.ContractVersionedObjectReference{
+				Name:     "test-kcp",
+				Kind:     "KubeadmControlPlane",
+				APIGroup: "controlplane.cluster.x-k8s.io",
+			},
+			ControlPlaneEndpoint: clusterv1beta2.APIEndpoint{
+				Host: host,
+				Port: port,
+			},
+		},
+	}
+}
+
+func TestControlPlaneEndpointCheck_ControlPlaneRefNotDefined(t *testing.T) {
+	t.Parallel()
+
+	// ControlPlaneRef with all zero-value fields is not considered defined.
+	cluster := &clusterv1beta2.Cluster{
+		Spec: clusterv1beta2.ClusterSpec{
+			ControlPlaneEndpoint: clusterv1beta2.APIEndpoint{
+				Host: "127.0.0.1",
+				Port: 6443,
+			},
+		},
+	}
+
+	check := &controlPlaneEndpointCheck{cluster: cluster}
+	result := check.Run(context.Background())
+
+	assert.Equal(t, preflight.CheckResult{Allowed: true}, result)
+}
+
+func TestControlPlaneEndpointCheck_EndpointAcceptsConnection(t *testing.T) {
+	t.Parallel()
+
+	// Start a real TCP listener so the dial succeeds.
+	listener := listenTCP(t)
+	defer listener.Close()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	cluster := clusterWithControlPlaneEndpoint("127.0.0.1", int32(addr.Port))
+
+	check := &controlPlaneEndpointCheck{cluster: cluster}
+	result := check.Run(context.Background())
+
+	expectedAddr := fmt.Sprintf("127.0.0.1:%d", addr.Port)
+	assert.False(t, result.Allowed)
+	require.Len(t, result.Causes, 1)
+	assert.Contains(t, result.Causes[0].Message, expectedAddr)
+	assert.Contains(t, result.Causes[0].Message, "established a TCP connection")
+}
+
+func TestControlPlaneEndpointCheck_EndpointRefusesConnection(t *testing.T) {
+	t.Parallel()
+
+	// Bind a listener, record its port, then close it immediately so the
+	// port is free but nothing is accepting connections.
+	listener := listenTCP(t)
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	cluster := clusterWithControlPlaneEndpoint("127.0.0.1", int32(port))
+
+	check := &controlPlaneEndpointCheck{cluster: cluster}
+	result := check.Run(context.Background())
+
+	assert.Equal(t, preflight.CheckResult{Allowed: true}, result)
+}


### PR DESCRIPTION
**What problem does this PR solve?**:
This check makes sure the control plane endpoint is not already being used before a new cluster is created. When no control plane nodes exist yet, it tries to open a TCP connection to the endpoint host and port. If the connection succeeds, that likely means something else (possibly another cluster) is already using that endpoint, so the check fails to stop the new cluster from being created. If the connection fails, or if control plane nodes already exist, the check passes.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
