### PR TITLE
fix: Allow CAPA Garbage Collection to find orphaned AWS LBC resources

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/aws-load-balancer-controller/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/aws-load-balancer-controller/values-template.yaml
@@ -1,11 +1,21 @@
 # The clusterName refers the kubernetes.io/cluster/ tag on AWS resources.
 # For EKS clusters, the name will be based on the cluster's namespace + a random suffix.
 # For AWS clusters, the name will just be based on the cluster name.
+
+# The defaultTags holds tags that will be applied to all resources created by the AWS Load Balancer Controller.
+# The tag "kubernetes.io/cluster/clusterName: owned" tag is added to allow CAPA Garbage Collection to identify
+# orphaned resources created by the AWS Load Balancer Controller.
+
 {{- $capiProvider := index .Cluster.metadata.labels "cluster.x-k8s.io/provider" }}
 {{- if eq $capiProvider "eks" }}
 clusterName: "{{ .ControlPlane.spec.eksClusterName }}"
+defaultTags:
+  "kubernetes.io/cluster/{{ .ControlPlane.spec.eksClusterName }}": owned
 {{- else }}
 clusterName: "{{ .Cluster.metadata.name }}"
+defaultTags:
+  "kubernetes.io/cluster/{{ .Cluster.metadata.name }}": owned
 {{- end }}
+
 # Set this value to avoid stutter in the resource names.
 fullnameOverride: aws-load-balancer-controller


### PR DESCRIPTION
**What problem does this PR solve?**:
CAPA Garbage Collection does not find orphaned AWS LBC resources like NLBs and Security Groups, because they do not have the `kubernetes.io/cluster/clusterName: owned` tag. This PR adds this tag, allowing CAPA GC to find the resources. This is useful when the managed cluster control plane is down, and LoadBalancer Services cannot be deleted by the CAREN's BeforeClusterDelete lifecycle handler, but the user wants to delete the cluster.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
