### PR TITLE
feat: Enforce all node pools use metro failure domains

### DIFF
--- a/pkg/webhook/preflight/nutanix/metro.go
+++ b/pkg/webhook/preflight/nutanix/metro.go
@@ -135,10 +135,113 @@ func newMetroChecks(cd *checkDependencies) []preflight.Check {
 				nclient:            cd.nclient,
 				errMessage:         errMessage,
 			},
+			// Every Control Plane and Worker node pool must be placed on a
+			// metro failure domain: otherwise only some node pools would be
+			// protected by synchronous replication and the Cluster would be
+			// only partially HA at the infrastructure level.
+			&allNodePoolsMetroCheck{
+				nodePools: clusterNodePools(cd),
+				field:     firstField,
+			},
 		)
 	}
 
 	return checks
+}
+
+// nodePool describes a single Control Plane or Worker node pool and the failure
+// domains it is configured with. failureDomains is empty when the node pool has
+// no failure domain configured.
+type nodePool struct {
+	description    string
+	failureDomains []string
+	field          string
+}
+
+// clusterNodePools enumerates every Control Plane and Worker node pool of the
+// Cluster, preserving node pools that have no failure domain configured (which
+// forEachClusterFailureDomain intentionally skips).
+func clusterNodePools(cd *checkDependencies) []nodePool {
+	pools := []nodePool{}
+	if cd == nil {
+		return pools
+	}
+
+	if cd.nutanixClusterConfigSpec != nil &&
+		cd.nutanixClusterConfigSpec.ControlPlane != nil &&
+		cd.nutanixClusterConfigSpec.ControlPlane.Nutanix != nil {
+		fds := []string{}
+		for _, fd := range cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.FailureDomains {
+			if fd != "" {
+				fds = append(fds, fd)
+			}
+		}
+		pools = append(pools, nodePool{
+			description:    "The Control Plane",
+			failureDomains: fds,
+			field:          cpFailureDomainsField,
+		})
+	}
+
+	if cd.cluster != nil && cd.cluster.Spec.Topology.IsDefined() {
+		for i := range cd.cluster.Spec.Topology.Workers.MachineDeployments {
+			md := &cd.cluster.Spec.Topology.Workers.MachineDeployments[i]
+			fds := []string{}
+			if md.FailureDomain != "" {
+				fds = append(fds, md.FailureDomain)
+			}
+			pools = append(pools, nodePool{
+				description:    fmt.Sprintf("Worker MachineDeployment %q", md.Name),
+				failureDomains: fds,
+				field: fmt.Sprintf(
+					"$.spec.topology.workers.machineDeployments[?@.name==%q].failureDomain",
+					md.Name,
+				),
+			})
+		}
+	}
+
+	return pools
+}
+
+// allNodePoolsMetroCheck enforces that, when the Cluster uses metro, every
+// Control Plane and Worker node pool is configured with a NutanixMetro or
+// NutanixMetroSite failure domain. This prevents a partially-protected Cluster
+// where only some node pools benefit from synchronous replication.
+type allNodePoolsMetroCheck struct {
+	nodePools []nodePool
+	field     string
+}
+
+func (c *allNodePoolsMetroCheck) Name() string {
+	return nutanixMetroName
+}
+
+func (c *allNodePoolsMetroCheck) Run(_ context.Context) preflight.CheckResult {
+	result := preflight.CheckResult{Allowed: true}
+
+	for _, np := range c.nodePools {
+		if len(np.failureDomains) == 0 {
+			failCheck(&result, np.field, fmt.Sprintf(
+				"%s is not configured with a failure domain. In a metro configuration, every Control Plane and Worker node pool must be placed on a NutanixMetro or NutanixMetroSite failure domain so that all nodes are protected by synchronous replication. Configure it with a NutanixMetro or NutanixMetroSite failure domain and retry.", //nolint:lll // Message is long.
+				np.description,
+			))
+			continue
+		}
+
+		for _, fd := range np.failureDomains {
+			if isNutanixMetroFailureDomain(fd) || isNutanixMetroSiteFailureDomain(fd) {
+				continue
+			}
+			failCheck(&result, np.field, fmt.Sprintf(
+				"%s uses failure domain %q, which is not a NutanixMetro or NutanixMetroSite failure domain. In a metro configuration, every Control Plane and Worker node pool must be placed on a NutanixMetro or NutanixMetroSite failure domain so that all nodes are protected by synchronous replication. Use a NutanixMetro or NutanixMetroSite failure domain and retry.", //nolint:lll // Message is long.
+				np.description,
+				fd,
+			))
+		}
+	}
+
+	return result
 }
 
 // clusterFailureDomainNames returns the distinct NutanixFailureDomain names used

--- a/pkg/webhook/preflight/nutanix/metro_test.go
+++ b/pkg/webhook/preflight/nutanix/metro_test.go
@@ -167,8 +167,8 @@ func TestNewMetroChecks(t *testing.T) {
 			},
 			nclient: &clientWrapper{},
 			// 1 per-metro check + 1 cluster PE-scale check + 1 PC-hosting check
-			// + 1 latency check.
-			expectedChecksCount: 4,
+			// + 1 latency check + 1 all-node-pools check.
+			expectedChecksCount: 5,
 		},
 		{
 			name: "same metro referenced by control plane and worker is de-duplicated",
@@ -185,8 +185,8 @@ func TestNewMetroChecks(t *testing.T) {
 			}},
 			nclient: &clientWrapper{},
 			// 1 per-metro check + 1 cluster PE-scale check + 1 PC-hosting check
-			// + 1 latency check.
-			expectedChecksCount: 4,
+			// + 1 latency check + 1 all-node-pools check.
+			expectedChecksCount: 5,
 		},
 		{
 			name: "two distinct metros add a single-metro check",
@@ -203,8 +203,8 @@ func TestNewMetroChecks(t *testing.T) {
 			}},
 			nclient: &clientWrapper{},
 			// 2 per-metro checks + 1 single-metro check + 1 cluster PE-scale check
-			// + 1 PC-hosting check + 1 latency check.
-			expectedChecksCount: 6,
+			// + 1 PC-hosting check + 1 latency check + 1 all-node-pools check.
+			expectedChecksCount: 7,
 		},
 		{
 			name: "metro site failure domain resolves to its metro",
@@ -223,8 +223,8 @@ func TestNewMetroChecks(t *testing.T) {
 			},
 			nclient: &clientWrapper{},
 			// 1 per-metro check + 1 cluster PE-scale check + 1 PC-hosting check
-			// + 1 latency check.
-			expectedChecksCount: 4,
+			// + 1 latency check + 1 all-node-pools check.
+			expectedChecksCount: 5,
 		},
 	}
 
@@ -476,6 +476,85 @@ func TestSingleMetroCheck(t *testing.T) {
 			} else {
 				assert.Empty(t, result.Causes)
 			}
+		})
+	}
+}
+
+func TestAllNodePoolsMetroCheck(t *testing.T) {
+	metroFD := metroFailureDomainPrefix + metroName
+	metroSiteFD := metroSiteFailureDomainPrefix + "site-1"
+
+	testCases := []struct {
+		name                 string
+		nodePools            []nodePool
+		expectedAllowed      bool
+		expectedCauseCount   int
+		expectedCauseMessage string
+	}{
+		{
+			name: "all node pools on metro failure domains are allowed",
+			nodePools: []nodePool{
+				{description: "The Control Plane", failureDomains: []string{metroFD}, field: field},
+				{description: `Worker MachineDeployment "md-1"`, failureDomains: []string{metroSiteFD}, field: field},
+			},
+			expectedAllowed: true,
+		},
+		{
+			name: "worker on a plain failure domain is rejected",
+			nodePools: []nodePool{
+				{description: "The Control Plane", failureDomains: []string{metroFD}, field: field},
+				{description: `Worker MachineDeployment "md-1"`, failureDomains: []string{"plain-fd"}, field: field},
+			},
+			expectedAllowed:      false,
+			expectedCauseCount:   1,
+			expectedCauseMessage: "is not a NutanixMetro or NutanixMetroSite failure domain",
+		},
+		{
+			name: "worker with no failure domain is rejected",
+			nodePools: []nodePool{
+				{description: "The Control Plane", failureDomains: []string{metroFD}, field: field},
+				{description: `Worker MachineDeployment "md-1"`, failureDomains: []string{}, field: field},
+			},
+			expectedAllowed:      false,
+			expectedCauseCount:   1,
+			expectedCauseMessage: "is not configured with a failure domain",
+		},
+		{
+			name: "control plane with no failure domain is rejected",
+			nodePools: []nodePool{
+				{description: "The Control Plane", failureDomains: []string{}, field: field},
+				{description: `Worker MachineDeployment "md-1"`, failureDomains: []string{metroFD}, field: field},
+			},
+			expectedAllowed:      false,
+			expectedCauseCount:   1,
+			expectedCauseMessage: "is not configured with a failure domain",
+		},
+		{
+			name: "multiple violations are all reported",
+			nodePools: []nodePool{
+				{description: "The Control Plane", failureDomains: []string{}, field: field},
+				{description: `Worker MachineDeployment "md-1"`, failureDomains: []string{"plain-fd"}, field: field},
+			},
+			expectedAllowed:    false,
+			expectedCauseCount: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			check := &allNodePoolsMetroCheck{nodePools: tc.nodePools, field: field}
+			result := check.Run(context.TODO())
+
+			assert.Equal(t, tc.expectedAllowed, result.Allowed)
+			if tc.expectedAllowed {
+				assert.Empty(t, result.Causes)
+				return
+			}
+			require.Len(t, result.Causes, tc.expectedCauseCount)
+			if tc.expectedCauseMessage != "" {
+				assert.Contains(t, result.Causes[0].Message, tc.expectedCauseMessage)
+			}
+			assert.Equal(t, field, result.Causes[0].Field)
 		})
 	}
 }


### PR DESCRIPTION
- When a Cluster uses metro (references at least one `NutanixMetro`/
  `NutanixMetroSite` failure domain), a new preflight check now requires
  **every** Control Plane and Worker node pool to be placed on a
  `NutanixMetro`/`NutanixMetroSite` failure domain.
- Rejects mixed configurations that would leave some node pools without
  synchronous-replication protection, so a "metro cluster" is fully HA at the
  infrastructure level rather than partially protected.
- Purely structural check (no Prism Central API calls); only runs when metro is
  already in use, so non-metro clusters are unaffected.

## Behavior

- Metro not used anywhere: no change; the check is not emitted.
- Metro used, all node pools on metro/metroSite FDs: allowed.
- Metro used, a node pool on a plain FD: rejected, cause names the node pool and
  the failure domain.
- Metro used, a node pool with no FD: rejected, cause names the node pool.

## Notes

- Policy is **strict**: both Control Plane and Workers must be metro.