### PR TITLE
ci: Add --ignore-scripts and isolate docs build workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -13,12 +13,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
@@ -31,9 +25,10 @@ defaults:
     shell: bash
 
 jobs:
-  # Build job
-  build:
+  prepare-helm-index:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -42,14 +37,6 @@ jobs:
         uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: true
-
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v6
-
-      - name: Install Node.js dependencies
-        run: if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then npm ci; fi
-        working-directory: docs
 
       - name: Update Helm index
         env:
@@ -66,6 +53,41 @@ jobs:
               rm -f docs/static/helm/*.tgz
             fi
           done
+
+      - name: Upload Helm index artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-helm-index
+          path: docs/static/helm/index.yaml
+
+  # Build job
+  build:
+    runs-on: ubuntu-24.04
+    needs: prepare-helm-index
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.15.0
+        with:
+          enable-cache: true
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v6
+
+      - name: Download Helm index artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: docs-helm-index
+          path: docs/static/helm
+
+      - name: Install Node.js dependencies
+        run: if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then npm ci --ignore-scripts; fi
+        working-directory: docs
 
       - name: Build with Hugo
         env:
@@ -89,6 +111,10 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
**What problem does this PR solve?**:
Added --ignore-scripts to npm dependency installation (npm ci) in docs build.
Split workflow into separate jobs so dependency install/build runs independently from deployment.
Scoped GitHub Actions token permissions per job using least privilege (read-only for prep/build, elevated only for deploy).
Added artifact upload/download (docs-helm-index) to preserve Helm index behavior across job boundaries.

https://jira.nutanix.com/browse/NCN-114489
