### PR TITLE
build: bump go toolchain to 1.26.3 and harden GO_TOOLCHAIN_VERSION handling

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/ap
 
 go 1.25.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 replace github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common => ../common
 

--- a/common/go.mod
+++ b/common/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/co
 
 go 1.24.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/evanphx/json-patch/v5 v5.9.11

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix
 
 go 1.25.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 replace (
 	github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api => ./api

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/ha
 
 go 1.24.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/make/go.mk
+++ b/make/go.mk
@@ -288,6 +288,20 @@ govulncheck.%: ## Runs govulncheck for a specific module
 govulncheck.%: ; $(info $(M) running govulncheck on $* module)
 	$(if $(filter-out root .,$*),cd $* && )govulncheck ./...
 
+# Normalize GO_TOOLCHAIN_VERSION by prepending the required 'go' prefix if missing
+# (e.g. "1.26.3" -> "go1.26.3").
+_GO_TOOLCHAIN_VERSION = $(if $(filter go%,$(GO_TOOLCHAIN_VERSION)),$(GO_TOOLCHAIN_VERSION),go$(GO_TOOLCHAIN_VERSION))
+
+.PHONY: _check-go-toolchain-version
+_check-go-toolchain-version:
+ifndef GO_TOOLCHAIN_VERSION
+	$(error GO_TOOLCHAIN_VERSION is not set: please set GO_TOOLCHAIN_VERSION to the desired version, e.g. go1.22.5)
+endif
+	@[ "$(GO_TOOLCHAIN_VERSION)" = "$(_GO_TOOLCHAIN_VERSION)" ] \
+		|| echo "Note: prepended 'go' prefix to GO_TOOLCHAIN_VERSION; using $(_GO_TOOLCHAIN_VERSION)"
+	@printf '%s' '$(_GO_TOOLCHAIN_VERSION)' | grep -qE '^go[0-9]+\.[0-9]+(\.[0-9]+)?((rc|beta)[0-9]+)?$$' \
+		|| { echo >&2 "GO_TOOLCHAIN_VERSION '$(GO_TOOLCHAIN_VERSION)' is not a valid go toolchain version, e.g. go1.22.5"; exit 1; }
+
 .PHONY: go-mod-edit-toolchain
 go-mod-edit-toolchain: ## Edits the go.mod file of all modules in repository to use the toolchain version
 ifneq ($(wildcard $(REPO_ROOT)/go.mod),)
@@ -297,13 +311,12 @@ ifneq ($(words $(GO_SUBMODULES_NO_DOCS)),0)
 go-mod-edit-toolchain: $(addprefix go-mod-edit-toolchain.,$(GO_SUBMODULES_NO_DOCS:/go.mod=))
 endif
 ifneq ($(wildcard $(REPO_ROOT)/hack/tools/go.mod),)
-	cd hack/tools && go mod edit -toolchain=$(GO_TOOLCHAIN_VERSION)
+go-mod-edit-toolchain: _check-go-toolchain-version
+	cd hack/tools && go mod edit -toolchain=$(_GO_TOOLCHAIN_VERSION)
 endif
 
 .PHONY: go-mod-edit-toolchain.%
+go-mod-edit-toolchain.%: _check-go-toolchain-version
 go-mod-edit-toolchain.%: ## Edits the go.mod file of a specifc module in repository to use the toolchain version
 go-mod-edit-toolchain.%: ; $(info $(M) setting go toolchain for $* module)
-ifndef GO_TOOLCHAIN_VERSION
-	$(error GO_TOOLCHAIN_VERSION is not set: please set GO_TOOLCHAIN_VERSION to the desired version, e.g. go1.22.5)
-endif
-	$(if $(filter-out root .,$*),cd $* && )go mod edit -toolchain=$(GO_TOOLCHAIN_VERSION)
+	$(if $(filter-out root .,$*),cd $* && )go mod edit -toolchain=$(_GO_TOOLCHAIN_VERSION)


### PR DESCRIPTION
## Summary
- Bump go toolchain across all modules (`go.mod`, `api/`, `common/`, `hack/tools/`) from `go1.26.2` to `go1.26.3` via `make go-mod-edit-toolchain GO_TOOLCHAIN_VERSION=go1.26.3` to fix toolchain-level govulncheck findings.
- Harden the `go-mod-edit-toolchain` make recipes:
  - Auto-prepend the required `go` prefix when `GO_TOOLCHAIN_VERSION` is missing it (e.g. `1.26.3` → `go1.26.3`).
  - Validate the (normalized) value matches a valid go toolchain format (`goX.Y[.Z][rcN|betaN]`); abort before modifying any `go.mod` otherwise.
  - Route the `hack/tools` update through the same validation so an invalid value no longer silently writes a broken toolchain directive into `hack/tools/go.mod`.

## Notes
- `make govulncheck` still reports `GO-2026-4918` in `golang.org/x/net@v0.49.0` (fixed in `v0.53.0`). That is a third-party dependency, not a toolchain issue, and is addressed separately in #1619.

## Test plan
- [x] `make go-mod-edit-toolchain GO_TOOLCHAIN_VERSION=go1.26.3` — all 4 modules updated.
- [x] `make go-mod-edit-toolchain GO_TOOLCHAIN_VERSION=1.26.3` — auto-prefixes to `go1.26.3`, all 4 modules updated, with a note printed.
- [x] `make go-mod-edit-toolchain GO_TOOLCHAIN_VERSION=foo` — aborts before any `go.mod` is touched.
- [x] `devbox run -- make govulncheck` — toolchain findings cleared; only the remaining `golang.org/x/net` finding (covered by #1619) is reported.
