### PR TITLE
revert: remove clusterctl CAPX metadata override setup

### DIFF
--- a/make/clusterctl.mk
+++ b/make/clusterctl.mk
@@ -7,17 +7,9 @@ export CAPA_VERSION := $(shell cd hack/third-party/capa && GOWORK=off go list -m
 export CAPX_VERSION := $(shell cd hack/third-party/capx && GOWORK=off go list -m -f '{{ .Version }}' github.com/nutanix-cloud-native/cluster-api-provider-nutanix)
 export CAAPH_VERSION := $(shell cd hack/third-party/caaph && GOWORK=off go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api-addon-provider-helm)
 
-# Copy local CAPX metadata.yaml override so clusterctl accepts v1.10+ series,
-# which is missing from the public CAPX release's metadata.yaml.
-.PHONY: clusterctl.setup-capx-override
-clusterctl.setup-capx-override:
-	mkdir -p $(HOME)/.config/cluster-api/overrides/infrastructure-nutanix/$(CAPX_VERSION)
-	cp test/e2e/data/shared/capx/metadata.yaml \
-	   $(HOME)/.config/cluster-api/overrides/infrastructure-nutanix/$(CAPX_VERSION)/metadata.yaml
-
 # Leave Nutanix credentials empty here and set it when creating the clusters
 .PHONY: clusterctl.init
-clusterctl.init: clusterctl.setup-capx-override
+clusterctl.init:
 	env CLUSTER_TOPOLOGY=true \
 	    EXP_RUNTIME_SDK=true \
 	    EXP_MACHINE_POOL=true \


### PR DESCRIPTION
The clusterctl.setup-capx-override target and its dependency on clusterctl.init are no longer needed. Removing them to clean up the clusterctl initialization flow.


**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
