### PR TITLE
refactor: [NCN-116148] Share HTTPS server for hooks and admission

### DIFF
--- a/.specify/features/NCN-116148/plan.md
+++ b/.specify/features/NCN-116148/plan.md
@@ -1,0 +1,651 @@
+<!--
+ Copyright 2026 Nutanix. All rights reserved.
+ SPDX-License-Identifier: Apache-2.0
+-->
+
+# Consolidate webhook servers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve CAPI runtime extension hooks and Kubernetes admission webhooks on one controller-runtime HTTPS listener (port 9443) with one TLS cert, without changing handler behavior.
+
+**Architecture:** Use CAPI `*runtimeserver.Server` as the manager `WebhookServer`. That type embeds `webhook.Server` and its `Start` registers runtime hook paths then listens once. Register admission handlers on the same instance via `Register` before `mgr.Start`. Do not `mgr.Add` a second HTTPS runnable. Chart keeps two Services pointing at the shared port; one Certificate (`*-runtimehooks-tls`) with SANs for both Service DNS names.
+
+**Tech Stack:** Go, controller-runtime v0.22.5, CAPI `exp/runtime/server` v1.12.x, Helm chart, cert-manager Certificates, testify.
+
+**Branch**: `NCN-116148-consolidate-webhook-servers`
+**Date**: 2026-07-24
+**Spec**: [./spec.md](./spec.md)
+
+## Global Constraints
+
+- No topology mutation handler version bumps; `GeneratePatches` output must stay identical (FR-013).
+- No changes to admission or runtime handler business logic (FR-004, FR-005).
+- Keep Service names `*-runtimehooks` and `*-admission` (FR-006).
+- Remove `--admission-webhook-cert-dir` entirely — no alias (FR-012).
+- Prefer `devbox run --` for Go/Helm commands when `devbox.json` is present.
+- Do not commit unless the user explicitly asks (or the execution session has commit approval).
+
+---
+
+## Summary
+
+Today `cmd/main.go` creates a manager `WebhookServer` on 9444 with `/admission-certs`, then `mgr.Add`s a separate `common/pkg/server` runnable that starts CAPI `runtimeserver` on 9443 with `/runtimehooks-certs`. Both are path-routed HTTPS; paths do not collide. This plan collapses them onto one listener by making the CAPI runtime server the manager webhook server, then updates chart TLS/ports/flags accordingly.
+
+## Technical Context
+
+**Language/Version**: Go (see `go.mod`).
+**Primary Dependencies**: `sigs.k8s.io/controller-runtime`, `sigs.k8s.io/cluster-api/exp/runtime/server`.
+**Testing**: testify unit tests in `common/pkg/server`; Helm template checks via `helm template` + `yq`; existing admission webhook suite tests remain valid.
+**Target Platform**: management-cluster Deployment.
+**Project Type**: single Go module + Helm chart.
+**Constraints**: single HTTPS port 9443; single cert secret `*-runtimehooks-tls`; handler version safety.
+**Scale/Scope**: `common/pkg/server`, `cmd/main.go`, chart templates, committed `runtime-extensions-components.yaml` for local e2e.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+| --- | --- | --- |
+| I. API-First | Pass | No API/CRD changes. |
+| II. Handler-per-Provider | Pass | No handler package changes. |
+| III. Library-First | Pass | Wiring stays in `common/pkg/server` + thin `cmd`. |
+| IV. Tests Required | Pass | New server unit test + chart render checks. |
+| V. Code Style | Pass | Follow existing import aliases; no narrating comments. |
+| VI. Dependency Management | Pass | No new deps. |
+| VII. Handler Version Safety | Pass | No `pkg/handlers/*/mutation/` edits. |
+| VIII. Handler Documentation | Pass | No handler behavior docs required; optional deploy note only if docs mention dual ports/certs. |
+
+No violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+.specify/features/NCN-116148/
+├── plan.md
+└── spec.md
+```
+
+### Source Code (repository root)
+
+```text
+common/pkg/server/
+├── server.go              # Create runtimeserver; AddHandlers; no second listener Runnable
+└── server_test.go         # Shared-server registration + dual-path smoke test
+
+cmd/
+└── main.go                # Use runtime server as mgr WebhookServer; drop admission cert flag/port
+
+charts/cluster-api-runtime-extensions-nutanix/templates/
+├── certificates.yaml      # SANs for both Services; delete admission Certificate
+├── deployment.yaml        # One port, one cert mount/arg
+├── admission-service.yaml # targetPort → shared HTTPS port name
+├── runtimehooks-service.yaml  # unchanged name; same targetPort
+└── webhooks.yaml          # inject-ca-from → runtimehooks-tls
+
+runtime-extensions-components.yaml  # Regenerate from helm template for local e2e
+```
+
+**Structure Decision:** Keep the existing `common/pkg/server` package as the place that builds/registers CAPI runtime handlers. Change its API so callers obtain a `webhook.Server` suitable for `manager.Options.WebhookServer`, then call `AddHandlers` after the manager (and thus handlers) exist.
+
+## Key Wiring (read before coding)
+
+Chicken-and-egg: `AllHandlers(mgr)` needs a manager, but `WebhookServer` must be set in `manager.Options` before `NewManager`.
+
+```text
+1. Parse flags (--webhook-port default 9443, --webhook-cert-dir)
+2. runtimeSrv := server.NewWebhookServer(opts)          // catalog + runtimeserver.New; NO Start
+3. mgr := NewManager(..., WebhookServer: runtimeSrv)
+4. handlers := AllHandlers(mgr)
+5. server.AddHandlers(runtimeSrv, handlers...)          // AddExtensionHandler only
+6. mgr.GetWebhookServer().Register(/mutate-..., ...)  // same instance
+7. mgr.Start(ctx)  // → runtimeserver.Start → register hook paths → listen once
+```
+
+Do **not** call `mgr.Add(runtimeSrv)` separately: `GetWebhookServer()` already `Add`s the webhook server runnable.
+
+`*runtimeserver.Server` implements `webhook.Server` (embeds the interface and defines `Start` that registers hooks then listens). Manager type-switch treats it as `webhook.Server` and runs that `Start`.
+
+## Tasks
+
+Atomic, TDD-ordered. Do not merge a task until its acceptance check passes.
+
+### T1 — Refactor `common/pkg/server` API (failing tests first)
+
+**Files:**
+
+- Create: `common/pkg/server/server_test.go`
+- Modify: `common/pkg/server/server.go`
+
+**Interfaces:**
+
+- Produces:
+  - `func NewServerOptions() *ServerOptions` (keep; default `webhookPort` to `9443`)
+  - `func (o *ServerOptions) AddFlags(*pflag.FlagSet)` — flags `--webhook-port`, `--webhook-cert-dir` only
+  - `func NewWebhookServer(opts *ServerOptions) (webhook.Server, error)` — builds catalog + `runtimeserver.New`
+  - `func AddHandlers(s webhook.Server, hooks ...handlers.Named) error` — type-asserts to `*runtimeserver.Server` (or accept `*runtimeserver.Server`), runs the existing `AddExtensionHandler` loop from today’s `Start`
+- Removes: custom `Server` Runnable with `Start`/`NeedLeaderElection` that creates a second listener
+
+- [ ] **Step 1: Write failing tests**
+
+Create `common/pkg/server/server_test.go` in package `server` (same package) so tests can set unexported option fields:
+
+```go
+package server
+
+import (
+  "context"
+  "crypto/ecdsa"
+  "crypto/elliptic"
+  "crypto/rand"
+  "crypto/tls"
+  "crypto/x509"
+  "crypto/x509/pkix"
+  "encoding/pem"
+  "fmt"
+  "io"
+  "math/big"
+  "net"
+  "net/http"
+  "os"
+  "path/filepath"
+  "testing"
+  "time"
+
+  "github.com/spf13/pflag"
+  "github.com/stretchr/testify/assert"
+  "github.com/stretchr/testify/require"
+  "sigs.k8s.io/controller-runtime/pkg/webhook"
+  "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type namedStub struct{}
+
+func (namedStub) Name() string { return "stub" }
+
+func TestNewWebhookServer_ImplementsWebhookServer(t *testing.T) {
+  t.Parallel()
+  opts := NewServerOptions()
+  opts.webhookPort = 0
+  opts.webhookCertDir = t.TempDir()
+  ws, err := NewWebhookServer(opts)
+  require.NoError(t, err)
+  require.NotNil(t, ws)
+  _, ok := any(ws).(webhook.Server)
+  assert.True(t, ok)
+}
+
+func TestAddHandlersAndAdmissionShareListener(t *testing.T) {
+  t.Parallel()
+
+  certDir := t.TempDir()
+  require.NoError(t, writeTestServingCerts(certDir))
+
+  ln, err := net.Listen("tcp", "127.0.0.1:0")
+  require.NoError(t, err)
+  port := ln.Addr().(*net.TCPAddr).Port
+  require.NoError(t, ln.Close())
+
+  opts := NewServerOptions()
+  opts.webhookPort = port
+  opts.webhookCertDir = certDir
+
+  ws, err := NewWebhookServer(opts)
+  require.NoError(t, err)
+  require.NoError(t, AddHandlers(ws, namedStub{}))
+
+  ws.Register("/mutate-test", &webhook.Admission{
+    Handler: admission.HandlerFunc(func(_ context.Context, _ admission.Request) admission.Response {
+      return admission.Allowed("")
+    }),
+  })
+
+  ctx, cancel := context.WithCancel(context.Background())
+  defer cancel()
+  errCh := make(chan error, 1)
+  go func() { errCh <- ws.Start(ctx) }()
+
+  client := &http.Client{
+    Transport: &http.Transport{
+      TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test-only
+    },
+  }
+  require.Eventually(t, func() bool {
+    resp, err := client.Post(
+      fmt.Sprintf("https://127.0.0.1:%d/hooks.runtime.cluster.x-k8s.io/v1alpha1/discovery", port),
+      "application/json",
+      nil,
+    )
+    if err != nil {
+      return false
+    }
+    defer resp.Body.Close()
+    _, _ = io.Copy(io.Discard, resp.Body)
+    return resp.StatusCode == http.StatusOK
+  }, 10*time.Second, 50*time.Millisecond)
+
+  resp, err := client.Post(
+    fmt.Sprintf("https://127.0.0.1:%d/mutate-test", port),
+    "application/json",
+    nil,
+  )
+  require.NoError(t, err)
+  defer resp.Body.Close()
+  // Admission may 400 on empty body; connection + TLS + route hit is enough.
+  assert.NotEqual(t, http.StatusNotFound, resp.StatusCode)
+
+  cancel()
+  select {
+  case err := <-errCh:
+    require.NoError(t, err)
+  case <-time.After(5 * time.Second):
+    t.Fatal("server did not shut down")
+  }
+}
+
+func TestServerOptions_NoAdmissionCertDirFlag(t *testing.T) {
+  t.Parallel()
+  fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+  NewServerOptions().AddFlags(fs)
+  assert.Nil(t, fs.Lookup("admission-webhook-cert-dir"))
+  assert.NotNil(t, fs.Lookup("webhook-port"))
+  assert.NotNil(t, fs.Lookup("webhook-cert-dir"))
+}
+
+func writeTestServingCerts(dir string) error {
+  key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+  if err != nil {
+    return err
+  }
+  tmpl := &x509.Certificate{
+    SerialNumber: big.NewInt(1),
+    Subject:      pkix.Name{CommonName: "localhost"},
+    NotBefore:    time.Now().Add(-time.Hour),
+    NotAfter:     time.Now().Add(24 * time.Hour),
+    KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+    ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+    IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+    DNSNames:     []string{"localhost"},
+  }
+  der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+  if err != nil {
+    return err
+  }
+  certOut, err := os.Create(filepath.Join(dir, "tls.crt"))
+  if err != nil {
+    return err
+  }
+  defer certOut.Close()
+  if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+    return err
+  }
+  keyBytes, err := x509.MarshalECPrivateKey(key)
+  if err != nil {
+    return err
+  }
+  keyOut, err := os.Create(filepath.Join(dir, "tls.key"))
+  if err != nil {
+    return err
+  }
+  defer keyOut.Close()
+  return pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+}
+```
+
+- [ ] **Step 2: Run tests — expect compile/fail**
+
+```bash
+devbox run -- go test ./common/pkg/server/ -count=1
+```
+
+Expected: fail — `NewWebhookServer` / `AddHandlers` undefined (or Runnable `Start` still owns the listener).
+
+- [ ] **Step 3: Implement minimal API**
+
+Rewrite `common/pkg/server/server.go` roughly as:
+
+```go
+func NewServerOptions() *ServerOptions {
+  return &ServerOptions{webhookPort: 9443}
+}
+
+func NewWebhookServer(opts *ServerOptions) (webhook.Server, error) {
+  catalog := runtimecatalog.New()
+  _ = runtimehooksv1.AddToCatalog(catalog)
+  return runtimeserver.New(runtimeserver.Options{
+    Catalog: catalog,
+    Port:    opts.webhookPort,
+    CertDir: opts.webhookCertDir,
+  })
+}
+
+func AddHandlers(s webhook.Server, hooks ...handlers.Named) error {
+  rs, ok := s.(*runtimeserver.Server)
+  if !ok {
+    return fmt.Errorf("webhook server is %T, want *runtimeserver.Server", s)
+  }
+  for _, h := range hooks {
+    // Copy the existing type-switch + AddExtensionHandler body from the old
+    // Server.Start loop verbatim (BeforeClusterCreate … ValidateTopology).
+    // Do NOT call rs.Start here — manager owns Start.
+    _ = h
+  }
+  return nil
+}
+```
+
+When implementing, paste the full `for _, h := range s.hooks { … }` block from the current `Server.Start` into `AddHandlers` (changing `s.hooks` to the `hooks` argument and `webhookServer` to `rs`). Delete the old `Server` struct Runnable (`Start` / `NeedLeaderElection`) that constructed and started a second server.
+
+- [ ] **Step 4: Re-run tests — expect pass**
+
+```bash
+devbox run -- go test ./common/pkg/server/ -count=1 -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit** (only if user asked)
+
+```bash
+git add common/pkg/server/
+git commit -m "$(cat <<'EOF'
+refactor: [NCN-116148] Expose shared runtime webhook.Server API
+
+Allow the CAPI runtime server to be used as the manager WebhookServer
+so admission and runtime hooks can share one listener.
+EOF
+)"
+```
+
+**Acceptance:** `go test ./common/pkg/server` passes; no second-listener Runnable remains in the package.
+
+---
+
+### T2 — Wire `cmd/main.go` onto the shared server
+
+**Files:**
+
+- Modify: `cmd/main.go`
+- Test: `common/pkg/server` (already covers dual paths); compile `cmd`
+
+**Interfaces:**
+
+- Consumes: `server.NewWebhookServer`, `server.AddHandlers`, `server.NewServerOptions`
+- Produces: process with one HTTPS listener; flags without `--admission-webhook-cert-dir`
+
+- [ ] **Step 1: Write a failing flag assertion**
+
+Add a small test under `cmd` only if the package is testable without `main` hazards; otherwise extend `TestServerOptions_NoAdmissionCertDirFlag` and add a compile-time check by deleting the admission flag usages (Step 3). Prefer not inventing a heavy `cmd` test.
+
+- [ ] **Step 2: Change manager construction**
+
+Replace:
+
+```go
+webhookOptions := webhook.Options{Port: 9444, CertDir: "/admission-certs"}
+mgrOptions := &ctrl.Options{
+  WebhookServer: webhook.NewServer(webhookOptions),
+  // ...
+}
+// --admission-webhook-cert-dir flag
+runtimeWebhookServer := server.NewServer(...)
+mgr.Add(runtimeWebhookServer)
+```
+
+With:
+
+```go
+runtimeWebhookServerOpts := server.NewServerOptions()
+// default cert dir for local/dev if desired:
+// still set via flag; chart passes --webhook-cert-dir=/runtimehooks-certs/
+
+runtimeWebhookServerOpts.AddFlags(pflag.CommandLine)
+// ... parse flags ...
+
+webhookServer, err := server.NewWebhookServer(runtimeWebhookServerOpts)
+if err != nil { /* exit */ }
+
+mgrOptions := &ctrl.Options{
+  WebhookServer: webhookServer,
+  // Metrics/HealthProbe unchanged
+}
+mgr, err := newManager(mgrOptions)
+
+allHandlers := slices.Concat(...)
+if err := server.AddHandlers(webhookServer, allHandlers...); err != nil { /* exit */ }
+
+// Admission registrations unchanged — they use mgr.GetWebhookServer()
+mgr.GetWebhookServer().Register("/mutate-cluster", ...)
+// ...
+// Do NOT mgr.Add(webhookServer) again.
+mgr.Start(signalCtx)
+```
+
+Remove `--admission-webhook-cert-dir` flag registration and any `/admission-certs` defaults.
+
+Ensure `WebhookServer` is assigned **before** `newManager`, and `AddHandlers` runs **after** `AllHandlers(mgr)`.
+
+- [ ] **Step 3: Build**
+
+```bash
+devbox run -- go build -o /dev/null ./cmd/
+```
+
+Expected: success.
+
+- [ ] **Step 4: Confirm help has no admission cert flag**
+
+```bash
+devbox run -- go run ./cmd --help 2>&1 | tee /tmp/caren-help.txt
+grep -E 'webhook-port|webhook-cert-dir|admission-webhook' /tmp/caren-help.txt
+```
+
+Expected: `webhook-port` and `webhook-cert-dir` present; `admission-webhook-cert-dir` absent.
+
+- [ ] **Step 5: Commit** (only if user asked)
+
+```bash
+git add cmd/main.go
+git commit -m "$(cat <<'EOF'
+refactor: [NCN-116148] Serve admission on the runtime webhook server
+
+Use a single manager WebhookServer for runtime hooks and admission
+paths so upgrading CAREN does not require two TLS listeners.
+EOF
+)"
+```
+
+**Acceptance:** Binary builds; one webhook server in process wiring; admission flag gone.
+
+---
+
+### T3 — Chart: certificate SANs + CA inject
+
+**Files:**
+
+- Modify: `charts/cluster-api-runtime-extensions-nutanix/templates/certificates.yaml`
+- Modify: `charts/cluster-api-runtime-extensions-nutanix/templates/webhooks.yaml`
+
+- [ ] **Step 1: Update Certificate**
+
+In `certificates.yaml`, keep only `*-runtimehooks-tls` and expand `dnsNames`:
+
+```yaml
+dnsNames:
+  - {{ template "chart.name" . }}-runtimehooks.{{ .Release.Namespace }}.svc
+  - {{ template "chart.name" . }}-runtimehooks.{{ .Release.Namespace }}.svc.cluster.local
+  - {{ template "chart.name" . }}-admission.{{ .Release.Namespace }}.svc
+  - {{ template "chart.name" . }}-admission.{{ .Release.Namespace }}.svc.cluster.local
+```
+
+Delete the entire `*-admission-tls` Certificate document.
+
+- [ ] **Step 2: Point admission webhooks at runtimehooks cert**
+
+In `webhooks.yaml`, change both `cert-manager.io/inject-ca-from` values from `...-admission-tls` to `...-runtimehooks-tls`.
+
+- [ ] **Step 3: Render and assert**
+
+```bash
+devbox run -- helm template caren ./charts/cluster-api-runtime-extensions-nutanix \
+  --namespace caren-system > /tmp/caren-chart.yaml
+yq 'select(.kind == "Certificate") | .metadata.name' /tmp/caren-chart.yaml
+yq 'select(.kind == "Certificate") | .spec.dnsNames' /tmp/caren-chart.yaml
+yq 'select(.kind == "MutatingWebhookConfiguration" or .kind == "ValidatingWebhookConfiguration") | .metadata.annotations["cert-manager.io/inject-ca-from"]' /tmp/caren-chart.yaml
+```
+
+Expected: one Certificate name ending in `runtimehooks-tls`; dnsNames include both Services; webhook annotations reference `runtimehooks-tls` only; no `admission-tls` Certificate.
+
+- [ ] **Step 4: Commit** (only if user asked)
+
+**Acceptance:** FR-007, FR-008, FR-009 satisfied in rendered output.
+
+---
+
+### T4 — Chart: Deployment + Services share one port
+
+**Files:**
+
+- Modify: `charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml`
+- Modify: `charts/cluster-api-runtime-extensions-nutanix/templates/admission-service.yaml`
+- Verify: `charts/cluster-api-runtime-extensions-nutanix/templates/runtimehooks-service.yaml` (name unchanged)
+- Verify: `charts/cluster-api-runtime-extensions-nutanix/templates/extensionconfig.yaml` (unchanged service + CA secret)
+
+- [ ] **Step 1: Deployment**
+
+- Keep `--webhook-cert-dir=/runtimehooks-certs/`.
+- Remove `--admission-webhook-cert-dir=...`.
+- Ports: keep single HTTPS `containerPort: 9443` name `runtimehooks` (or rename to `https` — if renamed, update both Services). Remove `9444` / `admission` port.
+- Volumes: only `runtimehooks-cert` secret `*-runtimehooks-tls`. Remove `admission-cert` volume/mount.
+
+- [ ] **Step 2: Admission Service**
+
+Change `targetPort: admission` → `targetPort: runtimehooks` (or `https` if renamed). Keep Service metadata name `*-admission`.
+
+- [ ] **Step 3: Render and assert**
+
+```bash
+devbox run -- helm template caren ./charts/cluster-api-runtime-extensions-nutanix \
+  --namespace caren-system > /tmp/caren-chart.yaml
+yq 'select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[].containerPort' /tmp/caren-chart.yaml
+yq 'select(.kind == "Deployment") | .spec.template.spec.containers[0].args[]' /tmp/caren-chart.yaml | rg 'webhook|admission' || true
+yq 'select(.kind == "Service") | {"name": .metadata.name, "target": .spec.ports[0].targetPort}' /tmp/caren-chart.yaml
+```
+
+Expected:
+
+- Container ports include 9443 once; no 9444.
+- No `--admission-webhook-cert-dir`.
+- Services `...-runtimehooks` and `...-admission` both target the same port name.
+- ExtensionConfig still references `...-runtimehooks` and `runtimehooks-tls` CA annotation.
+
+- [ ] **Step 4: Commit** (only if user asked)
+
+**Acceptance:** FR-002, FR-006, FR-010, FR-011, SC-001, SC-002.
+
+---
+
+### T5 — Regenerate `runtime-extensions-components.yaml`
+
+**Files:**
+
+- Modify: `runtime-extensions-components.yaml` (committed install manifest used by local e2e)
+
+- [ ] **Step 1: Regenerate from chart**
+
+Mirror goreleaser’s helm template (dev tag is fine for local tree):
+
+```bash
+devbox run -- sh -ec '
+NS=caren-system
+PROJECT=cluster-api-runtime-extensions-nutanix
+{
+  cat <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NS}
+EOF
+  helm template "${PROJECT}" "./charts/${PROJECT}" --namespace "${NS}"
+} > runtime-extensions-components.yaml
+'
+```
+
+- [ ] **Step 2: Spot-check**
+
+```bash
+rg -n 'admission-tls|9444|admission-webhook-cert-dir|containerPort: 9443' runtime-extensions-components.yaml
+```
+
+Expected: no `admission-tls` / `9444` / `admission-webhook-cert-dir`; `9443` present; both Service names remain.
+
+- [ ] **Step 3: Commit** (only if user asked)
+
+**Acceptance:** Local e2e manifest matches chart consolidation.
+
+---
+
+### T6 — Final verification (no mutation churn)
+
+**Files:** review-only (no mutation handler edits)
+
+- [ ] **Step 1: Diff touch list**
+
+```bash
+git diff --name-only
+```
+
+Expected: no files under `pkg/handlers/*/mutation/` or `pkg/handlers/v5/`.
+
+- [ ] **Step 2: Unit tests for touched packages**
+
+```bash
+devbox run -- go test ./common/pkg/server/ ./cmd/ ./pkg/webhook/... -count=1
+```
+
+Expected: PASS (skip packages that cannot build in isolation if `cmd` has no tests).
+
+- [ ] **Step 3: Optional representative patch sanity**
+
+If an existing capitest/GeneratePatches test target is cheap:
+
+```bash
+devbox run -- go test ./pkg/handlers/generic/mutation/... -count=1 -timeout 10m
+```
+
+Expected: PASS — confirms no accidental handler edits. (Not a before/after byte compare; this refactor must not change those packages.)
+
+- [ ] **Step 4: Docs grep**
+
+```bash
+rg -n '9444|admission-certs|admission-tls|admission-webhook-cert-dir' docs/ || true
+```
+
+Update any user-facing deploy docs that document dual ports/certs. Skip if none.
+
+**Acceptance:** FR-013 / SC-004 satisfied by inspection + green tests; SC-005 already covered in T2.
+
+---
+
+## Spec coverage checklist
+
+| Spec item | Task |
+| --- | --- |
+| FR-001 / FR-003 single listener | T1, T2 |
+| FR-002 port 9443 | T2, T4 |
+| FR-004 / FR-005 paths/behavior unchanged | T2 (Register paths unchanged), T1 smoke |
+| FR-006 two Services same targetPort | T4 |
+| FR-007 / FR-008 single Certificate | T3 |
+| FR-009 CA inject annotation | T3 |
+| FR-010 ExtensionConfig unchanged service/CA secret name | T4 verify |
+| FR-011 Deployment single mount/port/arg | T4 |
+| FR-012 remove admission cert flag | T1, T2 |
+| FR-013 no mutation version bump | T6 |
+| SC-001–SC-005 | T2–T6 |
+
+## Out of scope (do not implement)
+
+- Upstream CAPI API to inject an existing `webhook.Server` into `runtimeserver.New`
+- Merging the two Services
+- Metrics/health port consolidation

--- a/.specify/features/NCN-116148/spec.md
+++ b/.specify/features/NCN-116148/spec.md
@@ -1,0 +1,134 @@
+<!--
+ Copyright 2026 Nutanix. All rights reserved.
+ SPDX-License-Identifier: Apache-2.0
+-->
+
+# Feature Specification: Consolidate runtime hooks and admission webhooks onto one HTTPS server
+
+**Jira Ticket**: [NCN-116148](https://jira.nutanix.com/browse/NCN-116148)
+**Feature Branch**: `NCN-116148-consolidate-webhook-servers`
+**Created**: 2026-07-24
+**Status**: Draft
+**Input**: User description: "consolidate the server for the runtime hooks with the admission webhooks, specifically to use the same port and tls cert" (option 2; refactor)
+
+## User Scenarios & Testing
+
+### User Story 1 - Single HTTPS listener serves both surfaces (Priority: P1)
+
+An operator runs CAREN and expects both CAPI runtime extension hooks and Kubernetes admission webhooks to be served from one HTTPS listener in the manager process, on one port, with one TLS certificate.
+
+**Why this priority**: This is the refactor goal. Today two listeners (9443 runtime hooks, 9444 admission) and two certs add chart and operational complexity without a protocol requirement.
+
+**Independent Test**: Deploy the chart. Confirm the Deployment exposes a single HTTPS container port (9443). Confirm one TLS secret is mounted. Call runtime Discovery via the runtimehooks Service and an admission path via the admission Service; both succeed over TLS verified with the same CA.
+
+**Acceptance Scenarios**:
+
+1. **Given** CAREN is installed from the chart, **When** inspecting the manager container, **Then** there is exactly one HTTPS serving port (9443) and no 9444 container port.
+2. **Given** CAREN is running, **When** Cluster API calls runtime Discovery through the `*-runtimehooks` Service, **Then** Discovery succeeds over TLS.
+3. **Given** CAREN is running, **When** the API server calls an admission webhook (e.g. `/validate-cluster`) through the `*-admission` Service, **Then** admission succeeds over TLS using the same serving certificate CA as runtime hooks.
+
+---
+
+### User Story 2 - Stable Service names on upgrade (Priority: P1)
+
+An operator upgrades CAREN. ExtensionConfig and admission webhook configurations keep their existing Service name references (`*-runtimehooks` and `*-admission`). Both Services target the shared container port.
+
+**Why this priority**: Avoids clientConfig service-name churn and limits upgrade blast radius.
+
+**Independent Test**: Diff rendered chart before/after. Service names unchanged; both `targetPort` values point at the same container port. ExtensionConfig `clientConfig.service.name` and webhook `clientConfig.service.name` values unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing install using `*-runtimehooks` and `*-admission` Services, **When** upgrading to this version, **Then** both Service names remain and both target the shared HTTPS port.
+2. **Given** the upgrade, **When** inspecting ExtensionConfig and Mutating/ValidatingWebhookConfigurations, **Then** `clientConfig.service.name` values are unchanged.
+
+---
+
+### User Story 3 - Single Certificate and simplified flags (Priority: P1)
+
+The chart issues one cert-manager Certificate (`*-runtimehooks-tls`) with DNS SANs for both Services. Admission webhook CA injection points at that Certificate. The `*-admission-tls` Certificate is removed. Process flags are `--webhook-port` and `--webhook-cert-dir` only; `--admission-webhook-cert-dir` is removed.
+
+**Why this priority**: Completes consolidation of TLS and config surface.
+
+**Independent Test**: Helm template/render shows one Certificate with both Service DNS names, no `*-admission-tls`, admission webhook annotations use `inject-ca-from` for `*-runtimehooks-tls`, and Deployment args omit `--admission-webhook-cert-dir`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the chart is rendered, **When** listing Certificates, **Then** only `*-runtimehooks-tls` exists and its `dnsNames` include both `*-runtimehooks` and `*-admission` Service FQDNs.
+2. **Given** the chart is rendered, **When** inspecting Mutating/ValidatingWebhookConfigurations, **Then** `cert-manager.io/inject-ca-from` references `*-runtimehooks-tls` (not `*-admission-tls`).
+3. **Given** the manager binary, **When** listing flags, **Then** `--webhook-port` and `--webhook-cert-dir` exist and `--admission-webhook-cert-dir` does not.
+
+---
+
+### User Story 4 - Upgrade is a no-op for managed Clusters (Priority: P1)
+
+Upgrading CAREN MUST NOT change topology mutation patch output or trigger Machine rollouts.
+
+**Why this priority**: Constitution principle VII (handler version safety). This is infrastructure wiring only.
+
+**Independent Test**: Compare `GeneratePatches` output for representative Clusters before and after; output must be identical. No mutation handler version bumps in the change.
+
+**Acceptance Scenarios**:
+
+1. **Given** existing managed Clusters, **When** CAREN is upgraded to include this refactor, **Then** no topology mutation handler names or patch outputs change.
+2. **Given** the PR, **When** reviewing the diff, **Then** no new handler versions are introduced under `pkg/handlers/*/mutation/` solely due to this work.
+
+### Edge Cases
+
+- What happens when only one of the two Services is reachable? Each Service independently routes to the same pod port; failure of one Service does not stop the other from working if the pod is healthy.
+- How does cert-manager CA re-injection behave when admission webhook annotations switch from `*-admission-tls` to `*-runtimehooks-tls`? Expect a brief period until inject-ca-from updates `caBundle`; both Services must already be covered by the Certificate SANs before traffic relies on the shared cert.
+- What if an out-of-chart install still passes `--admission-webhook-cert-dir`? The flag is removed; the process must fail flag parsing (unknown flag) rather than silently ignore a second cert dir.
+- Path collisions: admission paths (`/mutate-cluster`, `/validate-cluster`, `/mutate-addons`, `/preflight-cluster`) MUST remain distinct from runtime hook paths (`/hooks.runtime.cluster.x-k8s.io/...`).
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The manager process MUST serve CAPI runtime extension hooks and Kubernetes admission webhooks on a single HTTPS listener owned by the controller-runtime manager `WebhookServer`.
+- **FR-002**: The default HTTPS listen port MUST be 9443. Port 9444 MUST NOT be used by the chart or default binary configuration.
+- **FR-003**: Runtime extension handlers MUST be registered on the manager `WebhookServer` and MUST NOT start a second TLS listener.
+- **FR-004**: Admission webhook registration paths and behavior MUST remain unchanged (`/mutate-cluster`, `/validate-cluster`, `/mutate-addons`, `/preflight-cluster`).
+- **FR-005**: Runtime hook registration paths and handler behavior MUST remain unchanged (Discovery and all registered extension handlers).
+- **FR-006**: The Helm chart MUST keep separate Services named `*-runtimehooks` and `*-admission`, both selecting the manager pods and targeting the shared HTTPS container port.
+- **FR-007**: The Helm chart MUST issue a single cert-manager Certificate named `*-runtimehooks-tls` whose `dnsNames` include both Service DNS names (`*.svc` and `*.svc.cluster.local` for each).
+- **FR-008**: The Helm chart MUST delete the `*-admission-tls` Certificate resource.
+- **FR-009**: MutatingWebhookConfiguration and ValidatingWebhookConfiguration MUST set `cert-manager.io/inject-ca-from` to the namespace/`*-runtimehooks-tls` Certificate.
+- **FR-010**: ExtensionConfig MUST continue to inject CA from `*-runtimehooks-tls` and reference the `*-runtimehooks` Service.
+- **FR-011**: The Deployment MUST mount a single TLS secret (`*-runtimehooks-tls`), pass a single cert dir flag, and expose a single HTTPS container port.
+- **FR-012**: CLI MUST expose `--webhook-port` and `--webhook-cert-dir` only. `--admission-webhook-cert-dir` MUST be removed (not aliased).
+- **FR-013**: This change MUST NOT alter topology mutation `GeneratePatches` output or require a handler version bump.
+
+### Key Entities
+
+- **Manager WebhookServer**: Single controller-runtime HTTPS server serving both admission and runtime-extension HTTP paths.
+- **Runtimehooks Service**: Stable ClusterIP/NodePort Service used by ExtensionConfig; targets shared HTTPS port.
+- **Admission Service**: Stable ClusterIP/NodePort Service used by admission webhook configs; targets shared HTTPS port.
+- **Runtimehooks TLS Certificate**: Sole cert-manager Certificate/secret for serving TLS; SANs cover both Services.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Rendered chart contains exactly one HTTPS container port and exactly one webhook TLS Certificate.
+- **SC-002**: Both Services remain named as today and share the same `targetPort`.
+- **SC-003**: Runtime Discovery and at least one admission webhook path succeed against a running install using the shared cert.
+- **SC-004**: Representative `GeneratePatches` outputs are byte-identical before and after the change.
+- **SC-005**: `--admission-webhook-cert-dir` is absent from `--help` / flag registration.
+
+## Design Decisions
+
+| Decision | Choice |
+| --- | --- |
+| Consolidation level | Shared port + TLS (option 2) |
+| Go wiring | Register runtime handlers on manager `WebhookServer`; no second `Start`/listen |
+| Services | Keep two Services, same target port |
+| Flags | Single `--webhook-port` / `--webhook-cert-dir`; remove admission cert-dir flag |
+| Certificate | Keep `*-runtimehooks-tls`; add admission SANs; remove `*-admission-tls` |
+| Default port | 9443 |
+
+## Out of Scope
+
+- Upstream changes to CAPI `exp/runtime/server` to natively accept an injected `webhook.Server`
+- Merging the two Kubernetes Services into one
+- Changing admission or runtime handler business logic
+- Metrics (8080) or health probe (8081) consolidation

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/admission-service.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/admission-service.yaml
@@ -18,7 +18,7 @@ spec:
   - name: https
     port: {{ .Values.service.port }}
     protocol: TCP
-    targetPort: admission
+    targetPort: runtimehooks
     {{- if and .Values.service.nodePort (eq "NodePort" .Values.service.type) }}
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/certificates.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/certificates.yaml
@@ -12,23 +12,9 @@ spec:
   dnsNames:
     - {{ template "chart.name" . }}-runtimehooks.{{ .Release.Namespace }}.svc
     - {{ template "chart.name" . }}-runtimehooks.{{ .Release.Namespace }}.svc.cluster.local
-  issuerRef:
-    kind: {{ .Values.certificates.issuer.kind }}
-    name: {{ template "chart.issuerName" . }}
-  secretName: {{ template "chart.name" . }}-runtimehooks-tls
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: {{ template "chart.name" . }}-admission-tls
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "chart.labels" . | nindent 4 }}
-spec:
-  dnsNames:
     - {{ template "chart.name" . }}-admission.{{ .Release.Namespace }}.svc
     - {{ template "chart.name" . }}-admission.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: {{ .Values.certificates.issuer.kind }}
     name: {{ template "chart.issuerName" . }}
-  secretName: {{ template "chart.name" . }}-admission-tls
+  secretName: {{ template "chart.name" . }}-runtimehooks-tls

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml
@@ -49,7 +49,6 @@ spec:
         {{- range $k, $v := .Values.hooks.ccm.aws.k8sMinorVersionToCCMVersion }}
         - --ccm.aws.aws-ccm-versions={{ $k }}={{ $v }}
         {{- end }}
-        - --admission-webhook-cert-dir=/admission-certs/
         {{- range $key, $value := .Values.extraArgs }}
         - --{{ $key }}={{ $value }}
         {{- end }}
@@ -62,9 +61,6 @@ spec:
         ports:
         - containerPort: 9443
           name: runtimehooks
-          protocol: TCP
-        - containerPort: 9444
-          name: admission
           protocol: TCP
         - containerPort: 8080
           name: metrics
@@ -84,9 +80,6 @@ spec:
         volumeMounts:
         - mountPath: /runtimehooks-certs
           name: runtimehooks-cert
-          readOnly: true
-        - mountPath: /admission-certs
-          name: admission-cert
           readOnly: true
         livenessProbe:
           httpGet:
@@ -109,7 +102,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ template "chart.name" . }}-runtimehooks-tls
-      - name: admission-cert
-        secret:
-          defaultMode: 420
-          secretName: {{ template "chart.name" . }}-admission-tls

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/webhooks.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/webhooks.yaml
@@ -6,7 +6,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: '{{ include "chart.name" . }}-mutating-webhook-configuration'
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace}}/{{ template "chart.name" . }}-admission-tls'
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace}}/{{ template "chart.name" . }}-runtimehooks-tls'
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -61,7 +61,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: '{{ include "chart.name" . }}-validating-webhook-configuration'
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace}}/{{ template "chart.name" . }}-admission-tls'
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace}}/{{ template "chart.name" . }}-runtimehooks-tls'
 webhooks:
   - admissionReviewVersions:
       - v1

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,10 +66,6 @@ func main() {
 	utilruntime.Must(capxv1.AddToScheme(clientScheme))
 	utilruntime.Must(metallbv1.AddToScheme(clientScheme))
 
-	webhookOptions := webhook.Options{
-		Port:    9444,
-		CertDir: "/admission-certs",
-	}
 	mgrOptions := &ctrl.Options{
 		Scheme: clientScheme,
 		Metrics: metricsserver.Options{
@@ -77,7 +73,6 @@ func main() {
 		},
 		HealthProbeBindAddress: ":8081",
 		LeaderElection:         false,
-		WebhookServer:          webhook.NewServer(webhookOptions),
 	}
 
 	pflag.CommandLine.StringVar(
@@ -96,13 +91,6 @@ func main() {
 
 	pflag.CommandLine.StringVar(&mgrOptions.PprofBindAddress, "profiler-address", "",
 		"Bind address to expose the pprof profiler (e.g. localhost:6060)")
-
-	pflag.CommandLine.StringVar(
-		&webhookOptions.CertDir,
-		"admission-webhook-cert-dir",
-		webhookOptions.CertDir,
-		"Admission webhooks server cert dir.",
-	)
 
 	logOptions := logs.NewOptions()
 
@@ -169,6 +157,13 @@ func main() {
 
 	signalCtx := ctrl.SetupSignalHandler()
 
+	webhookServer, err := server.NewWebhookServer(runtimeWebhookServerOpts)
+	if err != nil {
+		setupLog.Error(err, "failed to create webhook server")
+		os.Exit(1)
+	}
+	mgrOptions.WebhookServer = webhookServer
+
 	mgr, err := newManager(mgrOptions)
 	if err != nil {
 		setupLog.Error(err, "failed to create a new controller manager")
@@ -184,10 +179,8 @@ func main() {
 		genericMetaHandlers.AllHandlers(mgr),
 	)
 
-	runtimeWebhookServer := server.NewServer(runtimeWebhookServerOpts, allHandlers...)
-
-	if err := mgr.Add(runtimeWebhookServer); err != nil {
-		setupLog.Error(err, "unable to add runtime webhook server runnable to controller manager")
+	if err := server.AddHandlers(mgr.GetWebhookServer(), allHandlers...); err != nil {
+		setupLog.Error(err, "unable to register runtime extension handlers")
 		os.Exit(1)
 	}
 

--- a/common/pkg/server/server.go
+++ b/common/pkg/server/server.go
@@ -4,39 +4,19 @@
 package server
 
 import (
-	"context"
+	"fmt"
 	"strings"
 
 	"github.com/spf13/pflag"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1"
 	runtimecatalog "sigs.k8s.io/cluster-api/exp/runtime/catalog"
 	runtimeserver "sigs.k8s.io/cluster-api/exp/runtime/server"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/lifecycle"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 )
-
-type Server struct {
-	catalog *runtimecatalog.Catalog
-	hooks   []handlers.Named
-
-	opts *ServerOptions
-}
-
-func NewServer(opts *ServerOptions, hooks ...handlers.Named) *Server {
-	// catalog contains all information about RuntimeHooks.
-	catalog := runtimecatalog.New()
-
-	_ = runtimehooksv1.AddToCatalog(catalog)
-
-	return &Server{
-		catalog: catalog,
-		opts:    opts,
-		hooks:   hooks,
-	}
-}
 
 type ServerOptions struct {
 	webhookPort    int
@@ -44,7 +24,9 @@ type ServerOptions struct {
 }
 
 func NewServerOptions() *ServerOptions {
-	return &ServerOptions{}
+	return &ServerOptions{
+		webhookPort: 9443,
+	}
 }
 
 func (s *ServerOptions) AddFlags(fs *pflag.FlagSet) {
@@ -54,126 +36,114 @@ func (s *ServerOptions) AddFlags(fs *pflag.FlagSet) {
 		&s.webhookCertDir,
 		"webhook-cert-dir",
 		s.webhookCertDir,
-		"Runtime hooks server cert dir.",
+		"Webhook server cert dir.",
 	)
 }
 
-// NeedLeaderElection implements the LeaderElectionRunnable interface, which indicates
-// the webhook server doesn't need leader election.
-func (*Server) NeedLeaderElection() bool {
-	return false
+// NewWebhookServer creates a CAPI runtime extension server that implements
+// controller-runtime's webhook.Server. Use it as manager.Options.WebhookServer so
+// admission and runtime hooks share one HTTPS listener. Call AddHandlers before
+// manager.Start; do not Start the server separately.
+func NewWebhookServer(opts *ServerOptions) (webhook.Server, error) {
+	catalog := runtimecatalog.New()
+	_ = runtimehooksv1.AddToCatalog(catalog)
+
+	return runtimeserver.New(runtimeserver.Options{
+		Catalog: catalog,
+		Port:    opts.webhookPort,
+		CertDir: opts.webhookCertDir,
+	})
 }
 
-func (s *Server) Start(ctx context.Context) error {
-	// Creates a logger to be used during the main func.
-	setupLog := ctrl.Log.WithName("runtimehooks")
-
-	// Create a http server for serving runtime extensions
-	webhookServer, err := runtimeserver.New(runtimeserver.Options{
-		Catalog: s.catalog,
-		Port:    s.opts.webhookPort,
-		CertDir: s.opts.webhookCertDir,
-	})
-	if err != nil {
-		setupLog.Error(err, "error creating webhook server")
-		return err
+// AddHandlers registers runtime extension handlers on a server returned by
+// NewWebhookServer. Path registration and listening happen in the server's Start,
+// which the manager invokes.
+func AddHandlers(s webhook.Server, hooks ...handlers.Named) error {
+	rs, ok := s.(*runtimeserver.Server)
+	if !ok {
+		return fmt.Errorf("webhook server is %T, want *runtimeserver.Server", s)
 	}
 
-	for _, h := range s.hooks {
+	for _, h := range hooks {
 		if t, ok := h.(lifecycle.BeforeClusterCreate); ok {
-			if err := webhookServer.AddExtensionHandler(runtimeserver.ExtensionHandler{
+			if err := rs.AddExtensionHandler(runtimeserver.ExtensionHandler{
 				Hook:        runtimehooksv1.BeforeClusterCreate,
 				Name:        strings.ToLower(h.Name()) + "-bcc",
 				HandlerFunc: t.BeforeClusterCreate,
 			}); err != nil {
-				setupLog.Error(err, "error adding handler")
 				return err
 			}
 		}
 
 		if t, ok := h.(lifecycle.AfterControlPlaneInitialized); ok {
-			if err := webhookServer.AddExtensionHandler(runtimeserver.ExtensionHandler{
+			if err := rs.AddExtensionHandler(runtimeserver.ExtensionHandler{
 				Hook:        runtimehooksv1.AfterControlPlaneInitialized,
 				Name:        strings.ToLower(h.Name()) + "-acpi",
 				HandlerFunc: t.AfterControlPlaneInitialized,
 			}); err != nil {
-				setupLog.Error(err, "error adding handler")
 				return err
 			}
 		}
 
 		if t, ok := h.(lifecycle.BeforeClusterUpgrade); ok {
-			if err := webhookServer.AddExtensionHandler(runtimeserver.ExtensionHandler{
+			if err := rs.AddExtensionHandler(runtimeserver.ExtensionHandler{
 				Hook:        runtimehooksv1.BeforeClusterUpgrade,
 				Name:        strings.ToLower(h.Name()) + "-bcu",
 				HandlerFunc: t.BeforeClusterUpgrade,
 			}); err != nil {
-				setupLog.Error(err, "error adding handler")
 				return err
 			}
 		}
 
 		if t, ok := h.(lifecycle.AfterControlPlaneUpgrade); ok {
-			if err := webhookServer.AddExtensionHandler(runtimeserver.ExtensionHandler{
+			if err := rs.AddExtensionHandler(runtimeserver.ExtensionHandler{
 				Hook:        runtimehooksv1.AfterControlPlaneUpgrade,
 				Name:        h.Name() + "-acpu",
 				HandlerFunc: t.AfterControlPlaneUpgrade,
 			}); err != nil {
-				setupLog.Error(err, "error adding handler")
 				return err
 			}
 		}
 
 		if t, ok := h.(lifecycle.BeforeClusterDelete); ok {
-			if err := webhookServer.AddExtensionHandler(runtimeserver.ExtensionHandler{
+			if err := rs.AddExtensionHandler(runtimeserver.ExtensionHandler{
 				Hook:        runtimehooksv1.BeforeClusterDelete,
 				Name:        strings.ToLower(h.Name()) + "-bcd",
 				HandlerFunc: t.BeforeClusterDelete,
 			}); err != nil {
-				setupLog.Error(err, "error adding handler")
 				return err
 			}
 		}
 
 		if t, ok := h.(mutation.DiscoverVariables); ok {
-			if err := webhookServer.AddExtensionHandler(runtimeserver.ExtensionHandler{
+			if err := rs.AddExtensionHandler(runtimeserver.ExtensionHandler{
 				Hook:        runtimehooksv1.DiscoverVariables,
 				Name:        strings.ToLower(h.Name()) + "-dv",
 				HandlerFunc: t.DiscoverVariables,
 			}); err != nil {
-				setupLog.Error(err, "error adding handler")
 				return err
 			}
 		}
 
 		if t, ok := h.(mutation.GeneratePatches); ok {
-			if err := webhookServer.AddExtensionHandler(runtimeserver.ExtensionHandler{
+			if err := rs.AddExtensionHandler(runtimeserver.ExtensionHandler{
 				Hook:        runtimehooksv1.GeneratePatches,
 				Name:        strings.ToLower(h.Name()) + "-gp",
 				HandlerFunc: t.GeneratePatches,
 			}); err != nil {
-				setupLog.Error(err, "error adding handler")
 				return err
 			}
 		}
 
 		if t, ok := h.(mutation.ValidateTopology); ok {
-			if err := webhookServer.AddExtensionHandler(runtimeserver.ExtensionHandler{
+			if err := rs.AddExtensionHandler(runtimeserver.ExtensionHandler{
 				Hook:        runtimehooksv1.ValidateTopology,
 				Name:        strings.ToLower(h.Name()) + "-vt",
 				HandlerFunc: t.ValidateTopology,
 			}); err != nil {
-				setupLog.Error(err, "error adding handler")
 				return err
 			}
 		}
-	}
-
-	// Start the https server.
-	setupLog.Info("Starting Runtime Extension server")
-	if err := webhookServer.Start(ctx); err != nil {
-		setupLog.Error(err, "error running webhook server")
-		return err
 	}
 
 	return nil

--- a/common/pkg/server/server_test.go
+++ b/common/pkg/server/server_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type namedStub struct{}
+
+func (namedStub) Name() string { return "stub" }
+
+func TestNewWebhookServer_ImplementsWebhookServer(t *testing.T) {
+	t.Parallel()
+	opts := NewServerOptions()
+	opts.webhookPort = 0
+	opts.webhookCertDir = t.TempDir()
+	ws, err := NewWebhookServer(opts)
+	require.NoError(t, err)
+	require.NotNil(t, ws)
+	_, ok := any(ws).(webhook.Server)
+	assert.True(t, ok)
+}
+
+func TestAddHandlersAndAdmissionShareListener(t *testing.T) {
+	t.Parallel()
+
+	certDir := t.TempDir()
+	require.NoError(t, writeTestServingCerts(certDir))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
+	opts := NewServerOptions()
+	opts.webhookPort = port
+	opts.webhookCertDir = certDir
+
+	ws, err := NewWebhookServer(opts)
+	require.NoError(t, err)
+	require.NoError(t, AddHandlers(ws, namedStub{}))
+
+	ws.Register("/mutate-test", &webhook.Admission{
+		Handler: admission.HandlerFunc(func(_ context.Context, _ admission.Request) admission.Response {
+			return admission.Allowed("")
+		}),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- ws.Start(ctx) }()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test-only
+		},
+	}
+	require.Eventually(t, func() bool {
+		resp, err := client.Post(
+			fmt.Sprintf("https://127.0.0.1:%d/hooks.runtime.cluster.x-k8s.io/v1alpha1/discovery", port),
+			"application/json",
+			nil,
+		)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode == http.StatusOK
+	}, 10*time.Second, 50*time.Millisecond)
+
+	resp, err := client.Post(
+		fmt.Sprintf("https://127.0.0.1:%d/mutate-test", port),
+		"application/json",
+		nil,
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	// Admission may 400 on empty body; connection + TLS + route hit is enough.
+	assert.NotEqual(t, http.StatusNotFound, resp.StatusCode)
+
+	cancel()
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not shut down")
+	}
+}
+
+func TestServerOptions_NoAdmissionCertDirFlag(t *testing.T) {
+	t.Parallel()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	NewServerOptions().AddFlags(fs)
+	assert.Nil(t, fs.Lookup("admission-webhook-cert-dir"))
+	assert.NotNil(t, fs.Lookup("webhook-port"))
+	assert.NotNil(t, fs.Lookup("webhook-cert-dir"))
+}
+
+func writeTestServingCerts(dir string) error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return err
+	}
+	certOut, err := os.Create(filepath.Join(dir, "tls.crt"))
+	if err != nil {
+		return err
+	}
+	defer certOut.Close()
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		return err
+	}
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return err
+	}
+	keyOut, err := os.Create(filepath.Join(dir, "tls.key"))
+	if err != nil {
+		return err
+	}
+	defer keyOut.Close()
+	return pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+}

--- a/hack/update-webhook-configurations.yq
+++ b/hack/update-webhook-configurations.yq
@@ -6,7 +6,7 @@
 
 with(.metadata;
   .name = "{{ include \"chart.name\" . }}-" + .name,
-  .annotations["cert-manager.io/inject-ca-from"] = "{{ .Release.Namespace}}/{{ template \"chart.name\" . }}-admission-tls"
+  .annotations["cert-manager.io/inject-ca-from"] = "{{ .Release.Namespace}}/{{ template \"chart.name\" . }}-runtimehooks-tls"
 ) |
 with(.webhooks[].clientConfig.service;
   .name = "{{ include \"chart.name\" . }}-admission",


### PR DESCRIPTION
## Summary
- Serve runtime hooks and admission on one webhook listener/TLS cert (port 9443, `runtimehooks-tls`)
- Keep separate Services; drop `admission-tls` / 9444 / `--admission-webhook-cert-dir`

## Test plan
- [ ] `go test ./common/pkg/server/`
- [ ] Helm render: one Certificate, both Services → `runtimehooks`, no 9444
- [ ] Runtime Discovery + admission path against shared cert