### PR TITLE
fix: Summarize preflight failures in result message

### DIFF
--- a/pkg/webhook/preflight/preflight.go
+++ b/pkg/webhook/preflight/preflight.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
@@ -222,16 +223,34 @@ func (h *WebhookHandler) Handle(ctx context.Context, req admission.Request) admi
 		}
 	}
 
+	humanReadableCausesSummary := strings.Builder{}
+	for i, cause := range resp.Result.Details.Causes {
+		if i > 0 {
+			humanReadableCausesSummary.WriteString("; ")
+		}
+		causeSummary := fmt.Sprintf("%s: %s", cause.Type, cause.Message)
+		if cause.Field != "" {
+			causeSummary += fmt.Sprintf(" (field: %s)", cause.Field)
+		}
+		humanReadableCausesSummary.WriteString(causeSummary)
+	}
+
 	switch {
 	case internalError:
 		// Internal errors take precedence over check failures.
-		resp.Result.Message = "preflight checks failed due to an internal error"
+		resp.Result.Message = fmt.Sprintf(
+			"preflight checks failed due to an internal error: %s",
+			humanReadableCausesSummary.String(),
+		)
 		resp.Result.Code = http.StatusInternalServerError
 		resp.Result.Reason = metav1.StatusReasonInternalError
 		log.V(5).Error(nil, "Preflight checks failed due to an internal error", "response", resp)
 	case !resp.Allowed:
 		// Because the response is not allowed, preflights must have failed.
-		resp.Result.Message = "preflight checks failed"
+		resp.Result.Message = fmt.Sprintf(
+			"preflight checks failed: %s",
+			humanReadableCausesSummary.String(),
+		)
 		resp.Result.Code = http.StatusUnprocessableEntity
 		resp.Result.Reason = metav1.StatusReasonInvalid
 		log.V(5).Info("Preflight checks failed", "response", resp)

--- a/pkg/webhook/preflight/preflight_test.go
+++ b/pkg/webhook/preflight/preflight_test.go
@@ -308,7 +308,7 @@ func TestHandle(t *testing.T) {
 					Result: &metav1.Status{
 						Code:    http.StatusUnprocessableEntity,
 						Reason:  metav1.StatusReasonInvalid,
-						Message: "preflight checks failed",
+						Message: "preflight checks failed: Test1: test failed (field: spec.test)",
 						Details: &metav1.StatusDetails{
 							Causes: []metav1.StatusCause{
 								{
@@ -404,7 +404,7 @@ func TestHandle(t *testing.T) {
 					Result: &metav1.Status{
 						Code:    http.StatusInternalServerError,
 						Reason:  metav1.StatusReasonInternalError,
-						Message: "preflight checks failed due to an internal error",
+						Message: "preflight checks failed due to an internal error: Test1: internal error; Test2: check failed",
 						Details: &metav1.StatusDetails{
 							Causes: []metav1.StatusCause{
 								{
@@ -649,7 +649,7 @@ func TestHandleCancelledContext(t *testing.T) {
 			Result: &metav1.Status{
 				Code:    http.StatusInternalServerError,
 				Reason:  metav1.StatusReasonInternalError,
-				Message: "preflight checks failed due to an internal error",
+				Message: "preflight checks failed due to an internal error: Test1: context cancelled; Test2: context cancelled",
 				Details: &metav1.StatusDetails{
 					Causes: []metav1.StatusCause{
 						{


### PR DESCRIPTION
**What problem does this PR solve?**:
We want individual check failures to reach users. The message field is usually propagated by API clients, whereas the details field is not, so we now summarize the information in the details field in the message field.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
