### PR TITLE
feat: dockerhub nutanix - Don't trim org prefix for dockerhub nutanix, always wire credential provider

### DIFF
--- a/api/v1alpha1/clusterconfig_types.go
+++ b/api/v1alpha1/clusterconfig_types.go
@@ -320,6 +320,10 @@ type GenericClusterConfigSpec struct {
 	GlobalImageRegistryMirror *GlobalImageRegistryMirror `json:"globalImageRegistryMirror,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=true
+	WireImageCredentialProviderByDefault *bool `json:"wireImageCredentialProviderByDefault,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxItems=32
 	Users []User `json:"users,omitempty"`
 

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -39,6 +39,14 @@ const (
 	GlobalMirrorVariableName = "globalImageRegistryMirror"
 	// ImageRegistriesVariableName is the image registries patch variable name.
 	ImageRegistriesVariableName = "imageRegistries"
+	// WireImageCredentialProviderByDefaultVariableName is the patch variable name for
+	// the flag that wires the kubelet dynamic credential provider on every node even
+	// when no registry/mirror is configured.
+	WireImageCredentialProviderByDefaultVariableName = "wireImageCredentialProviderByDefault"
+
+	// DefaultKubeletCredentialProviderRegistryURL is the registry the credential
+	// provider is wired for by default (Docker Hub) when no registry/mirror is set.
+	DefaultKubeletCredentialProviderRegistryURL = "https://registry-1.docker.io"
 
 	// DNSVariableName is the DNS external patch variable name.
 	DNSVariableName = "dns"

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -42,11 +42,11 @@ const (
 	// WireImageCredentialProviderByDefaultVariableName is the patch variable name for
 	// the flag that wires the kubelet dynamic credential provider on every node even
 	// when no registry/mirror is configured.
-	WireImageCredentialProviderByDefaultVariableName = "wireImageCredentialProviderByDefault"
+	WireImageCredentialProviderByDefaultVariableName = "wireImageCredentialProviderByDefault" //nolint:gosec // Not a credential; a patch variable name.
 
 	// DefaultKubeletCredentialProviderRegistryURL is the registry the credential
 	// provider is wired for by default (Docker Hub) when no registry/mirror is set.
-	DefaultKubeletCredentialProviderRegistryURL = "https://registry-1.docker.io"
+	DefaultKubeletCredentialProviderRegistryURL = "https://registry-1.docker.io" //nolint:gosec // Not a credential; a registry URL.
 
 	// DNSVariableName is the DNS external patch variable name.
 	DNSVariableName = "dns"

--- a/api/v1alpha1/crds/caren.nutanix.com_awsclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_awsclusterconfigs.yaml
@@ -1160,6 +1160,9 @@ spec:
                     type: object
                   maxItems: 32
                   type: array
+                wireImageCredentialProviderByDefault:
+                  default: true
+                  type: boolean
               type: object
           type: object
       served: true

--- a/api/v1alpha1/crds/caren.nutanix.com_dockerclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_dockerclusterconfigs.yaml
@@ -951,6 +951,9 @@ spec:
                     type: object
                   maxItems: 32
                   type: array
+                wireImageCredentialProviderByDefault:
+                  default: true
+                  type: boolean
               type: object
           type: object
       served: true

--- a/api/v1alpha1/crds/caren.nutanix.com_eksclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_eksclusterconfigs.yaml
@@ -546,6 +546,9 @@ spec:
                     type: object
                   maxItems: 32
                   type: array
+                wireImageCredentialProviderByDefault:
+                  default: true
+                  type: boolean
               type: object
           type: object
       served: true

--- a/api/v1alpha1/crds/caren.nutanix.com_genericclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_genericclusterconfigs.yaml
@@ -191,6 +191,9 @@ spec:
                     type: object
                   maxItems: 32
                   type: array
+                wireImageCredentialProviderByDefault:
+                  default: true
+                  type: boolean
               type: object
           type: object
       served: true

--- a/api/v1alpha1/crds/caren.nutanix.com_nutanixclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_nutanixclusterconfigs.yaml
@@ -1305,6 +1305,9 @@ spec:
                     type: object
                   maxItems: 32
                   type: array
+                wireImageCredentialProviderByDefault:
+                  default: true
+                  type: boolean
               type: object
           type: object
       served: true

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -10,7 +10,7 @@ package v1alpha1
 import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -10,7 +10,7 @@ package v1alpha1
 import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1414,6 +1414,11 @@ func (in *GenericClusterConfigSpec) DeepCopyInto(out *GenericClusterConfigSpec) 
 		in, out := &in.GlobalImageRegistryMirror, &out.GlobalImageRegistryMirror
 		*out = new(GlobalImageRegistryMirror)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.WireImageCredentialProviderByDefault != nil {
+		in, out := &in.WireImageCredentialProviderByDefault, &out.WireImageCredentialProviderByDefault
+		*out = new(bool)
+		**out = **in
 	}
 	if in.Users != nil {
 		in, out := &in.Users, &out.Users

--- a/pkg/handlers/generic/mutation/generic/imageregistries/credentials/credentials_secret.go
+++ b/pkg/handlers/generic/mutation/generic/imageregistries/credentials/credentials_secret.go
@@ -106,16 +106,24 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 			return "", fmt.Errorf("failed parsing registry URL: %w", err)
 		}
 
+		// Org-scoped keying (host + path, e.g. registry-1.docker.io/nutanix) is
+		// applied ONLY to NKP's own docker.io/nutanix org.
+		pathPrefix := strings.TrimRight(registryURL.Path, "/")
+		if !isDockerHubNutanixOrgURL(registryURL.Host, pathPrefix) {
+			pathPrefix = ""
+		}
+
 		inputs = append(inputs, templateInput{
-			RegistryHost: registryURL.Host,
+			RegistryHost: registryURL.Host + pathPrefix,
 			Username:     config.Username,
 			Password:     config.Password,
 		})
 
-		// Preserve special handling of "registry-1.docker.io" and add "docker.io" as an alias.
+		// Preserve special handling of "registry-1.docker.io" and add "docker.io"
+		// as an alias, carrying the same org/path prefix.
 		if registryURL.Host == "registry-1.docker.io" {
 			inputs = append(inputs, templateInput{
-				RegistryHost: "docker.io",
+				RegistryHost: "docker.io" + pathPrefix,
 				Username:     config.Username,
 				Password:     config.Password,
 			})
@@ -133,6 +141,10 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 	}
 
 	return strings.TrimSpace(b.String()), nil
+}
+
+func isDockerHubNutanixOrgURL(host, pathPrefix string) bool {
+	return (host == "registry-1.docker.io" || host == "docker.io") && pathPrefix == "/nutanix"
 }
 
 func configsRequireStaticCredentials(configs []providerConfig) bool {

--- a/pkg/handlers/generic/mutation/generic/imageregistries/credentials/credentials_secret_test.go
+++ b/pkg/handlers/generic/mutation/generic/imageregistries/credentials/credentials_secret_test.go
@@ -182,6 +182,72 @@ func Test_kubeletStaticCredentialProviderSecretContents(t *testing.T) {
 }`,
 		},
 		{
+			name: "org-scoped 'registry-1.docker.io/nutanix', expect host+path keys plus docker.io alias",
+			configs: []providerConfig{
+				{
+					URL:      "https://registry-1.docker.io/nutanix",
+					Username: "myuser",
+					Password: "mypassword",
+				},
+			},
+			wantContents: `{
+  "kind":"CredentialProviderResponse",
+  "apiVersion":"credentialprovider.kubelet.k8s.io/v1",
+  "cacheKeyType":"Image",
+  "cacheDuration":"0s",
+  "auth":{
+    "registry-1.docker.io/nutanix": {"username": "myuser", "password": "mypassword"},
+    "docker.io/nutanix": {"username": "myuser", "password": "mypassword"}
+  }
+}`,
+		},
+		{
+			name: "org-scoped nutanix coexists with a customer host-only docker.io entry",
+			configs: []providerConfig{
+				{
+					URL:      "https://registry-1.docker.io",
+					Username: "customer",
+					Password: "customerpass",
+				},
+				{
+					URL:      "https://registry-1.docker.io/nutanix",
+					Username: "nutanix",
+					Password: "nutanixpass",
+				},
+			},
+			wantContents: `{
+  "kind":"CredentialProviderResponse",
+  "apiVersion":"credentialprovider.kubelet.k8s.io/v1",
+  "cacheKeyType":"Image",
+  "cacheDuration":"0s",
+  "auth":{
+    "registry-1.docker.io": {"username": "customer", "password": "customerpass"},
+    "docker.io": {"username": "customer", "password": "customerpass"},
+    "registry-1.docker.io/nutanix": {"username": "nutanix", "password": "nutanixpass"},
+    "docker.io/nutanix": {"username": "nutanix", "password": "nutanixpass"}
+  }
+}`,
+		},
+		{
+			name: "non-nutanix registry with a path stays host-only",
+			configs: []providerConfig{
+				{
+					URL:      "https://myregistry.com/myorg",
+					Username: "myuser",
+					Password: "mypassword",
+				},
+			},
+			wantContents: `{
+  "kind":"CredentialProviderResponse",
+  "apiVersion":"credentialprovider.kubelet.k8s.io/v1",
+  "cacheKeyType":"Image",
+  "cacheDuration":"0s",
+  "auth":{
+    "myregistry.com": {"username": "myuser", "password": "mypassword"}
+  }
+}`,
+		},
+		{
 			name: "multiple configs with some static credentials, expect a string with multiple entries",
 			configs: []providerConfig{
 				{

--- a/pkg/handlers/generic/mutation/generic/imageregistries/credentials/inject.go
+++ b/pkg/handlers/generic/mutation/generic/imageregistries/credentials/inject.go
@@ -89,9 +89,6 @@ func (h *imageRegistriesPatchHandler) Mutate(
 	)
 
 	switch {
-	case variables.IsNotFoundError(imageRegistriesErr) && variables.IsNotFoundError(globalMirrorErr):
-		log.V(5).Info("Image Registry Credentials and Global Registry Mirror variable not defined")
-		return nil
 	case imageRegistriesErr != nil && !variables.IsNotFoundError(imageRegistriesErr):
 		return imageRegistriesErr
 	case globalMirrorErr != nil && !variables.IsNotFoundError(globalMirrorErr):
@@ -139,8 +136,23 @@ func (h *imageRegistriesPatchHandler) Mutate(
 		return err
 	}
 	if len(registriesThatNeedConfiguration) == 0 {
-		log.V(5).Info("Image registry credentials are not needed")
-		return nil
+		// Nothing the user configured needs a credential provider. Unless the
+		// cluster opts out, still wire the kubelet dynamic credential provider for
+		// Docker Hub with an empty on-node credential file, so that Day-2 credential
+		// delivery (e.g. rotating the on-node file) needs no node roll.
+		wireByDefault, wireErr := wireCredentialProviderByDefault(vars)
+		if wireErr != nil {
+			return wireErr
+		}
+		if !wireByDefault {
+			log.V(5).Info("Image registry credentials are not needed")
+			return nil
+		}
+		log.V(5).Info("Wiring kubelet dynamic credential provider for Docker Hub with empty credentials")
+		registriesThatNeedConfiguration = append(
+			registriesThatNeedConfiguration,
+			providerConfig{URL: v1alpha1.DefaultKubeletCredentialProviderRegistryURL},
+		)
 	}
 
 	files, commands, generateErr := generateFilesAndCommands(
@@ -244,6 +256,24 @@ func (h *imageRegistriesPatchHandler) Mutate(
 	}
 
 	return nil
+}
+
+// wireCredentialProviderByDefault reports whether the kubelet dynamic credential
+// provider should be wired even when no image registry or mirror is configured.
+// It defaults to true when the variable is unset so the behavior is on-by-default
+func wireCredentialProviderByDefault(vars map[string]apiextensionsv1.JSON) (bool, error) {
+	wire, err := variables.Get[bool](
+		vars,
+		v1alpha1.ClusterConfigVariableName,
+		v1alpha1.WireImageCredentialProviderByDefaultVariableName,
+	)
+	if err != nil {
+		if variables.IsNotFoundError(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return wire, nil
 }
 
 func ensureOwnerReferenceOnCredentialsSecrets(

--- a/pkg/handlers/generic/mutation/generic/imageregistries/credentials/inject.go
+++ b/pkg/handlers/generic/mutation/generic/imageregistries/credentials/inject.go
@@ -260,7 +260,7 @@ func (h *imageRegistriesPatchHandler) Mutate(
 
 // wireCredentialProviderByDefault reports whether the kubelet dynamic credential
 // provider should be wired even when no image registry or mirror is configured.
-// It defaults to true when the variable is unset so the behavior is on-by-default
+// It defaults to true when the variable is unset so the behavior is on-by-default.
 func wireCredentialProviderByDefault(vars map[string]apiextensionsv1.JSON) (bool, error) {
 	wire, err := variables.Get[bool](
 		vars,

--- a/pkg/handlers/generic/mutation/generic/imageregistries/credentials/inject_test.go
+++ b/pkg/handlers/generic/mutation/generic/imageregistries/credentials/inject_test.go
@@ -192,8 +192,17 @@ var _ = Describe("Generate Image registry patches", func() {
 		expectOwnerReferenceOnSecrets bool
 	}{
 		{
+			// With no registry/mirror configured and the wire-by-default knob
+			// explicitly disabled, the handler is a no-op (legacy behavior).
 			PatchTestDef: capitest.PatchTestDef{
-				Name: "unset variable",
+				Name: "no registries and wiring opted out",
+				Vars: []runtimehooksv1.Variable{
+					capitest.VariableWithValue(
+						v1alpha1.ClusterConfigVariableName,
+						false,
+						v1alpha1.WireImageCredentialProviderByDefaultVariableName,
+					),
+				},
 			},
 		},
 		{

--- a/pkg/handlers/v5/generic/mutation/generic/imageregistries/credentials/credentials_secret.go
+++ b/pkg/handlers/v5/generic/mutation/generic/imageregistries/credentials/credentials_secret.go
@@ -106,16 +106,26 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 			return "", fmt.Errorf("failed parsing registry URL: %w", err)
 		}
 
+		// Org-scoped keying (host + path, e.g. registry-1.docker.io/nutanix) is
+		// applied ONLY to NKP's own docker.io/nutanix org; every other registry
+		// keeps the original host-only key to limit blast radius.
+		trimmedPath := strings.TrimRight(registryURL.Path, "/")
+		pathPrefix := ""
+		if isDockerHubNutanixOrgURL(registryURL.Host, trimmedPath) {
+			pathPrefix = trimmedPath
+		}
+
 		inputs = append(inputs, templateInput{
-			RegistryHost: registryURL.Host,
+			RegistryHost: registryURL.Host + pathPrefix,
 			Username:     config.Username,
 			Password:     config.Password,
 		})
 
-		// Preserve special handling of "registry-1.docker.io" and add "docker.io" as an alias.
+		// Preserve special handling of "registry-1.docker.io" and add "docker.io"
+		// as an alias, carrying the same org/path prefix.
 		if registryURL.Host == "registry-1.docker.io" {
 			inputs = append(inputs, templateInput{
-				RegistryHost: "docker.io",
+				RegistryHost: "docker.io" + pathPrefix,
 				Username:     config.Username,
 				Password:     config.Password,
 			})
@@ -133,6 +143,10 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 	}
 
 	return strings.TrimSpace(b.String()), nil
+}
+
+func isDockerHubNutanixOrgURL(host, pathPrefix string) bool {
+	return (host == "registry-1.docker.io" || host == "docker.io") && pathPrefix == "/nutanix"
 }
 
 func configsRequireStaticCredentials(configs []providerConfig) bool {


### PR DESCRIPTION
**What problem does this PR solve?**:

- Do not trim org prefix for Dockerhub Nutanix registry. This is so that it can co-exist with customer's existing registry (which could also be docker.io).
- Always wire credential provider (Dynamic-credential-provider). This is to remove an edge case where dynamic-credential-provider may not be configured and we can't configure dockerhub creds during upgrade. 

**Which issue(s) this PR fixes**:
Fixes # https://jira.nutanix.com/browse/NCN-115992

**How Has This Been Tested?**:
Pushed CAREN image with these changes to Harbor, updated CAREN build on management cluster, and rotated the new nodes to verify the above. 

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
