### PR TITLE
fix: kubeletconfiguration webhook for md overrides

### DIFF
--- a/pkg/webhook/cluster/kubeletconfiguration_validator.go
+++ b/pkg/webhook/cluster/kubeletconfiguration_validator.go
@@ -88,16 +88,67 @@ func (k *kubeletConfigurationValidator) validate(
 		})
 	}
 
-	workerConfig, err := variables.UnmarshalWorkerConfigVariable(
+	defaultWorkerConfig, err := variables.UnmarshalWorkerConfigVariable(
 		cluster.Spec.Topology.Variables,
 	)
-	if err == nil && workerConfig != nil {
+	if err != nil {
+		return admission.Denied(
+			fmt.Errorf(
+				"failed to unmarshal cluster topology variable %q: %w",
+				v1alpha1.WorkerConfigVariableName,
+				err,
+			).Error(),
+		)
+	}
+	if defaultWorkerConfig != nil {
+		cfgsToValidate = append(cfgsToValidate, struct {
+			cfg  *v1alpha1.KubeletConfiguration
+			path string
+		}{
+			defaultWorkerConfig.KubeletConfiguration,
+			"workerConfig.kubeletConfiguration",
+		})
+	}
+
+	for i := range cluster.Spec.Topology.Workers.MachineDeployments {
+		md := cluster.Spec.Topology.Workers.MachineDeployments[i]
+		mdWorkerConfigPath := fmt.Sprintf(
+			"workers.machineDeployments[%q].variables.overrides[workerConfig].kubeletConfiguration",
+			md.Name,
+		)
+
+		var workerConfig *variables.WorkerNodeConfigSpec
+		if len(md.Variables.Overrides) > 0 {
+			workerConfig, err = variables.UnmarshalWorkerConfigVariable(md.Variables.Overrides)
+			if err != nil {
+				return admission.Denied(
+					fmt.Errorf(
+						"failed to unmarshal worker overrides variable %q for machineDeployment %q: %w",
+						v1alpha1.WorkerConfigVariableName,
+						md.Name,
+						err,
+					).Error(),
+				)
+			}
+		}
+
+		cfgPath := mdWorkerConfigPath
+		if workerConfig == nil {
+			workerConfig = defaultWorkerConfig
+			cfgPath = "workerConfig.kubeletConfiguration"
+		}
+
+		// skip validation, if no config on MachineDeployment or global worker config
+		if workerConfig == nil {
+			continue
+		}
+
 		cfgsToValidate = append(cfgsToValidate, struct {
 			cfg  *v1alpha1.KubeletConfiguration
 			path string
 		}{
 			workerConfig.KubeletConfiguration,
-			"workerConfig.kubeletConfiguration",
+			cfgPath,
 		})
 	}
 
@@ -146,9 +197,16 @@ func (k *kubeletConfigurationValidator) validate(
 	hasControlPlaneMaxParallel := clusterConfig.ControlPlane != nil &&
 		clusterConfig.ControlPlane.KubeletConfiguration != nil &&
 		clusterConfig.ControlPlane.KubeletConfiguration.MaxParallelImagePulls != nil
-	hasWorkerMaxParallel := workerConfig != nil &&
-		workerConfig.KubeletConfiguration != nil &&
-		workerConfig.KubeletConfiguration.MaxParallelImagePulls != nil
+	hasWorkerMaxParallel := false
+	for _, entry := range cfgsToValidate {
+		if entry.path == "clusterConfig.controlPlane.kubeletConfiguration" || entry.cfg == nil {
+			continue
+		}
+		if entry.cfg.MaxParallelImagePulls != nil {
+			hasWorkerMaxParallel = true
+			break
+		}
+	}
 	if clusterConfig.MaxParallelImagePullsPerNode != nil &&
 		(hasControlPlaneMaxParallel || hasWorkerMaxParallel) {
 		warnings = append(

--- a/pkg/webhook/cluster/kubeletconfiguration_validator.go
+++ b/pkg/webhook/cluster/kubeletconfiguration_validator.go
@@ -156,40 +156,7 @@ func (k *kubeletConfigurationValidator) validate(
 		if entry.cfg == nil {
 			continue
 		}
-
-		if entry.cfg.AutomaticReservations != nil {
-			if len(entry.cfg.SystemReserved) > 0 ||
-				len(entry.cfg.KubeReserved) > 0 ||
-				len(entry.cfg.EvictionHard) > 0 {
-				return admission.Denied(fmt.Sprintf(
-					"%s: automaticReservations cannot be combined with "+
-						"systemReserved, kubeReserved, or evictionHard",
-					entry.path,
-				))
-			}
-		}
-
-		if entry.cfg.CPUManagerPolicy != nil &&
-			*entry.cfg.CPUManagerPolicy == v1alpha1.CPUManagerPolicyStatic {
-			hasCPU := hasCPUReservation(entry.cfg.SystemReserved) ||
-				hasCPUReservation(entry.cfg.KubeReserved)
-			if !hasCPU {
-				return admission.Denied(fmt.Sprintf(
-					"%s: cpuManagerPolicy 'static' requires CPU "+
-						"reservation in systemReserved or kubeReserved",
-					entry.path,
-				))
-			}
-		}
-
-		if err := validateEvictionThresholds(
-			entry.cfg.EvictionHard, entry.path+".evictionHard",
-		); err != nil {
-			return admission.Denied(err.Error())
-		}
-		if err := validateEvictionThresholds(
-			entry.cfg.EvictionSoft, entry.path+".evictionSoft",
-		); err != nil {
+		if err := validateKubeletConfig(entry.cfg, entry.path); err != nil {
 			return admission.Denied(err.Error())
 		}
 	}
@@ -229,6 +196,44 @@ func hasCPUReservation(reserved map[string]resource.Quantity) bool {
 	}
 	_, ok := reserved["cpu"]
 	return ok
+}
+
+func validateKubeletConfig(cfg *v1alpha1.KubeletConfiguration, path string) error {
+	if cfg.AutomaticReservations != nil {
+		if len(cfg.SystemReserved) > 0 ||
+			len(cfg.KubeReserved) > 0 ||
+			len(cfg.EvictionHard) > 0 {
+			return fmt.Errorf(
+				"%s: automaticReservations cannot be combined with systemReserved, kubeReserved, or evictionHard",
+				path,
+			)
+		}
+	}
+
+	if cfg.CPUManagerPolicy != nil &&
+		*cfg.CPUManagerPolicy == v1alpha1.CPUManagerPolicyStatic {
+		hasCPU := hasCPUReservation(cfg.SystemReserved) ||
+			hasCPUReservation(cfg.KubeReserved)
+		if !hasCPU {
+			return fmt.Errorf(
+				"%s: cpuManagerPolicy 'static' requires CPU reservation in systemReserved or kubeReserved",
+				path,
+			)
+		}
+	}
+
+	if err := validateEvictionThresholds(
+		cfg.EvictionHard, path+".evictionHard",
+	); err != nil {
+		return err
+	}
+	if err := validateEvictionThresholds(
+		cfg.EvictionSoft, path+".evictionSoft",
+	); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func validateEvictionThresholds(thresholds map[string]string, fieldPath string) error {

--- a/pkg/webhook/cluster/kubeletconfiguration_validator_test.go
+++ b/pkg/webhook/cluster/kubeletconfiguration_validator_test.go
@@ -288,6 +288,162 @@ var _ = Describe("KubeletConfigurationValidator", func() {
 			))
 		})
 	})
+
+	Context("workerConfig in machineDeployment override", func() {
+		clusterConfig := &variables.ClusterConfigSpec{}
+
+		It("should reject when cpuManagerPolicy=static has no CPU reservation", func() {
+			workerConfig := &variables.WorkerNodeConfigSpec{
+				KubeadmNodeSpec: v1alpha1.KubeadmNodeSpec{
+					KubeletConfiguration: &v1alpha1.KubeletConfiguration{
+						CPUManagerPolicy: ptrOf(v1alpha1.CPUManagerPolicyStatic),
+					},
+				},
+			}
+			cluster := createClusterWithWorkerConfigAndOverrides(
+				clusterConfig,
+				nil,
+				map[string]*variables.WorkerNodeConfigSpec{
+					"md-0": workerConfig,
+				},
+			)
+			req := createKubeletAdmissionRequest(cluster)
+
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+			validator = NewKubeletConfigurationValidator(client, decoder)
+
+			resp := validator.validate(context.Background(), req)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Result.Message).To(ContainSubstring(
+				`workers.machineDeployments["md-0"].variables.overrides[workerConfig].kubeletConfiguration`,
+			))
+			Expect(resp.Result.Message).To(ContainSubstring(
+				"cpuManagerPolicy 'static' requires CPU reservation in systemReserved or kubeReserved",
+			))
+		})
+
+		It("should accept when cpuManagerPolicy=static has CPU in systemReserved", func() {
+			workerConfig := &variables.WorkerNodeConfigSpec{
+				KubeadmNodeSpec: v1alpha1.KubeadmNodeSpec{
+					KubeletConfiguration: &v1alpha1.KubeletConfiguration{
+						CPUManagerPolicy: ptrOf(v1alpha1.CPUManagerPolicyStatic),
+						SystemReserved: map[string]resource.Quantity{
+							"cpu": resource.MustParse("200m"),
+						},
+					},
+				},
+			}
+			cluster := createClusterWithWorkerConfigAndOverrides(
+				clusterConfig,
+				nil,
+				map[string]*variables.WorkerNodeConfigSpec{
+					"md-0": workerConfig,
+				},
+			)
+			req := createKubeletAdmissionRequest(cluster)
+
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+			validator = NewKubeletConfigurationValidator(client, decoder)
+
+			resp := validator.validate(context.Background(), req)
+			Expect(resp.Allowed).To(BeTrue())
+		})
+
+		It("should reject invalid eviction threshold value", func() {
+			workerConfig := &variables.WorkerNodeConfigSpec{
+				KubeadmNodeSpec: v1alpha1.KubeadmNodeSpec{
+					KubeletConfiguration: &v1alpha1.KubeletConfiguration{
+						EvictionHard: map[string]string{
+							"memory.available": "bad-threshold",
+						},
+					},
+				},
+			}
+			cluster := createClusterWithWorkerConfigAndOverrides(
+				clusterConfig,
+				nil,
+				map[string]*variables.WorkerNodeConfigSpec{
+					"md-0": workerConfig,
+				},
+			)
+			req := createKubeletAdmissionRequest(cluster)
+
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+			validator = NewKubeletConfigurationValidator(client, decoder)
+
+			resp := validator.validate(context.Background(), req)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Result.Message).To(ContainSubstring(
+				`workers.machineDeployments["md-0"].variables.overrides[workerConfig].kubeletConfiguration.evictionHard`,
+			))
+			Expect(resp.Result.Message).To(ContainSubstring("invalid eviction threshold value"))
+		})
+
+		It("should reject automaticReservations with kubeReserved", func() {
+			workerConfig := &variables.WorkerNodeConfigSpec{
+				KubeadmNodeSpec: v1alpha1.KubeadmNodeSpec{
+					KubeletConfiguration: &v1alpha1.KubeletConfiguration{
+						AutomaticReservations: &v1alpha1.AutomaticReservations{
+							Profile: v1alpha1.ReservationProfileCapacityTiered,
+						},
+						KubeReserved: map[string]resource.Quantity{
+							"cpu": resource.MustParse("300m"),
+						},
+					},
+				},
+			}
+			cluster := createClusterWithWorkerConfigAndOverrides(
+				clusterConfig,
+				nil,
+				map[string]*variables.WorkerNodeConfigSpec{
+					"md-0": workerConfig,
+				},
+			)
+			req := createKubeletAdmissionRequest(cluster)
+
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+			validator = NewKubeletConfigurationValidator(client, decoder)
+
+			resp := validator.validate(context.Background(), req)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Result.Message).To(ContainSubstring(
+				`workers.machineDeployments["md-0"].variables.overrides[workerConfig].kubeletConfiguration`,
+			))
+			Expect(resp.Result.Message).To(ContainSubstring("automaticReservations cannot be combined with"))
+		})
+
+		It("should allow with warning when maxParallelImagePullsPerNode conflicts with worker override", func() {
+			clusterConfig := &variables.ClusterConfigSpec{
+				KubeadmClusterConfigSpec: v1alpha1.KubeadmClusterConfigSpec{
+					MaxParallelImagePullsPerNode: ptr.To(int32(4)), //nolint:staticcheck // testing deprecated field
+				},
+			}
+			workerConfig := &variables.WorkerNodeConfigSpec{
+				KubeadmNodeSpec: v1alpha1.KubeadmNodeSpec{
+					KubeletConfiguration: &v1alpha1.KubeletConfiguration{
+						MaxParallelImagePulls: ptr.To(int32(8)),
+					},
+				},
+			}
+			cluster := createClusterWithWorkerConfigAndOverrides(
+				clusterConfig,
+				nil,
+				map[string]*variables.WorkerNodeConfigSpec{
+					"md-0": workerConfig,
+				},
+			)
+			req := createKubeletAdmissionRequest(cluster)
+
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+			validator = NewKubeletConfigurationValidator(client, decoder)
+
+			resp := validator.validate(context.Background(), req)
+			Expect(resp.Allowed).To(BeTrue())
+			Expect(resp.Warnings).To(ContainElement(
+				ContainSubstring("maxParallelImagePullsPerNode will be ignored"),
+			))
+		})
+	})
 })
 
 func ptrOf[T any](v T) *T {
@@ -333,7 +489,10 @@ func createClusterWithKubeletConfig(cfg *v1alpha1.KubeletConfiguration) *cluster
 func createKubeletAdmissionRequest(cluster *clusterv1beta2.Cluster) admission.Request {
 	objRaw, err := json.Marshal(cluster)
 	Expect(err).NotTo(HaveOccurred())
+	return createKubeletAdmissionRequestRaw(objRaw)
+}
 
+func createKubeletAdmissionRequestRaw(objRaw []byte) admission.Request {
 	return admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{
 			Operation: admissionv1.Create,
@@ -347,4 +506,93 @@ func createKubeletAdmissionRequest(cluster *clusterv1beta2.Cluster) admission.Re
 			},
 		},
 	}
+}
+
+func createClusterWithWorkerConfigAndOverrides(
+	clusterConfig *variables.ClusterConfigSpec,
+	topLevelWorkerConfig *variables.WorkerNodeConfigSpec,
+	workerOverrides map[string]*variables.WorkerNodeConfigSpec,
+) *clusterv1beta2.Cluster {
+	var clusterVars []clusterv1beta2.ClusterVariable
+
+	if topLevelWorkerConfig != nil {
+		workerConfigRaw, err := json.Marshal(topLevelWorkerConfig)
+		Expect(err).NotTo(HaveOccurred())
+		clusterVars = append(clusterVars, clusterv1beta2.ClusterVariable{
+			Name:  v1alpha1.WorkerConfigVariableName,
+			Value: apiextensionsv1.JSON{Raw: workerConfigRaw},
+		})
+	}
+
+	mdOverrides := map[string][]clusterv1beta2.ClusterVariable{}
+	for mdName, workerConfig := range workerOverrides {
+		raw, err := json.Marshal(workerConfig)
+		Expect(err).NotTo(HaveOccurred())
+		mdOverrides[mdName] = []clusterv1beta2.ClusterVariable{
+			{
+				Name:  v1alpha1.WorkerConfigVariableName,
+				Value: apiextensionsv1.JSON{Raw: raw},
+			},
+		}
+	}
+
+	return createClusterWithRawVariables(clusterConfig, clusterVars, mdOverrides)
+}
+
+func createClusterWithRawVariables(
+	clusterConfig *variables.ClusterConfigSpec,
+	topologyVariables []clusterv1beta2.ClusterVariable,
+	mdOverrides map[string][]clusterv1beta2.ClusterVariable,
+) *clusterv1beta2.Cluster {
+	cluster := &clusterv1beta2.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: clusterv1beta2.ClusterSpec{
+			Topology: clusterv1beta2.Topology{
+				ClassRef: clusterv1beta2.ClusterClassRef{
+					Name: "test-class",
+				},
+				Version: "v1.30.0",
+			},
+		},
+	}
+
+	var vars []clusterv1beta2.ClusterVariable
+	if clusterConfig != nil {
+		clusterConfigRaw, err := json.Marshal(clusterConfig)
+		Expect(err).NotTo(HaveOccurred())
+		vars = append(vars, clusterv1beta2.ClusterVariable{
+			Name:  v1alpha1.ClusterConfigVariableName,
+			Value: apiextensionsv1.JSON{Raw: clusterConfigRaw},
+		})
+	}
+	vars = append(vars, topologyVariables...)
+	cluster.Spec.Topology.Variables = vars
+
+	for mdName, overrides := range mdOverrides {
+		cluster.Spec.Topology.Workers.MachineDeployments = append(
+			cluster.Spec.Topology.Workers.MachineDeployments,
+			clusterv1beta2.MachineDeploymentTopology{
+				Name:  mdName,
+				Class: "default-worker",
+				Variables: clusterv1beta2.MachineDeploymentVariables{
+					Overrides: overrides,
+				},
+			},
+		)
+	}
+
+	if len(cluster.Spec.Topology.Workers.MachineDeployments) == 0 {
+		cluster.Spec.Topology.Workers.MachineDeployments = append(
+			cluster.Spec.Topology.Workers.MachineDeployments,
+			clusterv1beta2.MachineDeploymentTopology{
+				Name:  "md-0",
+				Class: "default-worker",
+			},
+		)
+	}
+
+	return cluster
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
We got a report that the webhook was not properly running when the override is set for a machineDeployment

```
...
         variables:
            overrides:
            - name: workerConfig
              value:
                kubeletConfiguration:
                  cpuManagerPolicy: static 
                nodeRegistration:
                  ignorePreflightErrors:
                  - SystemVerification
                  -
``` 
Which resulted in:
```
...
Jul 28 20:14:00 can-test-md-0-brn6j-6dvqr-b5pvm kubelet[3673]: I0728 20:14:00.762837    3673 topology_manager.go:143] "Creating topology manager with none policy"
Jul 28 20:14:00 can-test-md-0-brn6j-6dvqr-b5pvm kubelet[3673]: I0728 20:14:00.762887    3673 container_manager_linux.go:308] "Creating device plugin manager"
Jul 28 20:14:00 can-test-md-0-brn6j-6dvqr-b5pvm kubelet[3673]: I0728 20:14:00.762993    3673 container_manager_linux.go:317] "Creating Dynamic Resource Allocation (DRA) manager"
Jul 28 20:14:00 can-test-md-0-brn6j-6dvqr-b5pvm kubelet[3673]: I0728 20:14:00.767606    3673 cpu_manager.go:181] "Detected CPU topology" topology={"NumCPUs":8,"NumCores":8,"NumUncoreCache":8,"NumSockets":8,"NumNUMANodes":1,"CPUDetails":{"0":{"NUMANodeID":0,"Socket>
Jul 28 20:14:00 can-test-md-0-brn6j-6dvqr-b5pvm kubelet[3673]: E0728 20:14:00.767766    3673 container_manager_linux.go:339] "Failed to initialize cpu manager" err="[cpumanager] unable to determine reserved CPU resources for static policy"
Jul 28 20:14:00 can-test-md-0-brn6j-6dvqr-b5pvm kubelet[3673]: E0728 20:14:00.767825    3673 run.go:72] "command failed" err="failed to run Kubelet: [cpumanager] unable to determine reserved CPU resources for static policy"
Jul 28 20:14:00 can-test-md-0-brn6j-6dvqr-b5pvm systemd[1]: kubelet.service: Main process exited, code=exited, status=1/FAILURE
```

This PR extends the webhook to also check the machineDeployment override variables. 

**Which issue(s) this PR fixes**:
Fixes https://jira.nutanix.com/browse/NCN-116355

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
New unit tests.

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
I added the second commit to fix gocylco error. It might be easier to review commits separately to see the diffs. 
