### PR TITLE
build: add a extra SAN in Kind cluster

### DIFF
--- a/hack/kind/kind-base-config.yaml
+++ b/hack/kind/kind-base-config.yaml
@@ -16,6 +16,14 @@ kubeadmConfigPatches:
     apiVersion: kubelet.config.k8s.io/v1beta1
     kind: KubeletConfiguration
     nodeStatusMaxImages: -1
+  - |
+    kind: ClusterConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    apiServer:
+      certSANs:
+        - "localhost"
+        - "127.0.0.1"
+        - "apiserver.kind.dev"
 nodes:
   - role: control-plane
     image: "${KINDEST_IMAGE}"


### PR DESCRIPTION
**What problem does this PR solve?**:
Useful when deploying this KIND cluster with a reverse tunnel. This extra SAN can then point back to a bastion host.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
