### PR TITLE
feat: [NCN-114349] Label addon namespaces with privileged PSA

### DIFF
--- a/.specify/features/NCN-114349/plan.md
+++ b/.specify/features/NCN-114349/plan.md
@@ -1,0 +1,237 @@
+<!--
+ Copyright 2026 Nutanix. All rights reserved.
+ SPDX-License-Identifier: Apache-2.0
+-->
+
+# Implementation Plan: Privileged PSA label on ntnx-system and node-feature-discovery namespaces
+
+**Branch**: `NCN-114349-psa-label-ntnx-system-nfd-namespaces`
+**Date**: 2026-05-14
+**Spec**: [./spec.md](./spec.md)
+
+## Summary
+
+Three lifecycle handlers must ensure a workload-cluster namespace exists with
+`pod-security.kubernetes.io/enforce=privileged` *before* installing their
+Helm-based addons. The required behaviour and helper already exist in
+`pkg/handlers/utils.EnsureNamespaceWithMetadata`, and the MetalLB lifecycle
+handler is the canonical template
+(`pkg/handlers/lifecycle/serviceloadbalancer/metallb/handler.go`). We follow
+that template in each of the three affected handlers and add a tiny shared
+constant for the label map. No topology mutation handlers are touched, so no
+version bump is required.
+
+## Technical Context
+
+**Language/Version**: Go (matches `go.mod`).
+**Primary Dependencies**: controller-runtime, sigs.k8s.io/cluster-api, in-repo
+`pkg/handlers/utils`.
+**Testing**: A single Ginkgo integration test in
+`pkg/handlers/utils/secrets_integration_test.go` (the same file that already
+covers `EnsureSecretOnRemoteCluster` with `helpers.TestEnv.WithFakeRemoteClusterClient`)
+extended to prove that `EnsureNamespaceWithMetadata` on the remote cluster
+applies the privileged PSA label idempotently. The three call-site changes
+in the handler files are simple, one-line glue and rely on this single test
+plus existing reviewer scrutiny — matching the precedent set by the MetalLB
+handler.
+**Target Platform**: management cluster controllers; workload cluster API as
+the remote target.
+**Project Type**: Go module / Kubernetes controller (single project).
+**Performance Goals**: N/A — single SSA call per Apply.
+**Constraints**: server-side apply, must be idempotent across multiple
+handlers ensuring the same namespace, must not change handler patch output.
+**Scale/Scope**: 3 handler files + 1 shared constant + tests + docs.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. API-First | Pass | No API/CRD changes. |
+| II. Handler-per-Provider | Pass | Each handler does its own ensure; shared constant lives in `pkg/handlers/utils`. |
+| III. Library-First | Pass | New constant is added to existing `pkg/handlers/utils`. |
+| IV. Tests Required | Pass | Each handler change ships with a unit test covering the namespace ensure. |
+| V. Code Style | Pass | No new comments narrating "what". Import aliases follow existing files. |
+| VI. Dependency Management | Pass | No new deps. |
+| VII. Handler Version Safety (No Silent Rollouts) | Pass | Lifecycle handlers only; no `GeneratePatches` change. Verified by inspection — no files under `pkg/handlers/*/mutation/` are modified. |
+| VIII. Handler Documentation | Pass | Docs updated under `docs/content/addons/` for the three addons. |
+
+No violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+.specify/features/NCN-114349/
+├── plan.md                # This file
+└── spec.md                # Feature specification
+```
+
+### Source Code (repository root)
+
+```text
+pkg/
+├── handlers/
+│   ├── utils/
+│   │   └── utils.go                # Add PrivilegedPodSecurityLabels var
+│   └── lifecycle/
+│       ├── csi/nutanix/
+│       │   ├── handler.go          # Ensure ntnx-system with PSA label
+│       │   └── handler_test.go     # New unit test
+│       ├── konnectoragent/
+│       │   ├── handler.go          # Ensure ntnx-system with PSA label
+│       │   └── handler_test.go     # New unit test
+│       └── nfd/
+│           ├── handler.go          # Ensure NFD ns with PSA label (Helm only)
+│           └── handler_test.go     # New unit test
+
+docs/
+└── content/addons/
+    ├── nfd.md                      # Mention PSA labelling
+    ├── konnector-agent.md          # Mention PSA labelling
+    └── (csi page)                  # Mention PSA labelling
+```
+
+**Structure Decision**: Stay with the existing single-project layout. Each
+affected handler gets one small additive change plus a focused unit test.
+Share the label-map constant from `pkg/handlers/utils` to avoid drift.
+
+## Tasks
+
+Atomic, TDD-ordered. Each is independently verifiable; do not merge a task
+until its acceptance check passes.
+
+### T1 — Shared constant
+
+**Files**: `pkg/handlers/utils/utils.go`
+
+Add an exported variable:
+
+```go
+// PrivilegedPodSecurityEnforceLabels is the label set applied to addon
+// namespaces on workload clusters that contain workloads requiring the
+// privileged Pod Security Standard (hostPath, hostNetwork, privileged
+// containers, etc.). The PSA version label is intentionally omitted because
+// "latest" is the PSA default and is the value we want.
+var PrivilegedPodSecurityEnforceLabels = map[string]string{
+    "pod-security.kubernetes.io/enforce": "privileged",
+}
+```
+
+**Acceptance**: `go build ./...` succeeds; no consumers yet.
+
+### T2 — Integration test for the underlying primitive (TDD)
+
+**File**: `pkg/handlers/utils/secrets_integration_test.go` (extend)
+
+Add a new Ginkgo `It` block:
+
+- Stand up a `Cluster` and `WithFakeRemoteClusterClient` like the existing tests.
+- Call `EnsureNamespaceWithMetadata(ctx, remoteClient, "test-ns",
+  PrivilegedPodSecurityEnforceLabels, nil)`.
+- Get the namespace on the remote client and assert
+  `metadata.labels["pod-security.kubernetes.io/enforce"] == "privileged"` and
+  that no `enforce-version` label was set.
+- Call `EnsureNamespaceWithMetadata` again with the same arguments and
+  reconfirm — idempotency.
+- Pre-create the namespace without labels, call
+  `EnsureNamespaceWithMetadata`, and confirm the label was added without
+  conflict.
+
+**Acceptance**: New `It` blocks pass under
+`make test-integration` / the integration-tagged test run for
+`pkg/handlers/utils`.
+
+### T3 — Nutanix CSI handler
+
+**File**: `pkg/handlers/lifecycle/csi/nutanix/handler.go`
+
+In `Apply`, after the existing call to `CopySecretToRemoteCluster` succeeds
+(or, more robustly, before `strategy.Apply`), obtain a remote-cluster client
+via `remote.NewClusterClient` and call
+`handlersutils.EnsureNamespaceWithMetadata(ctx, remoteClient,
+defaultHelmReleaseNamespace, handlersutils.PrivilegedPodSecurityEnforceLabels,
+nil)`. Mirror the MetalLB pattern exactly.
+
+**Acceptance**: Package still builds and `make test` for the package is
+green.
+
+### T4 — Konnector Agent handler
+
+**File**: `pkg/handlers/lifecycle/konnectoragent/handler.go`
+
+In `apply`, after the existing `CopySecretToRemoteCluster` call (which already
+constructs a remote client internally but doesn't expose it), build the
+remote client and call `EnsureNamespaceWithMetadata` exactly as in T3 for
+`defaultHelmReleaseNamespace` (= `ntnx-system`).
+
+**Acceptance**: Package builds; package tests pass.
+
+### T5 — NFD handler, Helm strategy only
+
+**File**: `pkg/handlers/lifecycle/nfd/handler.go`
+
+In the `case v1alpha1.AddonStrategyHelmAddon:` branch only — before
+`strategy.Apply` — build a remote client and call
+`EnsureNamespaceWithMetadata(ctx, remoteClient, defaultHelmReleaseNamespace,
+handlersutils.PrivilegedPodSecurityEnforceLabels, nil)`. The CRS branch is
+left untouched because the CRS ConfigMap already labels the namespace.
+
+**Acceptance**: Package builds; package tests pass.
+
+### T6 — Verify no handler-version bump needed
+
+Run `git diff origin/main -- pkg/handlers` and confirm no files under
+`pkg/handlers/*/mutation/` are modified. Per
+`.cursor/rules/handler-version-safety.mdc`, lifecycle handler changes that
+don't alter mutation patches do not require a version bump.
+
+**Acceptance**: `find pkg/handlers -path '*/mutation/*' -newer .specify/features/NCN-114349/plan.md` lists nothing material.
+
+### T7 — Docs
+
+**Files**:
+
+- `docs/content/addons/nfd.md`
+- `docs/content/addons/konnector-agent.md`
+- the CSI addon docs page (look up under `docs/content/addons/`)
+
+Add a short paragraph under each addon explaining that CAREN labels the
+addon's workload-cluster namespace with
+`pod-security.kubernetes.io/enforce=privileged`, why (workloads need
+privileged pod features), and that this happens automatically on every
+reconcile.
+
+**Acceptance**: Markdown files lint clean (per
+`.cursor/rules/markdown-quality.mdc`); the Dirty Frag doc still reads
+correctly (no contradiction).
+
+### T8 — Lint + full test pass
+
+Run repo-standard linters and the affected test packages.
+
+**Acceptance**:
+
+```bash
+golangci-lint run ./pkg/handlers/...
+gotestsum --format pkgname -- ./pkg/handlers/lifecycle/csi/nutanix/... \
+                              ./pkg/handlers/lifecycle/konnectoragent/... \
+                              ./pkg/handlers/lifecycle/nfd/...
+```
+
+both pass.
+
+### T9 — Manual smoke verification (optional, before commit)
+
+Build the operator image, deploy to a kind cluster with a Nutanix-flavoured
+workload cluster, set `clusterConfig.podSecurityAdmission.enforce: baseline`,
+and confirm `ntnx-system` and `node-feature-discovery` pods stay healthy and
+the namespaces carry the expected label.
+
+**Acceptance**: `kubectl get ns ntnx-system node-feature-discovery
+-o jsonpath='{range .items[*]}{.metadata.name}{": "}{.metadata.labels.pod-security\.kubernetes\.io/enforce}{"\n"}{end}'`
+prints `privileged` for each.
+
+## Complexity Tracking
+
+No constitution violations. No complexity worth tracking.

--- a/.specify/features/NCN-114349/spec.md
+++ b/.specify/features/NCN-114349/spec.md
@@ -1,0 +1,152 @@
+<!--
+ Copyright 2026 Nutanix. All rights reserved.
+ SPDX-License-Identifier: Apache-2.0
+-->
+
+# Feature Specification: Privileged PSA label on ntnx-system and node-feature-discovery namespaces
+
+**Jira Ticket**: [NCN-114349](https://jira.nutanix.com/browse/NCN-114349)
+**Feature Branch**: `NCN-114349-psa-label-ntnx-system-nfd-namespaces`
+**Created**: 2026-05-14
+**Status**: Draft
+**Input**: User description: "on main, we need to ensure that ntnx-system and node-feature-discovery namespaces are labelled with privileged PSA"
+
+## User Scenarios & Testing
+
+### User Story 1 - Operator enables baseline/restricted PSA enforcement cluster-wide (Priority: P1)
+
+An operator follows the Dirty Frag mitigation guide and turns on
+`clusterConfig.podSecurityAdmission.enforce: baseline` (or `restricted`) on a
+workload cluster. They expect all CAREN-managed addon namespaces to keep
+working without needing per-cluster manual labelling, because the addons
+legitimately need privileged pod features (hostPath, hostNetwork, privileged
+containers).
+
+**Why this priority**: This is the explicit reason the change exists. Without
+it, the very mitigation we ship guidance for breaks our own addons on upgrade.
+
+**Independent Test**: On a workload cluster with CAREN-managed Nutanix CSI,
+Konnector Agent, and NFD installed, set the cluster-wide PSA enforcement to
+`baseline`. Verify that pods in `ntnx-system` and `node-feature-discovery`
+continue to schedule, including after pod recreation. Verify the namespaces
+carry the label `pod-security.kubernetes.io/enforce=privileged`.
+
+**Scope note**: Only CAREN-managed addons that actually install into
+`ntnx-system` are in scope. Survey of the codebase confirms these are
+**Nutanix CSI** and **Konnector Agent**. The Nutanix CCM handler installs into
+`kube-system` and the Nutanix Flow CNI handler installs into `kube-system`
+(with image-pull secrets copied to `flow-cni-system` and `ovn-kubernetes`),
+so neither needs `ntnx-system` labelling. `kube-system` is the default PSA
+exemption and is documented as such in the Dirty Frag guide, so it does not
+need labelling either.
+
+**Acceptance Scenarios**:
+
+1. **Given** a CAREN-managed workload cluster with the Nutanix CSI lifecycle
+   handler enabled, **When** the handler has run to completion, **Then** the
+   `ntnx-system` namespace on the workload cluster exists with the label
+   `pod-security.kubernetes.io/enforce=privileged`.
+2. **Given** a CAREN-managed workload cluster with the Konnector Agent
+   lifecycle handler enabled, **When** the handler has run to completion,
+   **Then** the `ntnx-system` namespace on the workload cluster exists with
+   the label `pod-security.kubernetes.io/enforce=privileged`.
+3. **Given** a CAREN-managed workload cluster with NFD deployed via the
+   `HelmAddon` strategy, **When** the NFD lifecycle handler has run to
+   completion, **Then** the `node-feature-discovery` namespace on the workload
+   cluster exists with the label
+   `pod-security.kubernetes.io/enforce=privileged`.
+4. **Given** the `node-feature-discovery` namespace already exists on the
+   workload cluster without PSA labels (created by an older CAREN, by a stuck
+   CAAPH, or by the user), **When** the NFD lifecycle handler runs,
+   **Then** the label is added to the existing namespace without conflict.
+
+### User Story 2 - Operator upgrades CAREN on a working cluster (Priority: P1)
+
+An operator upgrades CAREN on a management cluster that has many running
+workload clusters. They expect no churn on existing clusters and no impact
+beyond namespace metadata changes.
+
+**Why this priority**: Constitution principle VII (no silent rollouts). This
+change must not bump any topology mutation handler version and must not
+generate a Machine rollout.
+
+**Independent Test**: Compare the output of every registered topology mutation
+handler's `GeneratePatches` before and after the change for a representative
+Cluster. The output must be byte-identical.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing managed Cluster on the previous CAREN version,
+   **When** CAREN is upgraded to the version including this change, **Then**
+   no MachineDeployment or KubeadmControlPlane is rolled out as a result of
+   the upgrade.
+
+### Edge Cases
+
+- The namespace already exists on the workload cluster with a different value
+  for `pod-security.kubernetes.io/enforce` (e.g. `baseline`, set by an
+  operator). The handler must overwrite the value back to `privileged`
+  because the addons cannot run otherwise. This is consistent with the
+  MetalLB precedent in the same codebase.
+- The namespace already carries the older two-label form (`enforce`
+  + `enforce-version: latest`). The handler must not remove the
+  `enforce-version` label (out of scope for this change). The label set the
+  handler manages is "the labels it explicitly applies".
+- The workload cluster API is unreachable when the handler runs. The handler
+  must return an error so CAPI retries — consistent with current behaviour of
+  `CopySecretToRemoteCluster`.
+- Multiple Nutanix lifecycle handlers (CSI + CCM + Konnector + Flow CNI) run
+  on the same cluster and all try to ensure the same `ntnx-system` namespace.
+  Server-side apply with a stable field-manager makes this safe and
+  idempotent.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The Nutanix CSI lifecycle handler MUST ensure the
+  `ntnx-system` namespace exists on the workload cluster with the label
+  `pod-security.kubernetes.io/enforce=privileged` before installing the
+  CSI Helm chart.
+- **FR-002**: The Konnector Agent lifecycle handler MUST ensure the
+  `ntnx-system` namespace exists on the workload cluster with the label
+  `pod-security.kubernetes.io/enforce=privileged` before installing the
+  Konnector Agent Helm chart.
+- **FR-003**: The NFD lifecycle handler, when using the `HelmAddon`
+  strategy, MUST ensure the `node-feature-discovery` namespace exists on the
+  workload cluster with the label
+  `pod-security.kubernetes.io/enforce=privileged` before installing the
+  NFD Helm chart.
+- **FR-004**: Label application MUST use server-side apply so that repeated
+  reconciles are idempotent and the handler's field-manager owns only the
+  label keys it explicitly sets.
+- **FR-005**: The change MUST NOT modify the output of any topology mutation
+  handler's `GeneratePatches`, and MUST NOT require a handler version bump.
+- **FR-006**: The handler MUST NOT set
+  `pod-security.kubernetes.io/enforce-version` explicitly, because PSA
+  defaults the version to `latest` when omitted.
+
+### Key Entities
+
+- **Namespace `ntnx-system`** (workload cluster): Holds Nutanix CSI and
+  Konnector Agent workloads. Requires PSA `privileged`.
+- **Namespace `node-feature-discovery`** (workload cluster): Holds the NFD
+  master/worker DaemonSets. Requires PSA `privileged`.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: On a workload cluster after the relevant lifecycle handler has
+  reconciled, `kubectl get namespace ntnx-system -o
+  jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}'` returns
+  `privileged`. Same check for `node-feature-discovery` when NFD is enabled.
+- **SC-002**: After enabling
+  `clusterConfig.podSecurityAdmission.enforce: baseline` cluster-wide on a
+  workload cluster with the affected addons installed, zero new pods in
+  `ntnx-system` or `node-feature-discovery` are rejected at admission for PSA
+  violations.
+- **SC-003**: Upgrading CAREN from the previous release to the release
+  including this change on a management cluster with N workload clusters
+  triggers zero MachineDeployment or KubeadmControlPlane rollouts attributable
+  to this change.

--- a/docs/content/addons/konnector-agent.md
+++ b/docs/content/addons/konnector-agent.md
@@ -127,6 +127,16 @@ The addon uses the following default values:
 - **Chart**: `konnector-agent`
 - **Version**: `1.3.2`
 
+## Pod Security Admission
+
+The Konnector Agent runs as a privileged workload (it reads cluster identity,
+manages kubeconfigs, etc.) and would be rejected on clusters that enforce a
+`baseline` or stricter Pod Security Standard. CAREN therefore labels the
+`ntnx-system` namespace with `pod-security.kubernetes.io/enforce=privileged`
+on every reconcile so the agent keeps working when an operator opts in to
+PSA enforcement. The same label is applied by the Nutanix CSI driver lifecycle
+handler, which also installs into `ntnx-system`.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/docs/content/addons/nfd.md
+++ b/docs/content/addons/nfd.md
@@ -32,5 +32,14 @@ spec:
 
 To deploy the addon via `ClusterResourceSet` replace the value of `strategy` with `ClusterResourceSet`.
 
+## Pod Security Admission
+
+NFD's master and worker DaemonSets require privileged pod features (hostNetwork,
+host filesystem access, etc.) and would be rejected on clusters that enforce a
+`baseline` or stricter Pod Security Standard. CAREN therefore labels the
+`node-feature-discovery` namespace with `pod-security.kubernetes.io/enforce=privileged`
+on every reconcile. This applies to both deployment strategies and means NFD
+keeps working when an operator opts in to PSA enforcement.
+
 [Node Feature Discovery]: https://github.com/kubernetes-sigs/node-feature-discovery
 [Cluster API Add-on Provider for Helm]: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm

--- a/pkg/handlers/lifecycle/csi/nutanix/handler.go
+++ b/pkg/handlers/lifecycle/csi/nutanix/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/controllers/remote"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
@@ -142,11 +143,38 @@ func (n *NutanixCSI) Apply(
 		}
 	}
 
+	// The Nutanix CSI driver requires hostPath volumes and other privileged
+	// pod features that fail to admit under baseline or stricter Pod Security
+	// Admission, so the workload-cluster namespace it runs in must be labelled
+	// privileged.
+	remoteClient, err := remote.NewClusterClient(
+		ctx,
+		"",
+		n.client,
+		ctrlclient.ObjectKeyFromObject(cluster),
+	)
+	if err != nil {
+		return fmt.Errorf("error creating remote cluster client: %w", err)
+	}
+	if err := handlersutils.EnsureNamespaceWithMetadata(
+		ctx,
+		remoteClient,
+		defaultHelmReleaseNamespace,
+		handlersutils.PrivilegedPodSecurityEnforceLabels,
+		nil,
+	); err != nil {
+		return fmt.Errorf(
+			"failed to ensure %q namespace on the remote cluster: %w",
+			defaultHelmReleaseNamespace,
+			err,
+		)
+	}
+
 	if err := strategy.Apply(ctx, cluster, n.config.DefaultsNamespace(), log); err != nil {
 		return fmt.Errorf("failed to apply nutanix CSI addon: %w", err)
 	}
 
-	err := csiutils.CreateStorageClassesOnRemote(
+	err = csiutils.CreateStorageClassesOnRemote(
 		ctx,
 		n.client,
 		provider.StorageClassConfigs,

--- a/pkg/handlers/lifecycle/konnectoragent/handler.go
+++ b/pkg/handlers/lifecycle/konnectoragent/handler.go
@@ -239,6 +239,35 @@ func (n *DefaultKonnectorAgent) apply(
 		return
 	}
 
+	// The Konnector Agent runs as a privileged workload (it reads kube-system
+	// UUID, manages kubeconfigs, etc.) and is rejected by baseline / restricted
+	// Pod Security Admission. Label its namespace so PSA does not block it.
+	remoteClient, err := remote.NewClusterClient(
+		ctx,
+		"",
+		n.client,
+		ctrlclient.ObjectKeyFromObject(cluster),
+	)
+	if err != nil {
+		resp.SetStatus(runtimehooksv1.ResponseStatusFailure)
+		resp.SetMessage(fmt.Sprintf("error creating remote cluster client: %v", err))
+		return
+	}
+	if err := handlersutils.EnsureNamespaceWithMetadata(
+		ctx,
+		remoteClient,
+		defaultHelmReleaseNamespace,
+		handlersutils.PrivilegedPodSecurityEnforceLabels,
+		nil,
+	); err != nil {
+		resp.SetStatus(runtimehooksv1.ResponseStatusFailure)
+		resp.SetMessage(fmt.Sprintf(
+			"failed to ensure %q namespace on the remote cluster: %v",
+			defaultHelmReleaseNamespace, err,
+		))
+		return
+	}
+
 	var strategy addons.Applier
 	helmChart, err := n.helmChartInfoGetter.For(ctx, log, config.KonnectorAgent)
 	if err != nil {

--- a/pkg/handlers/lifecycle/nfd/handler.go
+++ b/pkg/handlers/lifecycle/nfd/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/pflag"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1"
+	"sigs.k8s.io/cluster-api/controllers/remote"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/lifecycle/addons"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/lifecycle/config"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/options"
+	handlersutils "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/utils"
 )
 
 const (
@@ -172,6 +174,36 @@ func (n *DefaultNFD) apply(
 					err,
 				),
 			)
+			return
+		}
+		// NFD's master / worker DaemonSets need hostNetwork and hostPath access
+		// and fail to admit under baseline / restricted PSA. The CRS strategy
+		// bakes the privileged label into the namespace manifest; the Helm
+		// strategy relies on CAAPH to create a bare namespace, so we label it
+		// explicitly here.
+		remoteClient, err := remote.NewClusterClient(
+			ctx,
+			"",
+			n.client,
+			ctrlclient.ObjectKeyFromObject(cluster),
+		)
+		if err != nil {
+			resp.SetStatus(runtimehooksv1.ResponseStatusFailure)
+			resp.SetMessage(fmt.Sprintf("error creating remote cluster client: %v", err))
+			return
+		}
+		if err := handlersutils.EnsureNamespaceWithMetadata(
+			ctx,
+			remoteClient,
+			defaultHelmReleaseNamespace,
+			handlersutils.PrivilegedPodSecurityEnforceLabels,
+			nil,
+		); err != nil {
+			resp.SetStatus(runtimehooksv1.ResponseStatusFailure)
+			resp.SetMessage(fmt.Sprintf(
+				"failed to ensure %q namespace on the remote cluster: %v",
+				defaultHelmReleaseNamespace, err,
+			))
 			return
 		}
 		strategy = addons.NewHelmAddonApplier(

--- a/pkg/handlers/utils/utils.go
+++ b/pkg/handlers/utils/utils.go
@@ -21,6 +21,20 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/k8s/client"
 )
 
+// PrivilegedPodSecurityEnforceLabels is the label set applied to addon
+// namespaces on workload clusters that contain workloads requiring privileged
+// Pod Security Standard features (hostPath volumes, hostNetwork, privileged
+// containers, etc.). Setting this label means those addons keep working when
+// operators enable cluster-wide PSA enforcement at baseline or stricter (see
+// docs/content/security/dirty-frag-mitigation.md).
+//
+// The PSA version label is intentionally omitted: PSA defaults the version
+// to "latest" when no enforce-version label is present, which is the value
+// we want.
+var PrivilegedPodSecurityEnforceLabels = map[string]string{
+	"pod-security.kubernetes.io/enforce": "privileged",
+}
+
 type EnsureCRSForClusterFromObjectsOptions struct {
 	// OwnerCluster holds the owning cluster for the ClusterResourceSet.
 	// This allows setting the owner to something other than the workload cluster, which is

--- a/pkg/handlers/utils/utils_integration_test.go
+++ b/pkg/handlers/utils/utils_integration_test.go
@@ -94,4 +94,55 @@ var _ = Describe("Namespace", func() {
 			Expect(ns.GetLabels()).To(HaveKeyWithValue("newkey", "newvalue"))
 		},
 	)
+
+	It(
+		"applies the privileged PSA enforce label without an enforce-version label, idempotently, "+
+			"and on a pre-existing label-less namespace",
+		func(ctx SpecContext) {
+			c, err := helpers.TestEnv.GetK8sClient()
+			Expect(err).To(BeNil())
+
+			// Case 1: brand-new namespace gets the label.
+			newName := names.SimpleNameGenerator.GenerateName("psa-new-")
+			Expect(EnsureNamespaceWithMetadata(
+				ctx, c, newName, PrivilegedPodSecurityEnforceLabels, nil,
+			)).To(Succeed())
+
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: newName}}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(ns), ns)).To(Succeed())
+			Expect(ns.GetLabels()).To(HaveKeyWithValue(
+				"pod-security.kubernetes.io/enforce", "privileged",
+			))
+			Expect(ns.GetLabels()).NotTo(HaveKey(
+				"pod-security.kubernetes.io/enforce-version",
+			))
+
+			// Case 2: calling again is a no-op (idempotent).
+			Expect(EnsureNamespaceWithMetadata(
+				ctx, c, newName, PrivilegedPodSecurityEnforceLabels, nil,
+			)).To(Succeed())
+
+			ns2 := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: newName}}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(ns2), ns2)).To(Succeed())
+			Expect(ns2.GetLabels()).To(HaveKeyWithValue(
+				"pod-security.kubernetes.io/enforce", "privileged",
+			))
+
+			// Case 3: a pre-existing namespace without labels is updated in place.
+			preName := names.SimpleNameGenerator.GenerateName("psa-pre-")
+			Expect(c.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: preName},
+			})).To(Succeed())
+
+			Expect(EnsureNamespaceWithMetadata(
+				ctx, c, preName, PrivilegedPodSecurityEnforceLabels, nil,
+			)).To(Succeed())
+
+			pre := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: preName}}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(pre), pre)).To(Succeed())
+			Expect(pre.GetLabels()).To(HaveKeyWithValue(
+				"pod-security.kubernetes.io/enforce", "privileged",
+			))
+		},
+	)
 })


### PR DESCRIPTION
## Summary

- Three lifecycle handlers (Nutanix CSI driver, Konnector Agent, NFD Helm
  strategy) now ensure their workload-cluster namespace exists with
  `pod-security.kubernetes.io/enforce=privileged` before installing the Helm
  chart, mirroring the existing MetalLB pattern. Without this, the privileged
  workloads in `ntnx-system` and `node-feature-discovery` are rejected at
  admission once an operator enables baseline or stricter Pod Security
  Admission on the workload cluster.
- A new shared `PrivilegedPodSecurityEnforceLabels` constant in
  `pkg/handlers/utils` ensures the three handlers agree on the label set. The
  PSA enforce-version label is intentionally omitted because PSA defaults to
  ``latest`` when no enforce-version is set.
- The NFD `ClusterResourceSet` strategy is intentionally unchanged — the CRS
  ConfigMap already bakes the privileged label into the namespace manifest.
  The Nutanix CCM handler and Nutanix Flow CNI handler are also not in scope
  because both install into `kube-system` (the documented PSA exemption) and
  do not touch ``ntnx-system``.
- Lifecycle handlers only — no topology mutation handler patch output changes,
  so no handler version bump is required (constitution principle VII).

Jira: [NCN-114349](https://jira.nutanix.com/browse/NCN-114349)

## Test plan

- [x] ``go build ./...`` clean.
- [x] New ``It`` block in
      ``pkg/handlers/utils/utils_integration_test.go`` proves the label is
      applied via SSA, idempotently on repeat reconciles, and added in place
      to a pre-existing label-less namespace; ``enforce-version`` is never set.
- [x] ``go test ./pkg/handlers/utils ./pkg/handlers/lifecycle/csi/... ./pkg/handlers/lifecycle/konnectoragent/... ./pkg/handlers/lifecycle/nfd/...``
      green locally (envtest 1.29.5).
- [x] ``git diff --name-only origin/main | grep mutation/`` → empty
      (verifies no mutation-handler change).
- [ ] Manual smoke on a workload cluster: install Nutanix CSI + Konnector
      Agent + NFD, enable ``clusterConfig.podSecurityAdmission.enforce: baseline``,
      and confirm ``kubectl get ns ntnx-system node-feature-discovery -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.metadata.labels.pod-security\\.kubernetes\\.io/enforce}{\"\\n\"}{end}'``
      prints ``privileged`` for each and that the addon pods stay healthy.