### PR TITLE
feat: preflight checks for metro

### DIFF
--- a/pkg/webhook/preflight/nutanix/checker.go
+++ b/pkg/webhook/preflight/nutanix/checker.go
@@ -28,6 +28,7 @@ var Checker = &nutanixChecker{
 	vmImageKubernetesVersionChecksFactory: newVMImageKubernetesVersionChecks,
 	cidrValidationChecksFactory:           newCIDRValidationChecks,
 	storageContainerChecksFactory:         newStorageContainerChecks,
+	metroChecksFactory:                    newMetroChecks,
 }
 
 type nutanixChecker struct {
@@ -67,6 +68,10 @@ type nutanixChecker struct {
 	) []preflight.Check
 
 	storageContainerChecksFactory func(
+		cd *checkDependencies,
+	) []preflight.Check
+
+	metroChecksFactory func(
 		cd *checkDependencies,
 	) []preflight.Check
 }
@@ -118,6 +123,7 @@ func (n *nutanixChecker) Init(
 		n.vmImageKubernetesVersionChecksFactory(cd),
 		n.cidrValidationChecksFactory(cd),
 		n.storageContainerChecksFactory(cd),
+		n.metroChecksFactory(cd),
 	)
 
 	return checks

--- a/pkg/webhook/preflight/nutanix/checker_test.go
+++ b/pkg/webhook/preflight/nutanix/checker_test.go
@@ -46,6 +46,7 @@ func TestNutanixChecker_Init(t *testing.T) {
 		cidrValidationCheckCount           int
 		storageContainerCheckCount         int
 		failureDomainCheckCount            int
+		metroCheckCount                    int
 	}{
 		{
 			name:                               "basic initialization with no configs",
@@ -138,6 +139,7 @@ func TestNutanixChecker_Init(t *testing.T) {
 			vmImageKubernetesVersionCheckCount := 0
 			cidrValidationCheckCount := 0
 			failureDomainCheckCount := 0
+			metroCheckCount := 0
 
 			checker.configurationCheckFactory = func(cd *checkDependencies) preflight.Check {
 				configCheckCalled = true
@@ -248,6 +250,22 @@ func TestNutanixChecker_Init(t *testing.T) {
 				return checks
 			}
 
+			checker.metroChecksFactory = func(cd *checkDependencies) []preflight.Check {
+				checks := []preflight.Check{}
+				for i := 0; i < tt.metroCheckCount; i++ {
+					metroCheckCount++
+					checks = append(checks,
+						&mockCheck{
+							name: fmt.Sprintf("NutanixMetro-%d", i),
+							result: preflight.CheckResult{
+								Allowed: true,
+							},
+						},
+					)
+				}
+				return checks
+			}
+
 			// Call Init
 			ctx := context.Background()
 			checks := checker.Init(ctx, nil, &clusterv1beta2.Cluster{
@@ -282,6 +300,12 @@ func TestNutanixChecker_Init(t *testing.T) {
 				tt.failureDomainCheckCount,
 				failureDomainCheckCount,
 				"Wrong number of failure domain checks",
+			)
+			assert.Equal(
+				t,
+				tt.metroCheckCount,
+				metroCheckCount,
+				"Wrong number of metro checks",
 			)
 
 			// Verify the first three checks when we have results
@@ -396,6 +420,9 @@ func TestNutanixChecker_PrismCentralVersionGating(t *testing.T) {
 					return nil
 				},
 				storageContainerChecksFactory: func(cd *checkDependencies) []preflight.Check {
+					return nil
+				},
+				metroChecksFactory: func(cd *checkDependencies) []preflight.Check {
 					return nil
 				},
 			}

--- a/pkg/webhook/preflight/nutanix/metro.go
+++ b/pkg/webhook/preflight/nutanix/metro.go
@@ -1,0 +1,685 @@
+// Copyright 2026 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nutanix
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	clustermgmtv4 "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	netv4 "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	capxv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/webhook/preflight"
+)
+
+const (
+	metroPrismElementCount = 2
+	nutanixMetroName       = "NutanixMetro"
+	cpFailureDomainsField  = "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.controlPlane.nutanix.failureDomains" //nolint:lll // Message is long.
+)
+
+type metroCheck struct {
+	metroName  string
+	namespace  string
+	field      string
+	kclient    ctrlclient.Client
+	nclient    client
+	errMessage *string
+}
+
+func failCheck(result *preflight.CheckResult, field, message string) {
+	result.Allowed = false
+	result.Causes = append(result.Causes, preflight.Cause{
+		Message: message,
+		Field:   field,
+	})
+}
+
+func failCheckInternal(result *preflight.CheckResult, field, message string) {
+	result.InternalError = true
+	failCheck(result, field, message)
+}
+
+func (mc *metroCheck) Name() string {
+	return nutanixMetroName
+}
+
+func newMetroChecks(cd *checkDependencies) []preflight.Check {
+	checks := []preflight.Check{}
+
+	if cd == nil || cd.kclient == nil || cd.nclient == nil || cd.pcVersion == "" {
+		return checks
+	}
+
+	// Build the set of NutanixMetro objects referenced by the Cluster
+	refs := referencedMetros(cd)
+
+	metroNames := []string{}
+	var firstField string
+	for _, ref := range refs {
+		checks = append(checks, &metroCheck{
+			metroName:  ref.metroName,
+			namespace:  cd.cluster.Namespace,
+			field:      ref.field,
+			kclient:    cd.kclient,
+			nclient:    cd.nclient,
+			errMessage: ref.errMessage,
+		})
+
+		// Only count successfully resolved metros towards the single-metro rule.
+		if ref.errMessage == nil {
+			if firstField == "" {
+				firstField = ref.field
+			}
+			metroNames = append(metroNames, ref.metroName)
+		}
+	}
+
+	// A Cluster must be backed by exactly one NutanixMetro: a metro is a
+	// two-Prism-Element relationship, so referencing more than one would make the
+	// Cluster span more than two Prism Elements.
+	if len(metroNames) > 1 {
+		checks = append(checks, &singleMetroCheck{
+			metroNames: metroNames,
+			field:      firstField,
+		})
+	}
+
+	// For a metro Cluster, all Control Plane and Worker nodes must span exactly
+	// two Prism Elements in total, across every failure domain the Cluster uses
+	// (including standalone NutanixFailureDomains that are not backed by a
+	// NutanixMetro). This catches, for example, a MachineDeployment placed on a
+	// standalone failure domain whose Prism Element is a third PE.
+	if len(metroNames) > 0 {
+		fdNames, errMessage := clusterFailureDomainNames(cd)
+		checks = append(checks, &clusterPrismElementScaleCheck{
+			failureDomainNames: fdNames,
+			namespace:          cd.cluster.Namespace,
+			field:              firstField,
+			kclient:            cd.kclient,
+			nclient:            cd.nclient,
+			errMessage:         errMessage,
+		})
+	}
+
+	return checks
+}
+
+// clusterFailureDomainNames returns the distinct NutanixFailureDomain names used
+// by the Cluster across its control plane and worker failure domains, resolving
+// NutanixMetro and NutanixMetroSite references to their underlying failure
+// domains. The returned string is a non-nil error message if any reference could
+// not be resolved.
+func clusterFailureDomainNames(cd *checkDependencies) (names []string, errMessage *string) {
+	nameSet := map[string]struct{}{}
+
+	add := func(fd string) {
+		names, err := getFailureDomainNames(cd, fd)
+		if err != nil {
+			if errMessage == nil {
+				errMessage = ptr.To(err.Error())
+			}
+			return
+		}
+		for _, n := range names {
+			if n != "" {
+				nameSet[n] = struct{}{}
+			}
+		}
+	}
+
+	forEachClusterFailureDomain(cd, func(fd, _ string) {
+		add(fd)
+	})
+
+	names = make([]string, 0, len(nameSet))
+	for n := range nameSet {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names, errMessage
+}
+
+// forEachClusterFailureDomain iterates over every non-empty failure domain
+// referenced by the Cluster's control plane and worker machine deployments.
+func forEachClusterFailureDomain(cd *checkDependencies, visit func(fd, field string)) {
+	if cd == nil || visit == nil {
+		return
+	}
+
+	if cd.nutanixClusterConfigSpec != nil &&
+		cd.nutanixClusterConfigSpec.ControlPlane != nil &&
+		cd.nutanixClusterConfigSpec.ControlPlane.Nutanix != nil {
+		for _, fd := range cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.FailureDomains {
+			if fd != "" {
+				visit(fd, cpFailureDomainsField)
+			}
+		}
+	}
+
+	if cd.cluster != nil && cd.cluster.Spec.Topology.IsDefined() {
+		for i := range cd.cluster.Spec.Topology.Workers.MachineDeployments {
+			md := &cd.cluster.Spec.Topology.Workers.MachineDeployments[i]
+			if md.FailureDomain == "" {
+				continue
+			}
+			visit(md.FailureDomain, fmt.Sprintf(
+				"$.spec.topology.workers.machineDeployments[?@.name==%q].failureDomain",
+				md.Name,
+			))
+		}
+	}
+}
+
+// clusterPrismElementScaleCheck enforces that a metro Cluster's Control Plane and
+// Worker nodes span exactly two distinct Prism Elements in total, across every
+// failure domain the Cluster uses.
+type clusterPrismElementScaleCheck struct {
+	failureDomainNames []string
+	namespace          string
+	field              string
+	kclient            ctrlclient.Client
+	nclient            client
+	errMessage         *string
+}
+
+func (c *clusterPrismElementScaleCheck) Name() string {
+	return nutanixMetroName
+}
+
+func (c *clusterPrismElementScaleCheck) Run(ctx context.Context) preflight.CheckResult {
+	result := preflight.CheckResult{Allowed: true}
+
+	if c.errMessage != nil {
+		failCheck(&result, c.field, fmt.Sprintf(
+			"Failed to determine the Prism Elements the Cluster spans: %s",
+			*c.errMessage,
+		))
+		return result
+	}
+
+	peUUIDs := map[string]struct{}{}
+	for _, fdName := range c.failureDomainNames {
+		peUUID, err := failureDomainPrismElementUUID(ctx, c.kclient, c.nclient, c.namespace, fdName)
+		if err != nil {
+			// The specific failure domain is validated in detail by other checks;
+			// here we only report that the span could not be computed.
+			failCheckInternal(&result, c.field, fmt.Sprintf(
+				"Failed to determine the Prism Element of Failure Domain %q used by the Cluster: %s. This is usually a temporary error. Please retry.", //nolint:lll // Message is long.
+				fdName,
+				err,
+			))
+			return result
+		}
+		peUUIDs[peUUID] = struct{}{}
+	}
+
+	if len(peUUIDs) != metroPrismElementCount {
+		failCheck(&result, c.field, fmt.Sprintf(
+			"The Cluster's Control Plane and Worker nodes must span exactly %d distinct Prism Elements in a metro configuration, but they span %d across failure domains %s. Ensure all nodes are placed on the two Prism Elements of a single NutanixMetro.", //nolint:lll // Message is long.
+			metroPrismElementCount,
+			len(peUUIDs),
+			strings.Join(c.failureDomainNames, ", "),
+		))
+	}
+
+	return result
+}
+
+// failureDomainPrismElementUUID resolves the Prism Element UUID of a single
+// NutanixFailureDomain by name.
+func failureDomainPrismElementUUID(
+	ctx context.Context,
+	kclient ctrlclient.Client,
+	nclient client,
+	namespace string,
+	fdName string,
+) (string, error) {
+	fdObj := &capxv1.NutanixFailureDomain{}
+	fdKey := ctrlclient.ObjectKey{Name: fdName, Namespace: namespace}
+	if err := kclient.Get(ctx, fdKey, fdObj); err != nil {
+		return "", fmt.Errorf("failed to get NutanixFailureDomain %q: %w", fdName, err)
+	}
+
+	peIdentifier := fdObj.Spec.PrismElementCluster
+	peClusters, err := getClusters(ctx, nclient, &peIdentifier)
+	if err != nil {
+		return "", fmt.Errorf("failed to get Prism Element cluster %q: %w", peIdentifier, err)
+	}
+	if len(peClusters) != 1 {
+		return "", fmt.Errorf(
+			"found %d Prism Element cluster(s) matching identifier %q, expected exactly 1",
+			len(peClusters),
+			peIdentifier,
+		)
+	}
+	if peClusters[0].ExtId == nil {
+		return "", fmt.Errorf("no ExtId returned for Prism Element cluster %q", peIdentifier)
+	}
+	return *peClusters[0].ExtId, nil
+}
+
+// singleMetroCheck enforces that a Cluster references at most one NutanixMetro.
+type singleMetroCheck struct {
+	metroNames []string
+	field      string
+}
+
+func (c *singleMetroCheck) Name() string {
+	return nutanixMetroName
+}
+
+func (c *singleMetroCheck) Run(_ context.Context) preflight.CheckResult {
+	result := preflight.CheckResult{Allowed: true}
+
+	if len(c.metroNames) > 1 {
+		names := append([]string(nil), c.metroNames...)
+		sort.Strings(names)
+		failCheck(&result, c.field, fmt.Sprintf(
+			"A Cluster may reference at most one NutanixMetro, but it references %d: %s. Control Plane and Worker nodes in a metro configuration must span exactly two Prism Elements from a single NutanixMetro.", //nolint:lll // Message is long.
+			len(names),
+			strings.Join(names, ", "),
+		))
+	}
+
+	return result
+}
+
+// metroReference identifies a NutanixMetro referenced by the Cluster and the
+// topology field that referenced it.
+type metroReference struct {
+	metroName  string
+	field      string
+	errMessage *string
+}
+
+// referencedMetros returns the distinct NutanixMetro objects referenced by the
+// Cluster's control plane and worker failure domains.
+func referencedMetros(cd *checkDependencies) []metroReference {
+	seen := map[string]struct{}{}
+	refs := []metroReference{}
+
+	addMetro := func(fd, field string) {
+		metroName, err := metroNameFromFailureDomain(cd, fd)
+		if err != nil {
+			// Surface the resolution error through a check so the user sees it.
+			key := "err:" + fd
+			if _, ok := seen[key]; ok {
+				return
+			}
+			seen[key] = struct{}{}
+			cd.log.Error(err, fmt.Sprintf("failed to resolve NutanixMetro for failureDomain %s", fd))
+			refs = append(refs, metroReference{
+				metroName:  fd,
+				field:      field,
+				errMessage: ptr.To(err.Error()),
+			})
+			return
+		}
+		if metroName == "" {
+			return
+		}
+		if _, ok := seen[metroName]; ok {
+			return
+		}
+		seen[metroName] = struct{}{}
+		refs = append(refs, metroReference{metroName: metroName, field: field})
+	}
+
+	forEachClusterFailureDomain(cd, addMetro)
+
+	return refs
+}
+
+// metroNameFromFailureDomain resolves the NutanixMetro name referenced by a
+// failure domain string. It returns an empty name (and nil error) for failure
+// domains that are not backed by a NutanixMetro.
+func metroNameFromFailureDomain(cd *checkDependencies, fd string) (string, error) {
+	ctx := context.TODO()
+	namespace := cd.cluster.Namespace
+
+	switch {
+	case isNutanixMetroFailureDomain(fd):
+		return fd[len(metroFailureDomainPrefix):], nil
+	case isNutanixMetroSiteFailureDomain(fd):
+		metroSiteName := fd[len(metroSiteFailureDomainPrefix):]
+		metroSiteObj := &capxv1.NutanixMetroSite{}
+		key := ctrlclient.ObjectKey{Name: metroSiteName, Namespace: namespace}
+		if err := cd.kclient.Get(ctx, key, metroSiteObj); err != nil {
+			return "", fmt.Errorf(
+				"failed to fetch the NutanixMetroSite %s referenced by failureDomain %s: %w",
+				metroSiteName,
+				fd,
+				err,
+			)
+		}
+		return metroSiteObj.Spec.MetroRef.Name, nil
+	default:
+		return "", nil
+	}
+}
+
+func (mc *metroCheck) Run(ctx context.Context) preflight.CheckResult {
+	result := preflight.CheckResult{Allowed: true}
+
+	if mc.errMessage != nil {
+		failCheck(&result, mc.field, fmt.Sprintf("Failed to check NutanixMetro %q: %s", mc.metroName, *mc.errMessage))
+		return result
+	}
+
+	metroObj, ok := mc.getMetro(ctx, &result)
+	if !ok {
+		return result
+	}
+
+	// Resolve each failure domain to its Prism Element and the network layer of
+	// its subnets. peUUIDs de-duplicates Prism Elements so that two failure
+	// domains pointing at the same PE are detected. subnetAttrs collects the
+	// distinct network attributes (layer, VLAN ID/VNI and CIDR) observed across
+	// all failure-domain subnets.
+	subnetAttrs := newMetroSubnetAttributes()
+	peUUIDs, ok := mc.evaluateFailureDomains(ctx, metroObj, subnetAttrs, &result)
+	if !ok {
+		return result
+	}
+
+	// Guardrail: PE scale limit. The metro's failure domains must span exactly
+	// two distinct Prism Elements.
+	if len(peUUIDs) != metroPrismElementCount {
+		failCheck(&result, mc.field, fmt.Sprintf(
+			"NutanixMetro %q must span exactly %d distinct Prism Elements, but its failure domains resolve to %d. Control Plane and Worker nodes in a metro configuration must span exactly two Prism Elements.", //nolint:lll // Message is long.
+			mc.metroName,
+			metroPrismElementCount,
+			len(peUUIDs),
+		))
+	}
+
+	// Guardrail: network/subnet consistency. Subnets across the failure domains
+	// must reside on the same network layer (all VLAN-tagged, or all Overlay),
+	// and on the same network (same VLAN ID/VNI and same CIDR).
+	mc.checkSubnetConsistency(subnetAttrs, &result)
+
+	return result
+}
+
+func (mc *metroCheck) getMetro(ctx context.Context, result *preflight.CheckResult) (*capxv1.NutanixMetro, bool) {
+	metroObj := &capxv1.NutanixMetro{}
+	metroKey := ctrlclient.ObjectKey{Name: mc.metroName, Namespace: mc.namespace}
+	if err := mc.kclient.Get(ctx, metroKey, metroObj); err != nil {
+		if errors.IsNotFound(err) {
+			failCheck(result, mc.field, fmt.Sprintf(
+				"NutanixMetro %q was not found in the management cluster. Please create it and retry.",
+				mc.metroName,
+			))
+			return nil, false
+		}
+		failCheckInternal(result, mc.field, fmt.Sprintf(
+			"Failed to get NutanixMetro %q: %s. This is usually a temporary error. Please retry.",
+			mc.metroName,
+			err,
+		))
+		return nil, false
+	}
+	return metroObj, true
+}
+
+func (mc *metroCheck) evaluateFailureDomains(
+	ctx context.Context,
+	metroObj *capxv1.NutanixMetro,
+	subnetAttrs *metroSubnetAttributes,
+	result *preflight.CheckResult,
+) (map[string]struct{}, bool) {
+	peUUIDs := map[string]struct{}{}
+	for _, fdRef := range metroObj.Spec.FailureDomains {
+		if fdRef.Name == "" {
+			continue
+		}
+
+		fdObj, ok := mc.getFailureDomain(ctx, fdRef.Name, result)
+		if !ok {
+			return nil, false
+		}
+
+		peCluster, ok := mc.resolvePrismElement(ctx, fdObj, fdRef.Name, result)
+		if !ok {
+			return nil, false
+		}
+		peUUID := *peCluster.ExtId
+		peUUIDs[peUUID] = struct{}{}
+
+		if !mc.collectSubnetAttributes(ctx, fdObj, fdRef.Name, peUUID, subnetAttrs, result) {
+			return nil, false
+		}
+	}
+
+	return peUUIDs, true
+}
+
+func (mc *metroCheck) getFailureDomain(
+	ctx context.Context,
+	fdName string,
+	result *preflight.CheckResult,
+) (*capxv1.NutanixFailureDomain, bool) {
+	fdObj := &capxv1.NutanixFailureDomain{}
+	fdKey := ctrlclient.ObjectKey{Name: fdName, Namespace: mc.namespace}
+	if err := mc.kclient.Get(ctx, fdKey, fdObj); err != nil {
+		if errors.IsNotFound(err) {
+			failCheck(result, mc.field, fmt.Sprintf(
+				"NutanixFailureDomain %q referenced by NutanixMetro %q was not found in the management cluster. Please create it and retry.", //nolint:lll // Message is long.
+				fdName,
+				mc.metroName,
+			))
+			return nil, false
+		}
+		failCheckInternal(result, mc.field, fmt.Sprintf(
+			"Failed to get NutanixFailureDomain %q referenced by NutanixMetro %q: %s. This is usually a temporary error. Please retry.", //nolint:lll // Message is long.
+			fdName,
+			mc.metroName,
+			err,
+		))
+		return nil, false
+	}
+
+	return fdObj, true
+}
+
+// resolvePrismElement resolves the single Prism Element cluster for a failure
+// domain. It appends a cause and returns ok=false when resolution fails.
+func (mc *metroCheck) resolvePrismElement(
+	ctx context.Context,
+	fdObj *capxv1.NutanixFailureDomain,
+	fdName string,
+	result *preflight.CheckResult,
+) (*clustermgmtv4.Cluster, bool) {
+	peIdentifier := fdObj.Spec.PrismElementCluster
+	peClusters, err := getClusters(ctx, mc.nclient, &peIdentifier)
+	if err != nil {
+		failCheckInternal(result, mc.field, fmt.Sprintf(
+			"Failed to check the Prism Element cluster %q referenced by Failure Domain %q of NutanixMetro %q: %s. This is usually a temporary error. Please retry.", //nolint:lll // Message is long.
+			peIdentifier,
+			fdName,
+			mc.metroName,
+			err,
+		))
+		return nil, false
+	}
+	if len(peClusters) != 1 {
+		failCheck(result, mc.field, fmt.Sprintf(
+			"Found %d Prism Element cluster(s) that match identifier %q referenced by Failure Domain %q of NutanixMetro %q. There must be exactly 1 Cluster that matches this identifier.", //nolint:lll // Message is long.
+			len(peClusters),
+			peIdentifier,
+			fdName,
+			mc.metroName,
+		))
+		return nil, false
+	}
+	if peClusters[0].ExtId == nil {
+		failCheckInternal(result, mc.field, fmt.Sprintf(
+			"The Prism Element cluster %q referenced by Failure Domain %q of NutanixMetro %q was returned without an ExtId. This is usually a temporary error. Please retry.", //nolint:lll // Message is long.
+			peIdentifier,
+			fdName,
+			mc.metroName,
+		))
+		return nil, false
+	}
+	return &peClusters[0], true
+}
+
+// metroSubnetAttributes accumulates the distinct network attributes observed
+// across all subnets of a NutanixMetro's failure domains.
+type metroSubnetAttributes struct {
+	// layers holds the distinct network layer names (VLAN, OVERLAY, ...).
+	layers map[string]struct{}
+	// profilesByFailureDomain holds subnet profile sets keyed by failure domain.
+	profilesByFailureDomain map[string]map[string]struct{}
+}
+
+func newMetroSubnetAttributes() *metroSubnetAttributes {
+	return &metroSubnetAttributes{
+		layers:                  map[string]struct{}{},
+		profilesByFailureDomain: map[string]map[string]struct{}{},
+	}
+}
+
+// collectSubnetAttributes records the network attributes of each subnet
+// referenced by a failure domain into attrs. It appends a cause and returns
+// false on a non-recoverable error.
+func (mc *metroCheck) collectSubnetAttributes(
+	ctx context.Context,
+	fdObj *capxv1.NutanixFailureDomain,
+	fdName string,
+	peUUID string,
+	attrs *metroSubnetAttributes,
+	result *preflight.CheckResult,
+) bool {
+	for _, id := range fdObj.Spec.Subnets {
+		subnets, err := getSubnets(ctx, mc.nclient, &id)
+		if err != nil {
+			failCheckInternal(result, mc.field, fmt.Sprintf(
+				"Failed to get subnet %q referenced by Failure Domain %q of NutanixMetro %q: %s. This is usually a temporary error. Please retry.", //nolint:lll // Message is long.
+				id,
+				fdName,
+				mc.metroName,
+				err,
+			))
+			return false
+		}
+
+		// Valid subnets either belong to this failure domain's PE, or are overlay
+		// subnets with no cluster reference.
+		for i := range subnets {
+			s := &subnets[i]
+			if s.ClusterReference != nil && *s.ClusterReference != peUUID {
+				continue
+			}
+			profile := subnetProfileKey(s)
+			attrs.layers[subnetLayerName(s.SubnetType)] = struct{}{}
+			if _, ok := attrs.profilesByFailureDomain[fdName]; !ok {
+				attrs.profilesByFailureDomain[fdName] = map[string]struct{}{}
+			}
+			attrs.profilesByFailureDomain[fdName][profile] = struct{}{}
+		}
+	}
+	return true
+}
+
+// checkSubnetConsistency verifies that all observed subnets reside on the same
+// supported network layer (VLAN-tagged or Overlay), and that every failure
+// domain has the same set of subnet profiles (layer + VLAN/VNI + CIDR).
+func (mc *metroCheck) checkSubnetConsistency(attrs *metroSubnetAttributes, result *preflight.CheckResult) {
+	if len(attrs.layers) == 0 {
+		return
+	}
+
+	if len(attrs.layers) > 1 {
+		failCheck(result, mc.field, fmt.Sprintf(
+			"Subnets across the failure domains of NutanixMetro %q reside on multiple network layers (%s). All subnets must reside on the same network layer (either VLAN-tagged or Overlay) to support synchronous metro replication.", //nolint:lll // Message is long.
+			mc.metroName,
+			strings.Join(sortedKeys(attrs.layers), ", "),
+		))
+		return
+	}
+
+	layer := sortedKeys(attrs.layers)[0]
+	if layer != subnetLayerName(netv4.SUBNETTYPE_VLAN.Ref()) &&
+		layer != subnetLayerName(netv4.SUBNETTYPE_OVERLAY.Ref()) {
+		failCheck(result, mc.field, fmt.Sprintf(
+			"Subnets of NutanixMetro %q reside on an unsupported network layer %q. Metro configurations support only VLAN-tagged or Overlay subnets.", //nolint:lll // Message is long.
+			mc.metroName,
+			layer,
+		))
+		return
+	}
+
+	if !equalSubnetProfileSets(attrs.profilesByFailureDomain) {
+		failCheck(result, mc.field, fmt.Sprintf(
+			"Subnets across the failure domains of NutanixMetro %q do not match. Each failure domain must expose the same set of subnet profiles (layer, VLAN ID/VNI, CIDR) to support synchronous metro replication.", //nolint:lll // Message is long.
+			mc.metroName,
+		))
+	}
+}
+
+func subnetProfileKey(s *netv4.Subnet) string {
+	layer := subnetLayerName(s.SubnetType)
+	vlanID := ""
+	cidr := ""
+	if s.NetworkId != nil {
+		vlanID = strconv.Itoa(*s.NetworkId)
+	}
+	if s.IpPrefix != nil {
+		cidr = *s.IpPrefix
+	}
+	return fmt.Sprintf("%s|%s|%s", layer, vlanID, cidr)
+}
+
+func equalSubnetProfileSets(profilesByFD map[string]map[string]struct{}) bool {
+	var baseline map[string]struct{}
+	for _, profiles := range profilesByFD {
+		if baseline == nil {
+			baseline = profiles
+			continue
+		}
+		if !stringSetEqual(baseline, profiles) {
+			return false
+		}
+	}
+	return true
+}
+
+func stringSetEqual(a, b map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// subnetLayerName returns a stable, human-readable network layer name for a
+// subnet type, treating a nil type as UNKNOWN.
+func subnetLayerName(t *netv4.SubnetType) string {
+	if t == nil {
+		return "UNKNOWN"
+	}
+	return t.GetName()
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/webhook/preflight/nutanix/metro.go
+++ b/pkg/webhook/preflight/nutanix/metro.go
@@ -386,8 +386,8 @@ func (mc *metroCheck) Run(ctx context.Context) preflight.CheckResult {
 	// distinct network attributes (layer, VLAN ID/VNI and CIDR) observed across
 	// all failure-domain subnets.
 	subnetAttrs := newMetroSubnetAttributes()
-	peUUIDs, ok := mc.evaluateFailureDomains(ctx, metroObj, subnetAttrs, &result)
-	if !ok {
+	peUUIDs := mc.evaluateFailureDomains(ctx, metroObj, subnetAttrs, &result)
+	if !result.Allowed {
 		return result
 	}
 
@@ -436,7 +436,7 @@ func (mc *metroCheck) evaluateFailureDomains(
 	metroObj *capxv1.NutanixMetro,
 	subnetAttrs *metroSubnetAttributes,
 	result *preflight.CheckResult,
-) (map[string]struct{}, bool) {
+) map[string]struct{} {
 	peUUIDs := map[string]struct{}{}
 	for _, fdRef := range metroObj.Spec.FailureDomains {
 		if fdRef.Name == "" {
@@ -445,22 +445,22 @@ func (mc *metroCheck) evaluateFailureDomains(
 
 		fdObj, ok := mc.getFailureDomain(ctx, fdRef.Name, result)
 		if !ok {
-			return nil, false
+			continue
 		}
 
 		peCluster, ok := mc.resolvePrismElement(ctx, fdObj, fdRef.Name, result)
 		if !ok {
-			return nil, false
+			continue
 		}
 		peUUID := *peCluster.ExtId
 		peUUIDs[peUUID] = struct{}{}
 
 		if !mc.collectSubnetAttributes(ctx, fdObj, fdRef.Name, peUUID, subnetAttrs, result) {
-			return nil, false
+			continue
 		}
 	}
 
-	return peUUIDs, true
+	return peUUIDs
 }
 
 func (mc *metroCheck) getFailureDomain(

--- a/pkg/webhook/preflight/nutanix/metro_test.go
+++ b/pkg/webhook/preflight/nutanix/metro_test.go
@@ -1,0 +1,541 @@
+// Copyright 2026 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nutanix
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	clustermgmtv4 "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	netv4 "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	capxv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+	carenv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+)
+
+const (
+	metroName    = "metro-1"
+	metroFD1     = "metro-fd-1"
+	metroFD2     = "metro-fd-2"
+	metroPE1UUID = "metro-pe-1-uuid"
+	metroPE2UUID = "metro-pe-2-uuid"
+	metroSubnet1 = "metro-subnet-1-uuid"
+	metroSubnet2 = "metro-subnet-2-uuid"
+	metroSubnet3 = "metro-subnet-3-uuid"
+	metroSubnet4 = "metro-subnet-4-uuid"
+)
+
+// metroScheme returns a scheme with the CAPX types registered.
+func metroScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(capxv1.AddToScheme(scheme))
+	return scheme
+}
+
+// newMetroFailureDomain builds a NutanixFailureDomain referencing a PE and one
+// or more subnets, all identified by UUID.
+func newMetroFailureDomain(name, peUUID string, subnetUUIDs ...string) *capxv1.NutanixFailureDomain {
+	subnets := make([]capxv1.NutanixResourceIdentifier, 0, len(subnetUUIDs))
+	for _, subnetUUID := range subnetUUIDs {
+		subnets = append(subnets, capxv1.NutanixResourceIdentifier{
+			Type: capxv1.NutanixIdentifierUUID,
+			UUID: ptr.To(subnetUUID),
+		})
+	}
+
+	return &capxv1.NutanixFailureDomain{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: capxv1.NutanixFailureDomainSpec{
+			PrismElementCluster: capxv1.NutanixResourceIdentifier{
+				Type: capxv1.NutanixIdentifierUUID,
+				UUID: ptr.To(peUUID),
+			},
+			Subnets: subnets,
+		},
+	}
+}
+
+// newMetroObject builds a NutanixMetro referencing two failure domains.
+func newMetroObject(name, fd1, fd2 string) *capxv1.NutanixMetro {
+	return &capxv1.NutanixMetro{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: capxv1.NutanixMetroSpec{
+			FailureDomains: []corev1.LocalObjectReference{
+				{Name: fd1},
+				{Name: fd2},
+			},
+		},
+	}
+}
+
+// metroSubnetSpec describes the network attributes a mocked subnet should carry.
+type metroSubnetSpec struct {
+	subnetType netv4.SubnetType
+	networkID  *int
+	cidr       *string
+}
+
+// metroNClient builds a mock Nutanix client that returns a PE cluster for each
+// PE UUID and a subnet (with the given network attributes) for each subnet UUID.
+func metroNClient(subnets map[string]metroSubnetSpec) *clientWrapper {
+	return &clientWrapper{
+		GetClusterByIdFunc: func(
+			ctx context.Context,
+			uuid *string,
+			args ...map[string]any,
+		) (*clustermgmtv4.GetClusterApiResponse, error) {
+			cluster := clustermgmtv4.NewCluster()
+			cluster.ExtId = uuid
+			cluster.Name = uuid
+			resp := &clustermgmtv4.GetClusterApiResponse{
+				ObjectType_: ptr.To("clustermgmt.v4.config.GetClusterApiResponse"),
+			}
+			if err := resp.SetData(*cluster); err != nil {
+				return nil, err
+			}
+			return resp, nil
+		},
+		GetSubnetByIdFunc: func(
+			ctx context.Context,
+			uuid *string,
+			args ...map[string]any,
+		) (*netv4.GetSubnetApiResponse, error) {
+			spec := subnets[*uuid]
+			subnet := netv4.NewSubnet()
+			subnet.ExtId = uuid
+			subnet.Name = uuid
+			subnet.SubnetType = spec.subnetType.Ref()
+			subnet.NetworkId = spec.networkID
+			subnet.IpPrefix = spec.cidr
+			resp := &netv4.GetSubnetApiResponse{
+				ObjectType_: ptr.To("networking.v4.config.GetSubnetApiResponse"),
+			}
+			if err := resp.SetData(*subnet); err != nil {
+				return nil, err
+			}
+			return resp, nil
+		},
+	}
+}
+
+func TestNewMetroChecks(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		nutanixClusterConfigSpec *carenv1.NutanixClusterConfigSpec
+		machineDeployments       []clusterv1beta2.MachineDeploymentTopology
+		objects                  []ctrlclient.Object
+		nclient                  client
+		expectedChecksCount      int
+	}{
+		{
+			name:                "client not initialized",
+			nclient:             nil,
+			expectedChecksCount: 0,
+		},
+		{
+			name: "non-metro control plane failure domain",
+			nutanixClusterConfigSpec: &carenv1.NutanixClusterConfigSpec{
+				ControlPlane: &carenv1.NutanixControlPlaneSpec{
+					Nutanix: &carenv1.NutanixControlPlaneNodeSpec{
+						FailureDomains: []string{"plain-fd"},
+					},
+				},
+			},
+			nclient:             &clientWrapper{},
+			expectedChecksCount: 0,
+		},
+		{
+			name: "metro control plane failure domain",
+			nutanixClusterConfigSpec: &carenv1.NutanixClusterConfigSpec{
+				ControlPlane: &carenv1.NutanixControlPlaneSpec{
+					Nutanix: &carenv1.NutanixControlPlaneNodeSpec{
+						FailureDomains: []string{metroFailureDomainPrefix + metroName},
+					},
+				},
+			},
+			nclient: &clientWrapper{},
+			// 1 per-metro check + 1 cluster PE-scale check.
+			expectedChecksCount: 2,
+		},
+		{
+			name: "same metro referenced by control plane and worker is de-duplicated",
+			nutanixClusterConfigSpec: &carenv1.NutanixClusterConfigSpec{
+				ControlPlane: &carenv1.NutanixControlPlaneSpec{
+					Nutanix: &carenv1.NutanixControlPlaneNodeSpec{
+						FailureDomains: []string{metroFailureDomainPrefix + metroName},
+					},
+				},
+			},
+			machineDeployments: []clusterv1beta2.MachineDeploymentTopology{{
+				Name:          "md-1",
+				FailureDomain: metroFailureDomainPrefix + metroName,
+			}},
+			nclient: &clientWrapper{},
+			// 1 per-metro check + 1 cluster PE-scale check.
+			expectedChecksCount: 2,
+		},
+		{
+			name: "two distinct metros add a single-metro check",
+			nutanixClusterConfigSpec: &carenv1.NutanixClusterConfigSpec{
+				ControlPlane: &carenv1.NutanixControlPlaneSpec{
+					Nutanix: &carenv1.NutanixControlPlaneNodeSpec{
+						FailureDomains: []string{metroFailureDomainPrefix + metroName},
+					},
+				},
+			},
+			machineDeployments: []clusterv1beta2.MachineDeploymentTopology{{
+				Name:          "md-1",
+				FailureDomain: metroFailureDomainPrefix + "metro-2",
+			}},
+			nclient: &clientWrapper{},
+			// 2 per-metro checks + 1 single-metro check + 1 cluster PE-scale check.
+			expectedChecksCount: 4,
+		},
+		{
+			name: "metro site failure domain resolves to its metro",
+			machineDeployments: []clusterv1beta2.MachineDeploymentTopology{{
+				Name:          "md-1",
+				FailureDomain: metroSiteFailureDomainPrefix + "site-1",
+			}},
+			objects: []ctrlclient.Object{
+				&capxv1.NutanixMetroSite{
+					ObjectMeta: metav1.ObjectMeta{Name: "site-1", Namespace: namespace},
+					Spec: capxv1.NutanixMetroSiteSpec{
+						MetroRef:               corev1.LocalObjectReference{Name: metroName},
+						PreferredFailureDomain: corev1.LocalObjectReference{Name: metroFD1},
+					},
+				},
+			},
+			nclient: &clientWrapper{},
+			// 1 per-metro check + 1 cluster PE-scale check.
+			expectedChecksCount: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(metroScheme())
+			if len(tc.objects) > 0 {
+				builder = builder.WithObjects(tc.objects...)
+			}
+			kclient := builder.Build()
+
+			cd := &checkDependencies{
+				nutanixClusterConfigSpec: tc.nutanixClusterConfigSpec,
+				cluster: &clusterv1beta2.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace},
+					Spec: clusterv1beta2.ClusterSpec{
+						Topology: clusterv1beta2.Topology{
+							Workers: clusterv1beta2.WorkersTopology{
+								MachineDeployments: tc.machineDeployments,
+							},
+						},
+					},
+				},
+				nclient:   tc.nclient,
+				pcVersion: "7.3.0",
+				log:       logr.Discard(),
+			}
+			if tc.nclient != nil {
+				cd.kclient = kclient
+			}
+
+			checks := newMetroChecks(cd)
+			assert.Len(t, checks, tc.expectedChecksCount)
+		})
+	}
+}
+
+func TestMetroCheck(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		objects               []ctrlclient.Object
+		nclient               client
+		expectedAllowed       bool
+		expectedInternalError bool
+		expectedCauseMessage  string
+	}{
+		{
+			name:                 "metro not found",
+			objects:              nil,
+			nclient:              &clientWrapper{},
+			expectedAllowed:      false,
+			expectedCauseMessage: "was not found",
+		},
+		{
+			name: "valid metro spanning two PEs with consistent VLAN subnets",
+			objects: []ctrlclient.Object{
+				newMetroObject(metroName, metroFD1, metroFD2),
+				newMetroFailureDomain(metroFD1, metroPE1UUID, metroSubnet1),
+				newMetroFailureDomain(metroFD2, metroPE2UUID, metroSubnet2),
+			},
+			nclient: metroNClient(map[string]metroSubnetSpec{
+				metroSubnet1: {subnetType: netv4.SUBNETTYPE_VLAN, networkID: ptr.To(100), cidr: ptr.To("10.0.0.0/24")},
+				metroSubnet2: {subnetType: netv4.SUBNETTYPE_VLAN, networkID: ptr.To(100), cidr: ptr.To("10.0.0.0/24")},
+			}),
+			expectedAllowed: true,
+		},
+		{
+			name: "failure domains resolve to the same PE",
+			objects: []ctrlclient.Object{
+				newMetroObject(metroName, metroFD1, metroFD2),
+				newMetroFailureDomain(metroFD1, metroPE1UUID, metroSubnet1),
+				newMetroFailureDomain(metroFD2, metroPE1UUID, metroSubnet2),
+			},
+			nclient: metroNClient(map[string]metroSubnetSpec{
+				metroSubnet1: {subnetType: netv4.SUBNETTYPE_VLAN},
+				metroSubnet2: {subnetType: netv4.SUBNETTYPE_VLAN},
+			}),
+			expectedAllowed:      false,
+			expectedCauseMessage: "must span exactly 2 distinct Prism Elements",
+		},
+		{
+			name: "subnets reside on different network layers",
+			objects: []ctrlclient.Object{
+				newMetroObject(metroName, metroFD1, metroFD2),
+				newMetroFailureDomain(metroFD1, metroPE1UUID, metroSubnet1),
+				newMetroFailureDomain(metroFD2, metroPE2UUID, metroSubnet2),
+			},
+			nclient: metroNClient(map[string]metroSubnetSpec{
+				metroSubnet1: {subnetType: netv4.SUBNETTYPE_VLAN},
+				metroSubnet2: {subnetType: netv4.SUBNETTYPE_OVERLAY},
+			}),
+			expectedAllowed:      false,
+			expectedCauseMessage: "reside on multiple network layers",
+		},
+		{
+			name: "multiple subnets per FD with matching subnet sets are allowed",
+			objects: []ctrlclient.Object{
+				newMetroObject(metroName, metroFD1, metroFD2),
+				newMetroFailureDomain(metroFD1, metroPE1UUID, metroSubnet1, metroSubnet2),
+				newMetroFailureDomain(metroFD2, metroPE2UUID, metroSubnet3, metroSubnet4),
+			},
+			nclient: metroNClient(map[string]metroSubnetSpec{
+				metroSubnet1: {subnetType: netv4.SUBNETTYPE_VLAN, networkID: ptr.To(100), cidr: ptr.To("10.0.0.0/24")},
+				metroSubnet2: {subnetType: netv4.SUBNETTYPE_VLAN, networkID: ptr.To(200), cidr: ptr.To("10.0.1.0/24")},
+				metroSubnet3: {subnetType: netv4.SUBNETTYPE_VLAN, networkID: ptr.To(100), cidr: ptr.To("10.0.0.0/24")},
+				metroSubnet4: {subnetType: netv4.SUBNETTYPE_VLAN, networkID: ptr.To(200), cidr: ptr.To("10.0.1.0/24")},
+			}),
+			expectedAllowed: true,
+		},
+		{
+			name: "subnet sets differ across failure domains",
+			objects: []ctrlclient.Object{
+				newMetroObject(metroName, metroFD1, metroFD2),
+				newMetroFailureDomain(metroFD1, metroPE1UUID, metroSubnet1, metroSubnet2),
+				newMetroFailureDomain(metroFD2, metroPE2UUID, metroSubnet3, metroSubnet4),
+			},
+			nclient: metroNClient(map[string]metroSubnetSpec{
+				metroSubnet1: {subnetType: netv4.SUBNETTYPE_VLAN, networkID: ptr.To(100), cidr: ptr.To("10.0.0.0/24")},
+				metroSubnet2: {subnetType: netv4.SUBNETTYPE_VLAN, networkID: ptr.To(200), cidr: ptr.To("10.0.1.0/24")},
+				metroSubnet3: {subnetType: netv4.SUBNETTYPE_VLAN, networkID: ptr.To(100), cidr: ptr.To("10.0.0.0/24")},
+				metroSubnet4: {subnetType: netv4.SUBNETTYPE_VLAN, networkID: ptr.To(300), cidr: ptr.To("10.0.2.0/24")},
+			}),
+			expectedAllowed:      false,
+			expectedCauseMessage: "do not match",
+		},
+		{
+			name: "prism element returned without ExtId",
+			objects: []ctrlclient.Object{
+				newMetroObject(metroName, metroFD1, metroFD2),
+				newMetroFailureDomain(metroFD1, metroPE1UUID, metroSubnet1),
+				newMetroFailureDomain(metroFD2, metroPE2UUID, metroSubnet2),
+			},
+			nclient: &clientWrapper{
+				GetClusterByIdFunc: func(
+					ctx context.Context,
+					uuid *string,
+					args ...map[string]any,
+				) (*clustermgmtv4.GetClusterApiResponse, error) {
+					cluster := clustermgmtv4.NewCluster()
+					cluster.Name = uuid
+					// ExtId intentionally left nil.
+					resp := &clustermgmtv4.GetClusterApiResponse{
+						ObjectType_: ptr.To("clustermgmt.v4.config.GetClusterApiResponse"),
+					}
+					if err := resp.SetData(*cluster); err != nil {
+						return nil, err
+					}
+					return resp, nil
+				},
+			},
+			expectedAllowed:       false,
+			expectedInternalError: true,
+			expectedCauseMessage:  "without an ExtId",
+		},
+		{
+			name: "referenced failure domain not found",
+			objects: []ctrlclient.Object{
+				newMetroObject(metroName, metroFD1, metroFD2),
+				newMetroFailureDomain(metroFD1, metroPE1UUID, metroSubnet1),
+			},
+			nclient: metroNClient(map[string]metroSubnetSpec{
+				metroSubnet1: {subnetType: netv4.SUBNETTYPE_VLAN},
+			}),
+			expectedAllowed:      false,
+			expectedCauseMessage: "was not found",
+		},
+	}
+
+	ctx := context.TODO()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(metroScheme())
+			if len(tc.objects) > 0 {
+				builder = builder.WithObjects(tc.objects...)
+			}
+			kclient := builder.Build()
+
+			check := &metroCheck{
+				metroName: metroName,
+				namespace: namespace,
+				field:     field,
+				kclient:   kclient,
+				nclient:   tc.nclient,
+			}
+
+			result := check.Run(ctx)
+
+			assert.Equal(t, tc.expectedAllowed, result.Allowed)
+			assert.Equal(t, tc.expectedInternalError, result.InternalError)
+			if tc.expectedCauseMessage != "" {
+				require.NotEmpty(t, result.Causes)
+				assert.Contains(t, result.Causes[0].Message, tc.expectedCauseMessage)
+				assert.Equal(t, field, result.Causes[0].Field)
+			} else {
+				assert.Empty(t, result.Causes)
+			}
+		})
+	}
+}
+
+func TestSingleMetroCheck(t *testing.T) {
+	testCases := []struct {
+		name            string
+		metroNames      []string
+		expectedAllowed bool
+	}{
+		{
+			name:            "single metro is allowed",
+			metroNames:      []string{metroName},
+			expectedAllowed: true,
+		},
+		{
+			name:            "multiple metros are rejected",
+			metroNames:      []string{metroName, "metro-2"},
+			expectedAllowed: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			check := &singleMetroCheck{metroNames: tc.metroNames, field: field}
+			result := check.Run(context.TODO())
+
+			assert.Equal(t, tc.expectedAllowed, result.Allowed)
+			if !tc.expectedAllowed {
+				require.NotEmpty(t, result.Causes)
+				assert.Contains(t, result.Causes[0].Message, "at most one NutanixMetro")
+				assert.Equal(t, field, result.Causes[0].Field)
+			} else {
+				assert.Empty(t, result.Causes)
+			}
+		})
+	}
+}
+
+func TestMetroCheckErrMessage(t *testing.T) {
+	check := &metroCheck{
+		metroName:  metroName,
+		namespace:  namespace,
+		field:      field,
+		errMessage: ptr.To("boom"),
+	}
+
+	result := check.Run(context.TODO())
+
+	assert.False(t, result.Allowed)
+	require.NotEmpty(t, result.Causes)
+	assert.Contains(t, result.Causes[0].Message, "boom")
+}
+
+func TestClusterPrismElementScaleCheck(t *testing.T) {
+	const metroFD3 = "metro-fd-3"
+
+	testCases := []struct {
+		name                 string
+		failureDomainNames   []string
+		objects              []ctrlclient.Object
+		errMessage           *string
+		expectedAllowed      bool
+		expectedCauseMessage string
+	}{
+		{
+			name:                 "resolution error message is surfaced",
+			errMessage:           ptr.To("boom"),
+			expectedAllowed:      false,
+			expectedCauseMessage: "boom",
+		},
+		{
+			name:               "cluster spanning exactly two Prism Elements is allowed",
+			failureDomainNames: []string{metroFD1, metroFD2},
+			objects: []ctrlclient.Object{
+				newMetroFailureDomain(metroFD1, metroPE1UUID, metroSubnet1),
+				newMetroFailureDomain(metroFD2, metroPE2UUID, metroSubnet2),
+			},
+			expectedAllowed: true,
+		},
+		{
+			name:               "cluster spanning three Prism Elements is rejected",
+			failureDomainNames: []string{metroFD1, metroFD2, metroFD3},
+			objects: []ctrlclient.Object{
+				newMetroFailureDomain(metroFD1, metroPE1UUID, metroSubnet1),
+				newMetroFailureDomain(metroFD2, metroPE2UUID, metroSubnet2),
+				newMetroFailureDomain(metroFD3, "metro-pe-3-uuid", "metro-subnet-3-uuid"),
+			},
+			expectedAllowed:      false,
+			expectedCauseMessage: "must span exactly 2 distinct Prism Elements",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(metroScheme())
+			if len(tc.objects) > 0 {
+				builder = builder.WithObjects(tc.objects...)
+			}
+			kclient := builder.Build()
+
+			check := &clusterPrismElementScaleCheck{
+				failureDomainNames: tc.failureDomainNames,
+				namespace:          namespace,
+				field:              field,
+				kclient:            kclient,
+				nclient:            metroNClient(map[string]metroSubnetSpec{}),
+				errMessage:         tc.errMessage,
+			}
+
+			result := check.Run(context.TODO())
+
+			assert.Equal(t, tc.expectedAllowed, result.Allowed)
+			if !tc.expectedAllowed {
+				require.NotEmpty(t, result.Causes)
+				assert.Contains(t, result.Causes[0].Message, tc.expectedCauseMessage)
+			} else {
+				assert.Empty(t, result.Causes)
+			}
+		})
+	}
+}

--- a/pkg/webhook/preflight/nutanix/metro_test.go
+++ b/pkg/webhook/preflight/nutanix/metro_test.go
@@ -266,6 +266,7 @@ func TestMetroCheck(t *testing.T) {
 		expectedAllowed       bool
 		expectedInternalError bool
 		expectedCauseMessage  string
+		expectedCauseCount    int
 	}{
 		{
 			name:                 "metro not found",
@@ -273,6 +274,7 @@ func TestMetroCheck(t *testing.T) {
 			nclient:              &clientWrapper{},
 			expectedAllowed:      false,
 			expectedCauseMessage: "was not found",
+			expectedCauseCount:   1,
 		},
 		{
 			name: "valid metro spanning two PEs with consistent VLAN subnets",
@@ -300,6 +302,7 @@ func TestMetroCheck(t *testing.T) {
 			}),
 			expectedAllowed:      false,
 			expectedCauseMessage: "must span exactly 2 distinct Prism Elements",
+			expectedCauseCount:   1,
 		},
 		{
 			name: "subnets reside on different network layers",
@@ -314,6 +317,7 @@ func TestMetroCheck(t *testing.T) {
 			}),
 			expectedAllowed:      false,
 			expectedCauseMessage: "reside on multiple network layers",
+			expectedCauseCount:   1,
 		},
 		{
 			name: "multiple subnets per FD with matching subnet sets are allowed",
@@ -345,6 +349,7 @@ func TestMetroCheck(t *testing.T) {
 			}),
 			expectedAllowed:      false,
 			expectedCauseMessage: "do not match",
+			expectedCauseCount:   1,
 		},
 		{
 			name: "prism element returned without ExtId",
@@ -374,6 +379,7 @@ func TestMetroCheck(t *testing.T) {
 			expectedAllowed:       false,
 			expectedInternalError: true,
 			expectedCauseMessage:  "without an ExtId",
+			expectedCauseCount:    2,
 		},
 		{
 			name: "referenced failure domain not found",
@@ -386,6 +392,17 @@ func TestMetroCheck(t *testing.T) {
 			}),
 			expectedAllowed:      false,
 			expectedCauseMessage: "was not found",
+			expectedCauseCount:   1,
+		},
+		{
+			name: "accumulates errors across all metro failure domains",
+			objects: []ctrlclient.Object{
+				newMetroObject(metroName, metroFD1, metroFD2),
+			},
+			nclient:              &clientWrapper{},
+			expectedAllowed:      false,
+			expectedCauseMessage: "was not found",
+			expectedCauseCount:   2,
 		},
 	}
 
@@ -414,6 +431,9 @@ func TestMetroCheck(t *testing.T) {
 				require.NotEmpty(t, result.Causes)
 				assert.Contains(t, result.Causes[0].Message, tc.expectedCauseMessage)
 				assert.Equal(t, field, result.Causes[0].Field)
+				if tc.expectedCauseCount > 0 {
+					assert.Len(t, result.Causes, tc.expectedCauseCount)
+				}
 			} else {
 				assert.Empty(t, result.Causes)
 			}


### PR DESCRIPTION
This change adds Nutanix Metro-specific preflight validations to prevent invalid
cluster topology and networking combinations from passing admission. The checks
validate Metro object references, Prism Element placement boundaries, and subnet
consistency requirements needed for synchronous metro replication.

## Preflight checks added

- **Referenced Metro must exist and be readable**
  - Validates that each referenced `NutanixMetro` object exists.
  - Returns user-facing validation errors for missing objects.
  - Returns internal/retryable errors for transient API failures.

- **Cluster may reference at most one Metro**
  - Detects Metro references across control plane and worker failure domains.
  - Rejects configurations that resolve to more than one `NutanixMetro`.

- **Cluster-wide Prism Element span must be exactly two**
  - Resolves all failure domains used by control plane and workers.
  - Rejects if the cluster spans anything other than exactly two distinct Prism
    Elements for metro configuration.

- **Metro failure domains must resolve correctly**
  - Resolves `NutanixMetro` and `NutanixMetroSite` style failure-domain refs.
  - Validates referenced `NutanixFailureDomain` objects are present.
  - Validates each failure domain maps to exactly one Prism Element cluster with
    a valid `ExtId`.

- **Metro subnet consistency across failure domains**
  - Allows multiple subnets per failure domain.
  - Ensures all referenced subnets are on one supported layer only (`VLAN` or
    `Overlay`).
  - Rejects mixed network layers across the metro failure domains.
  - Enforces subnet-set equality across failure domains.
  - Requires each failure domain to expose the same subnet profiles (layer,
    VLAN ID/VNI, CIDR), while still allowing multiple subnet entries.

## Test plan

- `go test ./pkg/webhook/preflight/nutanix/...`
- Validate negative scenarios covered by metro unit tests:
  - missing Metro/MetroSite/FailureDomain references
  - multiple Metro references in one cluster
  - Prism Element count not equal to two
  - unsupported or mixed subnet layers
  - mismatched VLAN ID/VNI or CIDR across metro failure domains
- Validate positive scenario where referenced Metro topology is consistent and
  preflight checks are allowed.

Refer this doc for how this PR was tested: https://docs.google.com/document/d/1s2mZdpGfV6wTHigfbhXHrhe3uxOjXfXGafUna3amXQU/edit?usp=sharing