### PR TITLE
fix: node feature discovery addon: update node affinity and tolerations

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/nfd/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/nfd/values-template.yaml
@@ -6,10 +6,8 @@ master:
     - beta.amd.com
     - amd.com
   tolerations:
-    - key: "node-role.kubernetes.io/control-plane"
-      operator: "Equal"
-      value: ""
-      effect: "NoSchedule"
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoSchedule
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -28,10 +26,18 @@ worker: ### <NFD-WORKER-CONF-START-DO-NOT-REMOVE>
           - "class"
           - "vendor"
   tolerations:
-    - effect: NoSchedule
-      operator: Exists
+    - operator: Exists
 
 gc:
   tolerations:
-    - effect: NoSchedule
-      key: node-role.kubernetes.io/control-plane
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: In
+                values: [""]

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/node-feature-discovery-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/node-feature-discovery-configmap.yaml
@@ -1167,8 +1167,7 @@ data:
           securityContext: {}
           serviceAccountName: node-feature-discovery-worker
           tolerations:
-          - effect: NoSchedule
-            operator: Exists
+          - operator: Exists
           volumes:
           - hostPath:
               path: /boot
@@ -1296,8 +1295,6 @@ data:
           tolerations:
           - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
-            operator: Equal
-            value: ""
           volumes:
           - configMap:
               items:
@@ -1333,6 +1330,16 @@ data:
             app.kubernetes.io/name: node-feature-discovery
             role: gc
         spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: In
+                    values:
+                    - ""
+                weight: 1
           containers:
           - args:
             - -gc-interval=1h


### PR DESCRIPTION
**What problem does this PR solve?**:
We want Deployments to run on the control plane nodes.

We want the DaemonSet to tolerate any taints, because it is a critical component, and we know of cases where other components that depend on NFD add taints that the DaemonSet does not currently tolerate.

This change does both.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
