### PR TITLE
feat: Dockerhub Integration - Don't trim org prefix for Dockerhub Nutanix registry

### DIFF
--- a/pkg/handlers/generic/mutation/generic/imageregistries/credentials/credentials_secret.go
+++ b/pkg/handlers/generic/mutation/generic/imageregistries/credentials/credentials_secret.go
@@ -106,16 +106,24 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 			return "", fmt.Errorf("failed parsing registry URL: %w", err)
 		}
 
+		// Org-scoped keying (host + path, e.g. registry-1.docker.io/nutanix) is
+		// applied ONLY to NKP's own docker.io/nutanix org.
+		pathPrefix := strings.TrimRight(registryURL.Path, "/")
+		if !isDockerHubNutanixOrgURL(registryURL.Host, pathPrefix) {
+			pathPrefix = ""
+		}
+
 		inputs = append(inputs, templateInput{
-			RegistryHost: registryURL.Host,
+			RegistryHost: registryURL.Host + pathPrefix,
 			Username:     config.Username,
 			Password:     config.Password,
 		})
 
-		// Preserve special handling of "registry-1.docker.io" and add "docker.io" as an alias.
+		// Preserve special handling of "registry-1.docker.io" and add "docker.io"
+		// as an alias, carrying the same org/path prefix.
 		if registryURL.Host == "registry-1.docker.io" {
 			inputs = append(inputs, templateInput{
-				RegistryHost: "docker.io",
+				RegistryHost: "docker.io" + pathPrefix,
 				Username:     config.Username,
 				Password:     config.Password,
 			})
@@ -133,6 +141,10 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 	}
 
 	return strings.TrimSpace(b.String()), nil
+}
+
+func isDockerHubNutanixOrgURL(host, pathPrefix string) bool {
+	return (host == "registry-1.docker.io" || host == "docker.io") && pathPrefix == "/nutanix"
 }
 
 func configsRequireStaticCredentials(configs []providerConfig) bool {

--- a/pkg/handlers/generic/mutation/generic/imageregistries/credentials/credentials_secret.go
+++ b/pkg/handlers/generic/mutation/generic/imageregistries/credentials/credentials_secret.go
@@ -8,6 +8,7 @@ import (
 	_ "embed"
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 	"text/template"
 
@@ -20,6 +21,10 @@ import (
 
 const (
 	secretKeyForStaticCredentialProviderConfig = "static-credential-provider" //nolint:gosec // Not a credential.
+
+	dockerHost          = "docker.io"
+	registry1DockerHost = "registry-1.docker.io"
+	nutanixOrgPath      = "/nutanix"
 )
 
 var (
@@ -106,24 +111,23 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 			return "", fmt.Errorf("failed parsing registry URL: %w", err)
 		}
 
-		// Org-scoped keying (host + path, e.g. registry-1.docker.io/nutanix) is
-		// applied ONLY to NKP's own docker.io/nutanix org.
-		pathPrefix := strings.TrimRight(registryURL.Path, "/")
-		if !isDockerHubNutanixOrgURL(registryURL.Host, pathPrefix) {
-			pathPrefix = ""
+		// To maintain existing behavior, include include the path for Nutanix's docker.io org.
+		var pathPrefix string
+		if isDockerHubNutanixOrgURL(registryURL) {
+			pathPrefix = registryURL.Path
 		}
 
 		inputs = append(inputs, templateInput{
-			RegistryHost: registryURL.Host + pathPrefix,
+			RegistryHost: path.Join(registryURL.Host, pathPrefix),
 			Username:     config.Username,
 			Password:     config.Password,
 		})
 
 		// Preserve special handling of "registry-1.docker.io" and add "docker.io"
 		// as an alias, carrying the same org/path prefix.
-		if registryURL.Host == "registry-1.docker.io" {
+		if registryURL.Host == registry1DockerHost {
 			inputs = append(inputs, templateInput{
-				RegistryHost: "docker.io" + pathPrefix,
+				RegistryHost: path.Join(dockerHost, pathPrefix),
 				Username:     config.Username,
 				Password:     config.Password,
 			})
@@ -143,8 +147,14 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 	return strings.TrimSpace(b.String()), nil
 }
 
-func isDockerHubNutanixOrgURL(host, pathPrefix string) bool {
-	return (host == "registry-1.docker.io" || host == "docker.io") && pathPrefix == "/nutanix"
+func isDockerHubNutanixOrgURL(registryURL *url.URL) bool {
+	if registryURL == nil {
+		return false
+	}
+
+	matchesHost := registryURL.Host == dockerHost || registryURL.Host == registry1DockerHost
+	matchesPath := path.Clean(registryURL.Path) == nutanixOrgPath
+	return matchesHost && matchesPath
 }
 
 func configsRequireStaticCredentials(configs []providerConfig) bool {

--- a/pkg/handlers/generic/mutation/generic/imageregistries/credentials/credentials_secret_test.go
+++ b/pkg/handlers/generic/mutation/generic/imageregistries/credentials/credentials_secret_test.go
@@ -182,6 +182,72 @@ func Test_kubeletStaticCredentialProviderSecretContents(t *testing.T) {
 }`,
 		},
 		{
+			name: "org-scoped 'registry-1.docker.io/nutanix', expect host+path keys plus docker.io alias",
+			configs: []providerConfig{
+				{
+					URL:      "https://registry-1.docker.io/nutanix",
+					Username: "myuser",
+					Password: "mypassword",
+				},
+			},
+			wantContents: `{
+  "kind":"CredentialProviderResponse",
+  "apiVersion":"credentialprovider.kubelet.k8s.io/v1",
+  "cacheKeyType":"Image",
+  "cacheDuration":"0s",
+  "auth":{
+    "registry-1.docker.io/nutanix": {"username": "myuser", "password": "mypassword"},
+    "docker.io/nutanix": {"username": "myuser", "password": "mypassword"}
+  }
+}`,
+		},
+		{
+			name: "org-scoped nutanix coexists with a customer host-only docker.io entry",
+			configs: []providerConfig{
+				{
+					URL:      "https://registry-1.docker.io",
+					Username: "customer",
+					Password: "customerpass",
+				},
+				{
+					URL:      "https://registry-1.docker.io/nutanix",
+					Username: "nutanix",
+					Password: "nutanixpass",
+				},
+			},
+			wantContents: `{
+  "kind":"CredentialProviderResponse",
+  "apiVersion":"credentialprovider.kubelet.k8s.io/v1",
+  "cacheKeyType":"Image",
+  "cacheDuration":"0s",
+  "auth":{
+    "registry-1.docker.io": {"username": "customer", "password": "customerpass"},
+    "docker.io": {"username": "customer", "password": "customerpass"},
+    "registry-1.docker.io/nutanix": {"username": "nutanix", "password": "nutanixpass"},
+    "docker.io/nutanix": {"username": "nutanix", "password": "nutanixpass"}
+  }
+}`,
+		},
+		{
+			name: "non-nutanix registry with a path stays host-only",
+			configs: []providerConfig{
+				{
+					URL:      "https://myregistry.com/myorg",
+					Username: "myuser",
+					Password: "mypassword",
+				},
+			},
+			wantContents: `{
+  "kind":"CredentialProviderResponse",
+  "apiVersion":"credentialprovider.kubelet.k8s.io/v1",
+  "cacheKeyType":"Image",
+  "cacheDuration":"0s",
+  "auth":{
+    "myregistry.com": {"username": "myuser", "password": "mypassword"}
+  }
+}`,
+		},
+		{
 			name: "multiple configs with some static credentials, expect a string with multiple entries",
 			configs: []providerConfig{
 				{

--- a/pkg/handlers/v6/generic/mutation/generic/imageregistries/credentials/credentials_secret.go
+++ b/pkg/handlers/v6/generic/mutation/generic/imageregistries/credentials/credentials_secret.go
@@ -106,16 +106,26 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 			return "", fmt.Errorf("failed parsing registry URL: %w", err)
 		}
 
+		// Org-scoped keying (host + path, e.g. registry-1.docker.io/nutanix) is
+		// applied ONLY to NKP's own docker.io/nutanix org; every other registry
+		// keeps the original host-only key to limit blast radius.
+		trimmedPath := strings.TrimRight(registryURL.Path, "/")
+		pathPrefix := ""
+		if isDockerHubNutanixOrgURL(registryURL.Host, trimmedPath) {
+			pathPrefix = trimmedPath
+		}
+
 		inputs = append(inputs, templateInput{
-			RegistryHost: registryURL.Host,
+			RegistryHost: registryURL.Host + pathPrefix,
 			Username:     config.Username,
 			Password:     config.Password,
 		})
 
-		// Preserve special handling of "registry-1.docker.io" and add "docker.io" as an alias.
+		// Preserve special handling of "registry-1.docker.io" and add "docker.io"
+		// as an alias, carrying the same org/path prefix.
 		if registryURL.Host == "registry-1.docker.io" {
 			inputs = append(inputs, templateInput{
-				RegistryHost: "docker.io",
+				RegistryHost: "docker.io" + pathPrefix,
 				Username:     config.Username,
 				Password:     config.Password,
 			})
@@ -133,6 +143,10 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 	}
 
 	return strings.TrimSpace(b.String()), nil
+}
+
+func isDockerHubNutanixOrgURL(host, pathPrefix string) bool {
+	return (host == "registry-1.docker.io" || host == "docker.io") && pathPrefix == "/nutanix"
 }
 
 func configsRequireStaticCredentials(configs []providerConfig) bool {

--- a/pkg/handlers/v6/generic/mutation/generic/imageregistries/credentials/credentials_secret.go
+++ b/pkg/handlers/v6/generic/mutation/generic/imageregistries/credentials/credentials_secret.go
@@ -106,26 +106,16 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 			return "", fmt.Errorf("failed parsing registry URL: %w", err)
 		}
 
-		// Org-scoped keying (host + path, e.g. registry-1.docker.io/nutanix) is
-		// applied ONLY to NKP's own docker.io/nutanix org; every other registry
-		// keeps the original host-only key to limit blast radius.
-		trimmedPath := strings.TrimRight(registryURL.Path, "/")
-		pathPrefix := ""
-		if isDockerHubNutanixOrgURL(registryURL.Host, trimmedPath) {
-			pathPrefix = trimmedPath
-		}
-
 		inputs = append(inputs, templateInput{
-			RegistryHost: registryURL.Host + pathPrefix,
+			RegistryHost: registryURL.Host,
 			Username:     config.Username,
 			Password:     config.Password,
 		})
 
-		// Preserve special handling of "registry-1.docker.io" and add "docker.io"
-		// as an alias, carrying the same org/path prefix.
+		// Preserve special handling of "registry-1.docker.io" and add "docker.io" as an alias.
 		if registryURL.Host == "registry-1.docker.io" {
 			inputs = append(inputs, templateInput{
-				RegistryHost: "docker.io" + pathPrefix,
+				RegistryHost: "docker.io",
 				Username:     config.Username,
 				Password:     config.Password,
 			})
@@ -143,10 +133,6 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 	}
 
 	return strings.TrimSpace(b.String()), nil
-}
-
-func isDockerHubNutanixOrgURL(host, pathPrefix string) bool {
-	return (host == "registry-1.docker.io" || host == "docker.io") && pathPrefix == "/nutanix"
 }
 
 func configsRequireStaticCredentials(configs []providerConfig) bool {


### PR DESCRIPTION
**What problem does this PR solve?**:
Do not trim org prefix for Dockerhub Nutanix registry. This is so that it can co-exist with customer's existing registry (which could also be docker.io).

**Which issue(s) this PR fixes**:
Fixes # https://jira.nutanix.com/browse/NCN-115992

**How Has This Been Tested?**:
Pushed CAREN image with these changes to Harbor, updated CAREN build on management cluster, and rotated the new nodes to verify the above.

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
