### PR TITLE
fix: return metalLB config apply conflict errors

### DIFF
--- a/pkg/handlers/lifecycle/serviceloadbalancer/metallb/handler.go
+++ b/pkg/handlers/lifecycle/serviceloadbalancer/metallb/handler.go
@@ -193,8 +193,8 @@ func (n *MetalLB) Apply(
 						err,
 					)
 
-					// Return false with no error to retry the apply.
-					return false, nil
+					// Conflicts won't resolve by retrying; return the error immediately.
+					return false, applyErr
 				default:
 					// Otherwise return the error early and do not retry.
 					return false, err


### PR DESCRIPTION
**What problem does this PR solve?**:
For MetalLB configuration, we want the Cluster resource to remain the single source of truth, meaning any manual changes made via kubectl edit should be reconciled back to the state defined in the Cluster object. To make this behavior clearer, https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/1225/ introduced more explicit user-facing messages.

However, we were also retrying on conflict errors. Since these conflicts cannot be resolved through retries alone, the retry loop continued until the Cluster API webhook request eventually timed out.

This PR makes the fix to directly return the conflicting error which will be shown instead of generic timeout that happened earlier.

**Which issue(s) this PR fixes**:
Fixes # https://jira.nutanix.com/browse/NCN-114970

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
