### PR TITLE
fix: Surface Cluster topology patch decode failures

### DIFF
--- a/common/pkg/capi/clustertopology/patches/generator.go
+++ b/common/pkg/capi/clustertopology/patches/generator.go
@@ -55,7 +55,7 @@ func MutateIfApplicable[T runtime.Object](
 			"objKind", obj.GetObjectKind().GroupVersionKind(),
 			"expectedType", fmt.Sprintf("%T", &typed),
 		).Info("not matching type")
-		return nil
+		return fmt.Errorf("failed to convert unstructured object to typed object: %w", err)
 	}
 
 	// Create a deep clone of the typed object.

--- a/common/pkg/capi/clustertopology/patches/generator.go
+++ b/common/pkg/capi/clustertopology/patches/generator.go
@@ -55,7 +55,11 @@ func MutateIfApplicable[T runtime.Object](
 			"objKind", obj.GetObjectKind().GroupVersionKind(),
 			"expectedType", fmt.Sprintf("%T", &typed),
 		).Info("not matching type")
-		return fmt.Errorf("failed to convert unstructured object to typed object: %w", err)
+		return fmt.Errorf(
+			"failed to convert unstructured object (%s) to typed object: %w",
+			obj.GetObjectKind().GroupVersionKind().String(),
+			err,
+		)
 	}
 
 	// Create a deep clone of the typed object.

--- a/common/pkg/capi/clustertopology/patches/generator_test.go
+++ b/common/pkg/capi/clustertopology/patches/generator_test.go
@@ -21,12 +21,13 @@ func TestMutateIfApplicable(t *testing.T) {
 	t.Parallel()
 
 	type testSpec[T runtime.Object] struct {
-		name          string
-		input         *unstructured.Unstructured
-		holderRef     *runtimehooksv1.HolderReference
-		patchSelector clusterv1beta2.PatchSelector
-		mutFn         func(T) error
-		expected      *unstructured.Unstructured
+		name            string
+		input           *unstructured.Unstructured
+		holderRef       *runtimehooksv1.HolderReference
+		patchSelector   clusterv1beta2.PatchSelector
+		mutFn           func(T) error
+		expected        *unstructured.Unstructured
+		wantErrContains string
 	}
 	tests := []testSpec[*v1.ConfigMap]{{
 		name: "empty input matches holder and selector",
@@ -74,7 +75,7 @@ func TestMutateIfApplicable(t *testing.T) {
 			Object: map[string]any{},
 		},
 	}, {
-		name: "invalid typed object - ignored",
+		name: "selector mismatch on missing GVK - skipped",
 		input: &unstructured.Unstructured{Object: map[string]any{
 			"unknownField": "foo",
 		}},
@@ -91,6 +92,29 @@ func TestMutateIfApplicable(t *testing.T) {
 				"unknownField": "foo",
 			},
 		},
+	}, {
+		// Regression guard: when the patch selector matches but the unstructured input carries a
+		// field unknown to the typed view (e.g. a newer provider API adding a status sub-resource),
+		// MutateIfApplicable must surface the strict decode error instead of silently skipping the
+		// mutation. Silent skips previously produced clusters with un-patched templates and no
+		// visible signal in controller logs.
+		name: "unknown field surfaces decode error when selector matches",
+		input: &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "controlplane.cluster.x-k8s.io/v1beta2",
+			"kind":       "KubeadmControlPlaneTemplate",
+			"status": map[string]any{
+				"someProviderManagedField": "value-from-newer-api",
+			},
+		}},
+		holderRef: &runtimehooksv1.HolderReference{
+			Kind:      "Cluster",
+			FieldPath: "spec.controlPlaneRef",
+		},
+		patchSelector: selectors.ControlPlane(),
+		mutFn: func(obj *v1.ConfigMap) error {
+			return nil
+		},
+		wantErrContains: "failed to convert unstructured object to typed object",
 	}, {
 		name: "check deletion of elements in slice",
 		input: &unstructured.Unstructured{Object: map[string]any{
@@ -137,6 +161,11 @@ func TestMutateIfApplicable(t *testing.T) {
 				logr.Discard(),
 				tt.mutFn,
 			)
+			if tt.wantErrContains != "" {
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(err.Error()).To(gomega.ContainSubstring(tt.wantErrContains))
+				return
+			}
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 			g.Expect(tt.input).To(gomega.Equal(tt.expected))
 		})

--- a/common/pkg/capi/clustertopology/patches/generator_test.go
+++ b/common/pkg/capi/clustertopology/patches/generator_test.go
@@ -29,124 +29,130 @@ func TestMutateIfApplicable(t *testing.T) {
 		expected        *unstructured.Unstructured
 		wantErrContains string
 	}
-	tests := []testSpec[*v1.ConfigMap]{{
-		name: "empty input matches holder and selector",
-		input: &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "controlplane.cluster.x-k8s.io/v1beta2",
-			"kind":       "KubeadmControlPlaneTemplate",
-		}},
-		holderRef: &runtimehooksv1.HolderReference{
-			Kind:      "Cluster",
-			FieldPath: "spec.controlPlaneRef",
-		},
-		patchSelector: selectors.ControlPlane(),
-		mutFn: func(obj *v1.ConfigMap) error {
-			if obj.Data == nil {
-				obj.Data = map[string]string{}
-			}
-			obj.Data["foo"] = "bar" //nolint:goconst // bar doesn't need to be a const.
-			return nil
-		},
-		expected: &unstructured.Unstructured{
-			Object: map[string]any{
+	tests := []testSpec[*v1.ConfigMap]{
+		{
+			name: "empty input matches holder and selector",
+			input: &unstructured.Unstructured{Object: map[string]any{
 				"apiVersion": "controlplane.cluster.x-k8s.io/v1beta2",
 				"kind":       "KubeadmControlPlaneTemplate",
-				"data": map[string]any{
-					"foo": "bar",
+			}},
+			holderRef: &runtimehooksv1.HolderReference{
+				Kind:      "Cluster",
+				FieldPath: "spec.controlPlaneRef",
+			},
+			patchSelector: selectors.ControlPlane(),
+			mutFn: func(obj *v1.ConfigMap) error {
+				if obj.Data == nil {
+					obj.Data = map[string]string{}
+				}
+				obj.Data["foo"] = "bar" //nolint:goconst // bar doesn't need to be a const.
+				return nil
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "controlplane.cluster.x-k8s.io/v1beta2",
+					"kind":       "KubeadmControlPlaneTemplate",
+					"data": map[string]any{
+						"foo": "bar",
+					},
 				},
 			},
 		},
-	}, {
-		name:  "empty input not matching holder and selector",
-		input: &unstructured.Unstructured{Object: map[string]any{}},
-		holderRef: &runtimehooksv1.HolderReference{
-			Kind:      "NotMatching",
-			FieldPath: "spec.controlPlaneRef",
+		{
+			name:  "empty input not matching holder and selector",
+			input: &unstructured.Unstructured{Object: map[string]any{}},
+			holderRef: &runtimehooksv1.HolderReference{
+				Kind:      "NotMatching",
+				FieldPath: "spec.controlPlaneRef",
+			},
+			patchSelector: selectors.ControlPlane(),
+			mutFn: func(obj *v1.ConfigMap) error {
+				if obj.Data == nil {
+					obj.Data = map[string]string{}
+				}
+				obj.Data["foo"] = "bar"
+				return nil
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]any{},
+			},
 		},
-		patchSelector: selectors.ControlPlane(),
-		mutFn: func(obj *v1.ConfigMap) error {
-			if obj.Data == nil {
-				obj.Data = map[string]string{}
-			}
-			obj.Data["foo"] = "bar"
-			return nil
-		},
-		expected: &unstructured.Unstructured{
-			Object: map[string]any{},
-		},
-	}, {
-		name: "selector mismatch on missing GVK - skipped",
-		input: &unstructured.Unstructured{Object: map[string]any{
-			"unknownField": "foo",
-		}},
-		holderRef: &runtimehooksv1.HolderReference{
-			Kind:      "Cluster",
-			FieldPath: "spec.controlPlaneRef",
-		},
-		patchSelector: selectors.ControlPlane(),
-		mutFn: func(obj *v1.ConfigMap) error {
-			return nil
-		},
-		expected: &unstructured.Unstructured{
-			Object: map[string]any{
+		{
+			name: "selector mismatch on missing GVK - skipped",
+			input: &unstructured.Unstructured{Object: map[string]any{
 				"unknownField": "foo",
+			}},
+			holderRef: &runtimehooksv1.HolderReference{
+				Kind:      "Cluster",
+				FieldPath: "spec.controlPlaneRef",
 			},
-		},
-	}, {
-		// Regression guard: when the patch selector matches but the unstructured input carries a
-		// field unknown to the typed view (e.g. a newer provider API adding a status sub-resource),
-		// MutateIfApplicable must surface the strict decode error instead of silently skipping the
-		// mutation. Silent skips previously produced clusters with un-patched templates and no
-		// visible signal in controller logs.
-		name: "unknown field surfaces decode error when selector matches",
-		input: &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "controlplane.cluster.x-k8s.io/v1beta2",
-			"kind":       "KubeadmControlPlaneTemplate",
-			"status": map[string]any{
-				"someProviderManagedField": "value-from-newer-api",
+			patchSelector: selectors.ControlPlane(),
+			mutFn: func(obj *v1.ConfigMap) error {
+				return nil
 			},
-		}},
-		holderRef: &runtimehooksv1.HolderReference{
-			Kind:      "Cluster",
-			FieldPath: "spec.controlPlaneRef",
-		},
-		patchSelector: selectors.ControlPlane(),
-		mutFn: func(obj *v1.ConfigMap) error {
-			return nil
-		},
-		wantErrContains: "failed to convert unstructured object to typed object",
-	}, {
-		name: "check deletion of elements in slice",
-		input: &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "controlplane.cluster.x-k8s.io/v1beta2",
-			"kind":       "KubeadmControlPlaneTemplate",
-			"data": map[string]any{
-				"existingFoo": "bar",
-			},
-		}},
-		holderRef: &runtimehooksv1.HolderReference{
-			Kind:      "Cluster",
-			FieldPath: "spec.controlPlaneRef",
-		},
-		patchSelector: selectors.ControlPlane(),
-		mutFn: func(obj *v1.ConfigMap) error {
-			if obj.Data == nil {
-				obj.Data = map[string]string{}
-			}
-			obj.Data["foo"] = "bar"
-			delete(obj.Data, "existingFoo")
-			return nil
-		},
-		expected: &unstructured.Unstructured{
-			Object: map[string]any{
-				"apiVersion": "controlplane.cluster.x-k8s.io/v1beta2",
-				"kind":       "KubeadmControlPlaneTemplate",
-				"data": map[string]any{
-					"foo": "bar",
+			expected: &unstructured.Unstructured{
+				Object: map[string]any{
+					"unknownField": "foo",
 				},
 			},
 		},
-	}}
+		{
+			// Regression guard: when the patch selector matches but the unstructured input carries a
+			// field unknown to the typed view (e.g. a newer provider API adding a status sub-resource),
+			// MutateIfApplicable must surface the strict decode error instead of silently skipping the
+			// mutation. Silent skips previously produced clusters with un-patched templates and no
+			// visible signal in controller logs.
+			name: "unknown field surfaces decode error when selector matches",
+			input: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "controlplane.cluster.x-k8s.io/v1beta2",
+				"kind":       "KubeadmControlPlaneTemplate",
+				"status": map[string]any{
+					"someProviderManagedField": "value-from-newer-api",
+				},
+			}},
+			holderRef: &runtimehooksv1.HolderReference{
+				Kind:      "Cluster",
+				FieldPath: "spec.controlPlaneRef",
+			},
+			patchSelector: selectors.ControlPlane(),
+			mutFn: func(obj *v1.ConfigMap) error {
+				return nil
+			},
+			wantErrContains: "controlplane.cluster.x-k8s.io/v1beta2, Kind=KubeadmControlPlaneTemplate) to typed object: strict decoding error: unknown field \"status\"",
+		},
+		{
+			name: "check deletion of elements in slice",
+			input: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "controlplane.cluster.x-k8s.io/v1beta2",
+				"kind":       "KubeadmControlPlaneTemplate",
+				"data": map[string]any{
+					"existingFoo": "bar",
+				},
+			}},
+			holderRef: &runtimehooksv1.HolderReference{
+				Kind:      "Cluster",
+				FieldPath: "spec.controlPlaneRef",
+			},
+			patchSelector: selectors.ControlPlane(),
+			mutFn: func(obj *v1.ConfigMap) error {
+				if obj.Data == nil {
+					obj.Data = map[string]string{}
+				}
+				obj.Data["foo"] = "bar"
+				delete(obj.Data, "existingFoo")
+				return nil
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "controlplane.cluster.x-k8s.io/v1beta2",
+					"kind":       "KubeadmControlPlaneTemplate",
+					"data": map[string]any{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
**What problem does this PR solve?**:
Previously, when a patch selector matched a template but strict decoding into the typed view failed, MutateIfApplicable only logged the issue at V(5) and returned nil. As a result, the mutator was silently skipped and the original unstructured object was returned without any patches applied, with no visible indication at normal log levels.

I encountered this while creating a cluster where the capx-controller version was newer and introduced the NutanixMachineTemplateStatus field. Since CAREN’s vendored CAPX types had not yet been updated, strict decoding rejected the object due to the unknown field. Because of this, the NutanixMachineTemplate mutators silently failed to patch subnets and images, leading to broken cluster configuration without surfacing any clear error.

This change propagates the conversion error instead of suppressing it. As a result, the meta GeneratePatches handler now logs these failures at Error level, making future provider API drift immediately visible instead of silently producing partially patched or broken clusters.


**How Has This Been Tested?**:
I tested this on the mentioned  setup and was able to see the error clearly:

`0518 14:03:22.602010    1 meta.go:123] "Mutator failed" err="failed to convert unstructured object to typed object: strict decoding error: unknown field \"status\"" template="infrastructure.cluster.x-k8s.io/v1beta1/NutanixMachineTemplate" holder="controlplane.cluster.x-k8s.io/v1beta2/KubeadmControlPlane/default/nkp-vedansh-caren-test-2-rcm7v" holderRef={"apiVersion":"controlplane.cluster.x-k8s.io/v1beta2","kind":"KubeadmControlPlane","namespace":"default","name":"nkp-vedansh-caren-test-2-rcm7v","fieldPath":"spec.machineTemplate.spec.infrastructureRef"} objectKind="infrastructure.cluster.x-k8s.io/v1beta1, Kind=NutanixMachineTemplate" handlerName="nutanixClusterv6configpatch" index=3 handler="*machinedetails.nutanixMachineDetailsPatchHandler"

`