### PR TITLE
refactor: pass oldCluster to preflight checker

### DIFF
--- a/pkg/webhook/preflight/README.md
+++ b/pkg/webhook/preflight/README.md
@@ -63,7 +63,7 @@ type checkDependencies struct {
 func (m *myChecker) Init(
     ctx context.Context,
     client ctrlclient.Client,
-    cluster *clusterv1beta2.Cluster,
+    cluster, oldCluster *clusterv1beta2.Cluster,
 ) []preflight.Check {
     log := ctrl.LoggerFrom(ctx).WithName("preflight/myprovider")
 

--- a/pkg/webhook/preflight/README.md
+++ b/pkg/webhook/preflight/README.md
@@ -63,7 +63,8 @@ type checkDependencies struct {
 func (m *myChecker) Init(
     ctx context.Context,
     client ctrlclient.Client,
-    cluster, oldCluster *clusterv1beta2.Cluster,
+    cluster *clusterv1beta2.Cluster,
+    oldCluster *clusterv1beta2.Cluster,
 ) []preflight.Check {
     log := ctrl.LoggerFrom(ctx).WithName("preflight/myprovider")
 

--- a/pkg/webhook/preflight/generic/checker.go
+++ b/pkg/webhook/preflight/generic/checker.go
@@ -32,6 +32,7 @@ type genericChecker struct {
 type checkDependencies struct {
 	kclient                  ctrlclient.Client
 	cluster                  *clusterv1.Cluster
+	oldCluster               *clusterv1.Cluster
 	genericClusterConfigSpec *carenv1.GenericClusterConfigSpec
 	log                      logr.Logger
 }
@@ -39,12 +40,13 @@ type checkDependencies struct {
 func (g *genericChecker) Init(
 	ctx context.Context,
 	kclient ctrlclient.Client,
-	cluster *clusterv1.Cluster,
+	cluster, oldCluster *clusterv1.Cluster,
 ) []preflight.Check {
 	cd := &checkDependencies{
-		kclient: kclient,
-		cluster: cluster,
-		log:     ctrl.LoggerFrom(ctx).WithName("preflight/generic"),
+		kclient:    kclient,
+		cluster:    cluster,
+		oldCluster: oldCluster,
+		log:        ctrl.LoggerFrom(ctx).WithName("preflight/generic"),
 	}
 	checks := slices.Concat(
 		[]preflight.Check{

--- a/pkg/webhook/preflight/generic/checker.go
+++ b/pkg/webhook/preflight/generic/checker.go
@@ -40,7 +40,8 @@ type checkDependencies struct {
 func (g *genericChecker) Init(
 	ctx context.Context,
 	kclient ctrlclient.Client,
-	cluster, oldCluster *clusterv1.Cluster,
+	cluster *clusterv1.Cluster,
+	oldCluster *clusterv1.Cluster,
 ) []preflight.Check {
 	cd := &checkDependencies{
 		kclient:    kclient,

--- a/pkg/webhook/preflight/nutanix/checker.go
+++ b/pkg/webhook/preflight/nutanix/checker.go
@@ -88,7 +88,8 @@ type checkDependencies struct {
 func (n *nutanixChecker) Init(
 	ctx context.Context,
 	kclient ctrlclient.Client,
-	cluster, oldCluster *clusterv1.Cluster,
+	cluster *clusterv1.Cluster,
+	oldCluster *clusterv1.Cluster,
 ) []preflight.Check {
 	cd := &checkDependencies{
 		kclient:    kclient,

--- a/pkg/webhook/preflight/nutanix/checker.go
+++ b/pkg/webhook/preflight/nutanix/checker.go
@@ -72,8 +72,9 @@ type nutanixChecker struct {
 }
 
 type checkDependencies struct {
-	kclient ctrlclient.Client
-	cluster *clusterv1.Cluster
+	kclient    ctrlclient.Client
+	cluster    *clusterv1.Cluster
+	oldCluster *clusterv1.Cluster
 
 	nutanixClusterConfigSpec                           *carenv1.NutanixClusterConfigSpec
 	nutanixWorkerNodeConfigSpecByMachineDeploymentName map[string]*carenv1.NutanixWorkerNodeConfigSpec
@@ -87,13 +88,14 @@ type checkDependencies struct {
 func (n *nutanixChecker) Init(
 	ctx context.Context,
 	kclient ctrlclient.Client,
-	cluster *clusterv1.Cluster,
+	cluster, oldCluster *clusterv1.Cluster,
 ) []preflight.Check {
 	cd := &checkDependencies{
-		kclient:   kclient,
-		cluster:   cluster,
-		log:       ctrl.LoggerFrom(ctx).WithName("preflight/nutanix"),
-		pcVersion: "",
+		kclient:    kclient,
+		cluster:    cluster,
+		oldCluster: oldCluster,
+		log:        ctrl.LoggerFrom(ctx).WithName("preflight/nutanix"),
+		pcVersion:  "",
 	}
 
 	checks := []preflight.Check{

--- a/pkg/webhook/preflight/nutanix/checker_test.go
+++ b/pkg/webhook/preflight/nutanix/checker_test.go
@@ -255,7 +255,7 @@ func TestNutanixChecker_Init(t *testing.T) {
 					Name:      "test-cluster",
 					Namespace: "default",
 				},
-			})
+			}, nil)
 
 			// Verify correct number of checks
 			assert.Len(t, checks, tt.expectedCheckCount)
@@ -406,7 +406,7 @@ func TestNutanixChecker_PrismCentralVersionGating(t *testing.T) {
 				},
 			}
 
-			checks := checker.Init(ctx, nil, cluster)
+			checks := checker.Init(ctx, nil, cluster, nil)
 
 			dependentCount := 0
 			hasVersionCheck := false

--- a/pkg/webhook/preflight/preflight.go
+++ b/pkg/webhook/preflight/preflight.go
@@ -34,7 +34,8 @@ type (
 	// such as an infrastructure API client.
 	Checker interface {
 		// Init returns the checks that should run for the cluster.
-		Init(ctx context.Context, client ctrlclient.Client, cluster *clusterv1.Cluster) []Check
+		// oldCluster is the cluster state before an Update operation and nil for Create operations.
+		Init(ctx context.Context, client ctrlclient.Client, cluster, oldCluster *clusterv1.Cluster) []Check
 	}
 
 	// Check represents a single preflight check that can be run against a cluster.
@@ -146,8 +147,9 @@ func (h *WebhookHandler) Handle(ctx context.Context, req admission.Request) admi
 		return admission.Allowed("")
 	}
 
+	var oldCluster *clusterv1.Cluster
 	if req.Operation == admissionv1.Update {
-		oldCluster := &clusterv1.Cluster{}
+		oldCluster = &clusterv1.Cluster{}
 		err := h.decoder.DecodeRaw(req.OldObject, oldCluster)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
@@ -188,7 +190,7 @@ func (h *WebhookHandler) Handle(ctx context.Context, req admission.Request) admi
 	checkTimeout := Timeout - 2*time.Second
 	checkCtx, checkCtxCancel := context.WithTimeout(ctx, checkTimeout)
 	log.V(5).Info("Running preflight checks")
-	resultsOrderedByCheckerAndCheck := run(checkCtx, h.client, cluster, skipEvaluator, h.checkers)
+	resultsOrderedByCheckerAndCheck := run(checkCtx, h.client, cluster, oldCluster, skipEvaluator, h.checkers)
 	checkCtxCancel()
 
 	// Summarize the results.
@@ -244,9 +246,11 @@ func (h *WebhookHandler) Handle(ctx context.Context, req admission.Request) admi
 
 // run runs all checks for the cluster, concurrently, and returns the results ordered by checker and check.
 // Checker are initialized concurrently, and checks runs concurrently as well.
+// oldCluster is the cluster state before an Update operation and nil for Create operations.
 func run(ctx context.Context,
 	client ctrlclient.Client,
 	cluster *clusterv1.Cluster,
+	oldCluster *clusterv1.Cluster,
 	skipEvaluator *skip.Evaluator,
 	checkers []Checker,
 ) [][]namedResult {
@@ -259,13 +263,14 @@ func run(ctx context.Context,
 			ctx context.Context,
 			client ctrlclient.Client,
 			cluster *clusterv1.Cluster,
+			oldCluster *clusterv1.Cluster,
 			skipEvaluator *skip.Evaluator,
 			checker Checker,
 			i int,
 		) {
 			defer checkersWG.Done()
 
-			checks := checker.Init(ctx, client, cluster)
+			checks := checker.Init(ctx, client, cluster, oldCluster)
 			resultsOrderedByCheck := make([]namedResult, len(checks))
 
 			checksWG := sync.WaitGroup{}
@@ -337,6 +342,7 @@ func run(ctx context.Context,
 			ctx,
 			client,
 			cluster,
+			oldCluster,
 			skipEvaluator,
 			checker,
 			i,

--- a/pkg/webhook/preflight/preflight_test.go
+++ b/pkg/webhook/preflight/preflight_test.go
@@ -33,7 +33,7 @@ type mockChecker struct {
 	checks []Check
 }
 
-func (m *mockChecker) Init(_ context.Context, _ ctrlclient.Client, _ *clusterv1beta2.Cluster) []Check {
+func (m *mockChecker) Init(_ context.Context, _ ctrlclient.Client, _, _ *clusterv1beta2.Cluster) []Check {
 	return m.checks
 }
 
@@ -711,7 +711,7 @@ func TestHandleCancelledContext(t *testing.T) {
 
 func TestRun_NoCheckers(t *testing.T) {
 	ctx := context.Background()
-	results := run(ctx, nil, nil, nil, nil)
+	results := run(ctx, nil, nil, nil, nil, nil)
 	assert.Empty(t, results, "expected no results when no checkers are provided")
 }
 
@@ -728,7 +728,7 @@ func TestRun_SingleCheckerSingleCheck(t *testing.T) {
 			},
 		},
 	}
-	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, skip.New(cluster), []Checker{checker})
+	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, nil, skip.New(cluster), []Checker{checker})
 	if len(resultsOrderedByCheckerAndCheck) != 1 {
 		t.Fatalf("expected results for 1 checker, got %d", len(resultsOrderedByCheckerAndCheck))
 	}
@@ -768,7 +768,7 @@ func TestRun_MultipleCheckersMultipleChecks(t *testing.T) {
 		},
 	}
 
-	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, skip.New(cluster), []Checker{checker1, checker2})
+	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, nil, skip.New(cluster), []Checker{checker1, checker2})
 	if len(resultsOrderedByCheckerAndCheck) != 2 {
 		t.Fatalf("expected results for 2 checkers, got %d", len(resultsOrderedByCheckerAndCheck))
 	}
@@ -832,7 +832,7 @@ func TestRun_ChecksRunInParallel(t *testing.T) {
 			},
 		},
 	}
-	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, skip.New(cluster), []Checker{checker})
+	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, nil, skip.New(cluster), []Checker{checker})
 
 	results := resultsOrderedByCheckerAndCheck[0]
 	if len(results) != 2 {
@@ -871,7 +871,7 @@ func TestRun_CheckersRunInParallel(t *testing.T) {
 		},
 	}
 
-	results := run(ctx, nil, cluster, skip.New(cluster), []Checker{checker1, checker2})
+	results := run(ctx, nil, cluster, nil, skip.New(cluster), []Checker{checker1, checker2})
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results, got %d", len(results))
 	}
@@ -928,7 +928,7 @@ func TestRun_ContextCancellation(t *testing.T) {
 		cancel()
 	}()
 
-	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, skip.New(cluster), []Checker{checker})
+	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, nil, skip.New(cluster), []Checker{checker})
 
 	select {
 	case <-completed:
@@ -976,7 +976,7 @@ func TestRun_OrderOfResults(t *testing.T) {
 		},
 	}
 
-	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, skip.New(cluster), []Checker{checker1, checker2})
+	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, nil, skip.New(cluster), []Checker{checker1, checker2})
 	if len(resultsOrderedByCheckerAndCheck) != 2 {
 		t.Fatalf("expected results for 2 checkers, got %d", len(resultsOrderedByCheckerAndCheck))
 	}
@@ -1021,7 +1021,7 @@ func TestRun_LargeNumberOfCheckersAndChecks(t *testing.T) {
 	}
 
 	start := time.Now()
-	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, skip.New(cluster), checkers)
+	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, nil, skip.New(cluster), checkers)
 	duration := time.Since(start)
 
 	resultTotal := 0
@@ -1056,7 +1056,7 @@ func TestRun_ErrorHandlingInChecks(t *testing.T) {
 	}
 
 	// Run the checks
-	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, skip.New(cluster), []Checker{checker})
+	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, nil, skip.New(cluster), []Checker{checker})
 	assert.Len(t, resultsOrderedByCheckerAndCheck, 1, "expected results for 1 checker")
 	assert.Len(t, resultsOrderedByCheckerAndCheck[0], 1, "expected 1 result from the checker")
 
@@ -1111,7 +1111,7 @@ func TestRun_PanicHandlingInChecks(t *testing.T) {
 	}
 
 	// Run the checks
-	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, skip.New(cluster), []Checker{checker})
+	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, nil, skip.New(cluster), []Checker{checker})
 	assert.Len(t, resultsOrderedByCheckerAndCheck, 1, "expected results for 1 checker")
 	assert.Len(t, resultsOrderedByCheckerAndCheck[0], 2, "expected 2 results from the checker")
 
@@ -1158,7 +1158,14 @@ func TestRun_ZeroChecksFromChecker(t *testing.T) {
 		},
 	}
 
-	resultsOrderedByCheckerAndCheck := run(ctx, nil, cluster, skip.New(cluster), []Checker{emptyChecker, normalChecker})
+	resultsOrderedByCheckerAndCheck := run(
+		ctx,
+		nil,
+		cluster,
+		nil,
+		skip.New(cluster),
+		[]Checker{emptyChecker, normalChecker},
+	)
 
 	if len(resultsOrderedByCheckerAndCheck) != 2 {
 		t.Fatalf("expected results for 2 checkers, got %d", len(resultsOrderedByCheckerAndCheck))


### PR DESCRIPTION
**What problem does this PR solve?**:
Im working on a preflight in the downstream repo where I also need the info from the `oldCluster`.  The preflight webhook already has access to the `oldCluster`, but with this PR it also passes it to the checker.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
I thought it would be useful to add it here instead of just the downstream repo to avoid merge conflicts in the future.
