### PR TITLE
fix: Adding mpio flag for metro clusters - csi

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/csi/nutanix/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/csi/nutanix/values-template.yaml
@@ -3,6 +3,7 @@ createPrismCentralSecret: false
 # Disable creating the Prism Element credentials Secret, it won't be used the CSI driver as configured here.
 createSecret: false
 pcSecretName: nutanix-csi-credentials
+applyMpioConfigs: {{ .ApplyMpioConfigs }}
 
 tolerations:
   - key: CriticalAddonsOnly

--- a/hack/tools/fetch-images/main.go
+++ b/hack/tools/fetch-images/main.go
@@ -254,8 +254,24 @@ func getValuesFileForChartIfNeeded(chartName, carenChartDirectory string) (strin
 	switch chartName {
 	case "nutanix-csi-storage":
 		// The Helm template expects the Secrets to already exist.
-		// Read the default value file and append override values to workaround this.
-		sourceValuesFile := filepath.Join(carenChartDirectory, "addons", "csi", "nutanix", defaultHelmAddonFilename)
+		// Read the default value file, render the Go template, and append override values to workaround this.
+		f := filepath.Join(carenChartDirectory, "addons", "csi", "nutanix", defaultHelmAddonFilename)
+		tempFile, err := os.CreateTemp("", "")
+		if err != nil {
+			return "", fmt.Errorf("failed to create temp file: %w", err)
+		}
+
+		templateInput := struct {
+			ApplyMpioConfigs bool
+		}{
+			ApplyMpioConfigs: false,
+		}
+
+		err = template.Must(template.New(defaultHelmAddonFilename).ParseFiles(f)).Execute(tempFile, &templateInput)
+		if err != nil {
+			return "", fmt.Errorf("failed to execute helm values template %w", err)
+		}
+
 		overrideValues := `
 createPrismCentralSecret: true
 pcUsername: admin
@@ -266,12 +282,12 @@ username: admin
 password: admin
 prismEndPoint: endpoint
 `
-		updatedValuesFile, err := getUpdatedValuesFile(sourceValuesFile, overrideValues)
+		_, err = tempFile.WriteString(overrideValues)
 		if err != nil {
-			return "", fmt.Errorf("failed to modify values file: %w", err)
+			return "", fmt.Errorf("failed to write override values to temp file: %w", err)
 		}
 
-		return updatedValuesFile.Name(), nil
+		return tempFile.Name(), nil
 	case "node-feature-discovery":
 		return filepath.Join(carenChartDirectory, "addons", "nfd", defaultHelmAddonFilename), nil
 	case "snapshot-controller":
@@ -592,31 +608,4 @@ func getImagesFromYAMLFiles(files []string) ([]string, error) {
 		}
 	}
 	return images, nil
-}
-
-// getUpdatedValuesFile reads the default values file and returns a new file with the override values appended.
-func getUpdatedValuesFile(valuesFilePath, overrideValues string) (*os.File, error) {
-	defaultValuesFile, err := os.Open(valuesFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open default values file: %w", err)
-	}
-	defer defaultValuesFile.Close()
-
-	tempFile, err := os.CreateTemp("", "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file: %w", err)
-	}
-	defer tempFile.Close()
-
-	_, err = io.Copy(tempFile, defaultValuesFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to copy default values file to temp file: %w", err)
-	}
-
-	_, err = tempFile.WriteString(overrideValues)
-	if err != nil {
-		return nil, fmt.Errorf("failed to write to temp file: %w", err)
-	}
-
-	return tempFile, nil
 }

--- a/pkg/handlers/lifecycle/csi/nutanix/handler.go
+++ b/pkg/handlers/lifecycle/csi/nutanix/handler.go
@@ -4,8 +4,11 @@
 package nutanix
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strings"
+	"text/template"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
@@ -15,11 +18,18 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	apivariables "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/variables"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/lifecycle/addons"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/lifecycle/config"
 	csiutils "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/lifecycle/csi/utils"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/options"
 	handlersutils "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/utils"
+)
+
+const (
+	metroFailureDomainPrefix     = "NutanixMetro/"
+	metroSiteFailureDomainPrefix = "NutanixMetroSite/"
 )
 
 const (
@@ -101,7 +111,7 @@ func (n *NutanixCSI) Apply(
 			n.config.helmAddonConfig,
 			n.client,
 			helmChart,
-		)
+		).WithValueTemplater(templateValuesFunc(cluster))
 	case "":
 		return fmt.Errorf("strategy not provided for Nutanix CSI driver")
 	default:
@@ -188,4 +198,65 @@ func (n *NutanixCSI) Apply(
 		return fmt.Errorf("error creating StorageClasses for the Nutanix CSI driver: %w", err)
 	}
 	return nil
+}
+
+func templateValuesFunc(
+	cluster *clusterv1.Cluster,
+) func(*clusterv1.Cluster, string) (string, error) {
+	return func(_ *clusterv1.Cluster, valuesTemplate string) (string, error) {
+		helmValuesTemplate, err := template.New("").Parse(valuesTemplate)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse Helm values template: %w", err)
+		}
+
+		type input struct {
+			ApplyMpioConfigs bool
+		}
+
+		templateInput := input{
+			ApplyMpioConfigs: isMetroCluster(cluster),
+		}
+
+		var b bytes.Buffer
+		if err = helmValuesTemplate.Execute(&b, templateInput); err != nil {
+			return "", fmt.Errorf("failed to template Nutanix CSI Helm values: %w", err)
+		}
+
+		return b.String(), nil
+	}
+}
+
+// isMetroCluster returns true when the cluster uses metro-aware failure domains,
+// i.e. any control-plane or worker failure domain references a NutanixMetro or
+// NutanixMetroSite object (identified by the respective name prefix).
+func isMetroCluster(cluster *clusterv1.Cluster) bool {
+	if !cluster.Spec.Topology.IsDefined() {
+		return false
+	}
+
+	varMap := variables.ClusterVariablesToVariablesMap(cluster.Spec.Topology.Variables)
+	clusterConfigVar, err := variables.Get[apivariables.ClusterConfigSpec](
+		varMap,
+		v1alpha1.ClusterConfigVariableName,
+	)
+	if err == nil &&
+		clusterConfigVar.ControlPlane != nil &&
+		clusterConfigVar.ControlPlane.Nutanix != nil {
+		for _, fd := range clusterConfigVar.ControlPlane.Nutanix.FailureDomains {
+			if strings.HasPrefix(fd, metroFailureDomainPrefix) ||
+				strings.HasPrefix(fd, metroSiteFailureDomainPrefix) {
+				return true
+			}
+		}
+	}
+
+	for i := range cluster.Spec.Topology.Workers.MachineDeployments {
+		fd := cluster.Spec.Topology.Workers.MachineDeployments[i].FailureDomain
+		if strings.HasPrefix(fd, metroFailureDomainPrefix) ||
+			strings.HasPrefix(fd, metroSiteFailureDomainPrefix) {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
Nutanix CSI multipath I/O (applyMpioConfigs) must be enabled on metro/VHA clusters to handle the multi-path storage access across AHV sites. 

What does this PR change?

Two files changed:

charts/.../addons/csi/nutanix/values-template.yaml - adds applyMpioConfigs: {{ .ApplyMpioConfigs }} to the CSI Helm values template so the flag can be dynamically rendered per cluster.

pkg/handlers/lifecycle/csi/nutanix/handler.go - introduces a templateValuesFunc that is wired into the CSI addon via WithValueTemplater. It:

Inspects the cluster's ClusterConfigSpec variables and MachineDeployment failure domains
Detects metro topology by checking if any failure domain name starts with NutanixMetro/ or NutanixMetroSite/
Sets ApplyMpioConfigs: true in the rendered Helm values if a metro failure domain is found; false otherwise
Result: CSI is automatically deployed with MPIO enabled on metro clusters and disabled on standard single-site clusters - no manual override needed.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
Tested locally with kind cluster

CSI HCP:
`valuesTemplate: |-
    # Disable creating the Prism Central credentials Secret, the Secret will be created by the handler.
    createPrismCentralSecret: false
    # Disable creating the Prism Element credentials Secret, it won't be used the CSI driver as configured here.
    createSecret: false
    pcSecretName: nutanix-csi-credentials
    applyMpioConfigs: true

    tolerations:
      - key: CriticalAddonsOnly
        operator: Exists
      - effect: NoExecute
        operator: Exists
        tolerationSeconds: 300
      - effect: NoSchedule
        operator: Exists`

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
