### PR TITLE
feat: add dev-vm pre-PR test runner on dynamic PC VMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ golangci-lint-kube-api-linter
 
 # Cursor IDE - ignore local/user state, commit shared rules
 .cursor/mcp.json
+
+# results produced by hack/dev-vm/caren-pc-test.sh
+test-results/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,19 @@
 repos:
 - repo: local
   hooks:
+  # Manual-stage only: runs the CI checks on a dynamic Prism Central VM against
+  # your local working tree and writes test-results/<ts>/RESULTS.md for the PR.
+  # Requires NUTANIX_USER/NUTANIX_PASSWORD - see hack/dev-vm/README.md.
+  # Invoke with: pre-commit run caren-pc-test --hook-stage manual
+  - id: caren-pc-test
+    name: Run the CI checks on a dynamic PC VM (pre-PR gate)
+    entry: hack/dev-vm/caren-pc-test.sh run
+    language: script
+    pass_filenames: false
+    always_run: true
+    require_serial: true
+    verbose: true
+    stages: [manual]
   - id: schema-chart
     name: schema-chart
     entry: make schema-chart

--- a/hack/dev-vm/README.md
+++ b/hack/dev-vm/README.md
@@ -1,0 +1,140 @@
+# Run the CAREN checks on a dev VM (pre-PR gate)
+
+Run the same checks CI runs — on a Prism Central VM created on demand —
+against your **local working tree**, before you commit or push.
+
+You never log into the VM. One command from your laptop provisions it, runs the
+checks, copies the results back, and deletes the VM.
+
+---
+
+## 1. One-time setup (~2 minutes)
+
+```bash
+gh auth login --web     # avoids anonymous GitHub API rate limits during tool downloads
+```
+
+You also need to be **on VPN** (the PC subnet must be reachable) and have
+`python3`, `ssh` and `git` — all standard on macOS.
+
+CAREN has no private Go module dependencies, so no SAML SSO gymnastics are
+needed (unlike konvoy2 or kommander).
+
+## 2. Get Prism Central credentials
+
+They rotate every few days, so fetch fresh ones when a run fails with `401`:
+
+```bash
+cd <your tam-cli checkout> && ./tam login pc-dev
+```
+
+It prints ready-to-paste `export NUTANIX_USER=… / export NUTANIX_PASSWORD=…`
+lines.
+
+## 3. Run the checks
+
+```bash
+export NUTANIX_USER=<pc-username>
+export NUTANIX_PASSWORD=<pc-password>
+
+cd <your CAREN checkout>
+./hack/dev-vm/caren-pc-test.sh run
+```
+
+Or through the pre-commit hook that ships with this repo:
+
+```bash
+pre-commit run caren-pc-test --hook-stage manual
+```
+
+### What exactly gets tested
+
+Your **local working tree** — committed, uncommitted and untracked files alike.
+No commit or push required; that is the point of a pre-commit gate.
+
+Mechanically the VM clones the repo history from `origin` (fast, and needed for
+tags), and the script ships only your delta on top of it: commits you have not
+pushed as a git bundle, edits to tracked files as a patch, and untracked files
+as a tarball. Files ignored by `.gitignore` are not sent. `RESULTS.md` records
+when a run came from a dirty tree.
+
+### Suites
+
+Default set is `precommit unit lint` — the fast blocking jobs in
+`.github/workflows/checks.yml` (~25 min). The heavier suites are opt-in:
+
+```bash
+./hack/dev-vm/caren-pc-test.sh run --suites "precommit unit lint helm"
+./hack/dev-vm/caren-pc-test.sh run --suites "e2e-docker"          # Quick start focus
+E2E_FOCUS='Self-hosted' ./hack/dev-vm/caren-pc-test.sh run --suites "e2e-docker"
+./hack/dev-vm/caren-pc-test.sh run --keep                          # keep the VM afterwards
+./hack/dev-vm/caren-pc-test.sh list                                # your test VMs on PC
+./hack/dev-vm/caren-pc-test.sh destroy <vm-uuid>                   # manual cleanup
+```
+
+| Suite | Mirrors CI job | What it runs | Typical duration |
+|---|---|---|---|
+| `precommit` | `pre-commit` | `make pre-commit` with CI's `SKIP` list | ~5 min |
+| `unit` | `unit-test` | `make test` — root, `api` and `common` modules | ~15 min |
+| `lint` | `lint-go` | `make lint` — custom `golangci-lint-kube-api-linter`, all modules | ~5 min |
+| `helm` | `lint-test-helm` | `ct lint`, kind cluster, `release-snapshot`, `clusterctl.init`, `ct install` | ~15 min |
+| `e2e-docker` | `e2e-quick-start` / `e2e-self-hosted` | `make e2e-test E2E_LABEL='provider:Docker'` | ~20 min per focus |
+
+The Nutanix-provider e2e suites are not wired up here: they need a full CAPX
+environment (PC endpoint, subnet, machine image) beyond the credentials this
+script uses to create the VM.
+
+## 4. Results
+
+Everything lands in `test-results/<timestamp>/` on your laptop:
+
+```
+test-results/20260803-102619/
+├── RESULTS.md          # pass/fail table + branch, commit sha, runner — attach to your PR
+├── results.txt         # raw per-suite verdicts
+└── artifacts/
+    ├── unit/           # suite log, test.json, junit-report.xml
+    ├── lint/           # suite log
+    └── …               # one folder per suite
+```
+
+Attach `RESULTS.md` to the PR when you raise it — paste it (it renders as a
+table) or screenshot it.
+
+## Configuration reference
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `NUTANIX_USER` | **yes** | — | Prism Central username (VM create/delete) |
+| `NUTANIX_PASSWORD` | **yes** | — | Prism Central password (never logged) |
+| `VM_CPU` / `VM_MEM_GIB` / `VM_DISK_GIB` | no | `16` / `32` / `200` | VM sizing |
+| `CAREN_TEST_SUITES` | no | `precommit unit lint` | Change your default suite list |
+| `CAREN_REPO_URL` | no | the public repo | Point at the `internal-` fork if that is what you work in |
+| `PC_URL` | no | `https://pc.dev.nkp.sh:9440` | Prism Central endpoint |
+| `IMAGE_UUID` | no | Ubuntu 24.04 cloud image | Boot image (cloud-init-enabled DISK_IMAGE) |
+| `SUBNET_UUID` | no | `vlan170-dhcp` | NIC subnet (DHCP) |
+| `PE_CLUSTER_UUID` | no | `ncn-dev-sandbox` | PE cluster to place the VM on |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `Set NUTANIX_USER and NUTANIX_PASSWORD` | the two env vars aren't exported in this shell |
+| `HTTP 401 … Invalid Credentials` | PC credentials rotated — re-run `tam login pc-dev` |
+| Hangs at *waiting for IP* / SSH | VPN dropped, or the PE is out of capacity — retry with smaller `VM_CPU`/`VM_MEM_GIB` |
+| A suite fails | the VM is **kept**; the script prints the `ssh` command to debug it and the `destroy` command to clean up |
+| Docker Hub rate limits (429) | `docker login` on the VM with your own account, then re-run the suite |
+
+## Advanced: a long-lived DevVM
+
+`caren-test-vm.sh` is the VM-side half and works standalone if you keep a
+personal DevVM instead of creating one per run:
+
+```bash
+scp hack/dev-vm/caren-test-vm.sh <user>@<vm-ip>:
+ssh <user>@<vm-ip>
+./caren-test-vm.sh setup          # one-time: apt, docker, nix, devbox, gh
+# log out and back in (docker group + nix PATH)
+./caren-test-vm.sh clone my-branch
+./caren-test-vm.sh pre-pr         # precommit + unit + lint
+```

--- a/hack/dev-vm/README.md
+++ b/hack/dev-vm/README.md
@@ -1,3 +1,8 @@
+<!--
+ Copyright 2023 Nutanix. All rights reserved.
+ SPDX-License-Identifier: Apache-2.0
+ -->
+
 # Run the CAREN checks on a dev VM (pre-PR gate)
 
 Run the same checks CI runs — on a Prism Central VM created on demand —
@@ -88,7 +93,7 @@ script uses to create the VM.
 
 Everything lands in `test-results/<timestamp>/` on your laptop:
 
-```
+```text
 test-results/20260803-102619/
 ├── RESULTS.md          # pass/fail table + branch, commit sha, runner — attach to your PR
 ├── results.txt         # raw per-suite verdicts

--- a/hack/dev-vm/README.md
+++ b/hack/dev-vm/README.md
@@ -65,13 +65,15 @@ when a run came from a dirty tree.
 
 ### Suites
 
-Default set is `precommit unit lint` — the fast blocking jobs in
-`.github/workflows/checks.yml` (~25 min). The heavier suites are opt-in:
+The default set is **every blocking job** in `.github/workflows/checks.yml`, so
+a green run here means CI should be green too (~40 min). `helm` costs about a
+minute unless you touched a chart — it runs the same `ct list-changed` check CI
+does — and `e2e-docker` runs one focus rather than CI's full matrix.
 
 ```bash
-./hack/dev-vm/caren-pc-test.sh run --suites "precommit unit lint helm"
-./hack/dev-vm/caren-pc-test.sh run --suites "e2e-docker"          # Quick start focus
+./hack/dev-vm/caren-pc-test.sh run --suites "precommit unit lint"  # fast loop, ~25 min
 E2E_FOCUS='Self-hosted' ./hack/dev-vm/caren-pc-test.sh run --suites "e2e-docker"
+CT_FORCE=true ./hack/dev-vm/caren-pc-test.sh run --suites "helm"   # force the chart install
 ./hack/dev-vm/caren-pc-test.sh run --keep                          # keep the VM afterwards
 ./hack/dev-vm/caren-pc-test.sh list                                # your test VMs on PC
 ./hack/dev-vm/caren-pc-test.sh destroy <vm-uuid>                   # manual cleanup
@@ -82,8 +84,8 @@ E2E_FOCUS='Self-hosted' ./hack/dev-vm/caren-pc-test.sh run --suites "e2e-docker"
 | `precommit` | `pre-commit` | `make pre-commit` with CI's `SKIP` list | ~5 min |
 | `unit` | `unit-test` | `make test` — root, `api` and `common` modules | ~15 min |
 | `lint` | `lint-go` | `make lint` — custom `golangci-lint-kube-api-linter`, all modules | ~5 min |
-| `helm` | `lint-test-helm` | `ct lint`, kind cluster, `release-snapshot`, `clusterctl.init`, `ct install` | ~15 min |
-| `e2e-docker` | `e2e-quick-start` / `e2e-self-hosted` | `make e2e-test E2E_LABEL='provider:Docker'` | ~20 min per focus |
+| `helm` | `lint-test-helm` | `ct lint`, kind cluster, `release-snapshot`, `clusterctl.init`, `ct install` | ~1 min, ~15 min if charts changed |
+| `e2e-docker` | `e2e-quick-start` / `e2e-self-hosted` | `make e2e-test E2E_LABEL='provider:Docker'` | ~13 min per focus |
 
 The Nutanix-provider e2e suites are not wired up here: they need a full CAPX
 environment (PC endpoint, subnet, machine image) beyond the credentials this
@@ -113,7 +115,9 @@ table) or screenshot it.
 | `NUTANIX_USER` | **yes** | — | Prism Central username (VM create/delete) |
 | `NUTANIX_PASSWORD` | **yes** | — | Prism Central password (never logged) |
 | `VM_CPU` / `VM_MEM_GIB` / `VM_DISK_GIB` | no | `16` / `32` / `200` | VM sizing |
-| `CAREN_TEST_SUITES` | no | `precommit unit lint` | Change your default suite list |
+| `CAREN_TEST_SUITES` | no | all five suites | Change your default suite list |
+| `E2E_FOCUS` | no | `Quick start` | Which e2e focus `e2e-docker` runs |
+| `CT_FORCE` | no | `false` | Run the chart install even when no charts changed |
 | `CAREN_REPO_URL` | no | the public repo | Point at the `internal-` fork if that is what you work in |
 | `PC_URL` | no | `https://pc.dev.nkp.sh:9440` | Prism Central endpoint |
 | `IMAGE_UUID` | no | Ubuntu 24.04 cloud image | Boot image (cloud-init-enabled DISK_IMAGE) |

--- a/hack/dev-vm/caren-pc-test.sh
+++ b/hack/dev-vm/caren-pc-test.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC1091,SC2016,SC2029
+#
+# caren-pc-test.sh — run CAREN checks on a dynamic VM on Prism Central.
+#
+# Developer flow (from your laptop, inside the CAREN repo):
+#   export NUTANIX_USER=<pc-username>
+#   export NUTANIX_PASSWORD=<pc-password>
+#   ./hack/dev-vm/caren-pc-test.sh run                 # full pre-PR gate
+#   ./hack/dev-vm/caren-pc-test.sh run --suites "unit lint"   # subset
+#   ./hack/dev-vm/caren-pc-test.sh list                # your test VMs on PC
+#   ./hack/dev-vm/caren-pc-test.sh destroy <vm-uuid>   # manual cleanup
+#
+# What `run` does:
+#   1. provisions an Ubuntu 24.04 VM on PC (16 vCPU / 64 GiB / 200 GiB) with an
+#      ephemeral SSH key via cloud-init
+#   2. bootstraps it exactly like the GitHub CI runners (caren-test-vm.sh setup)
+#   3. transfers your `gh` token (never printed) for private-repo access
+#   4. clones your CURRENT BRANCH (must be pushed) and runs the suites
+#   5. pulls back test-results/<ts>/RESULTS.md + logs; deletes the VM on success
+#      (kept for debugging on failure — destroy with the printed command)
+#
+# Requirements: bash, python3, ssh, git, gh (authenticated, SSO for
+# mesosphere + nutanix-cloud-native), network access to the PC subnet (VPN).
+#
+# Timing: full suite set is ~2.5-3h. Use as a pre-PR gate, e.g.:
+#   pre-commit run caren-pc-test --hook-stage manual
+# Not suitable as a per-commit hook.
+
+set -euo pipefail
+
+# --- Configuration (defaults = Nutanix dev PC; override via env) ---------------
+PC_URL="${PC_URL:-https://pc.dev.nkp.sh:9440}"
+# rohith-24.04-ubuntu-server-cloudimg-amd64.img (Ubuntu 24.04 cloud image)
+IMAGE_UUID="${IMAGE_UUID:-ce5c64be-7896-4fd9-9695-ad8b63f0eda8}"
+# subnet vlan170-dhcp
+SUBNET_UUID="${SUBNET_UUID:-cd32cd27-ffd9-4bde-88e5-cb5167d7bd17}"
+# PE cluster ncn-dev-sandbox
+PE_CLUSTER_UUID="${PE_CLUSTER_UUID:-00061f7f-44f7-19dc-3be1-7cc25586ee44}"
+VM_CPU="${VM_CPU:-16}"
+VM_MEM_GIB="${VM_MEM_GIB:-32}"
+VM_DISK_GIB="${VM_DISK_GIB:-200}"
+VM_USER="nkp"
+# The blocking jobs from .github/workflows/checks.yml. The heavier `helm` and
+# `e2e-docker` suites are available but opt-in (see --suites).
+DEFAULT_SUITES="${CAREN_TEST_SUITES:-precommit unit lint}"
+
+STATE_DIR="$HOME/.caren-pc-test"
+SSH_KEY="$STATE_DIR/id_ed25519"
+SSH_OPTS=(-i "$SSH_KEY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10)
+
+log() { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
+die() {
+  printf '\033[1;31mERROR: %s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+require_creds() {
+  if [ -z "${NUTANIX_USER:-}" ] || [ -z "${NUTANIX_PASSWORD:-}" ]; then
+    die "Set NUTANIX_USER and NUTANIX_PASSWORD env vars (your PC credentials)"
+  fi
+}
+
+# --- PC API helper: creds from env (never argv/logs), body from stdin ----------
+pc_api() { # pc_api <method> <path> [json-body-on-stdin]
+  local body=""
+  [ -t 0 ] || body=$(cat)
+  PC_BODY="$body" python3 -c '
+import base64, os, ssl, sys, urllib.request, urllib.error
+method, path = sys.argv[1], sys.argv[2]
+body = os.environ.get("PC_BODY", "")
+data = body.encode() if body.strip() else None
+ctx = ssl.create_default_context(); ctx.check_hostname = False; ctx.verify_mode = ssl.CERT_NONE
+u = os.environ["NUTANIX_USER"]; p = os.environ["NUTANIX_PASSWORD"]
+auth = base64.b64encode((u + ":" + p).encode()).decode()
+req = urllib.request.Request(os.environ["PC_URL"] + path, method=method, data=data)
+req.add_header("Authorization", "Basic " + auth)
+req.add_header("Content-Type", "application/json")
+try:
+    with urllib.request.urlopen(req, context=ctx) as r:
+        sys.stdout.write(r.read().decode())
+except urllib.error.HTTPError as e:
+    sys.stderr.write(f"HTTP {e.code}: {e.read().decode()[:500]}\n"); sys.exit(1)
+' "$1" "$2"
+}
+export PC_URL
+
+# --- Provisioning ---------------------------------------------------------------
+ensure_ssh_key() {
+  mkdir -p "$STATE_DIR"
+  [ -f "$SSH_KEY" ] || ssh-keygen -t ed25519 -N "" -f "$SSH_KEY" -C "caren-pc-test" >/dev/null
+}
+
+vm_name() { echo "caren-test-$(whoami | tr -cd 'a-z0-9')-$(date +%y%m%d%H%M%S)"; }
+
+provision_vm() { # -> sets VM_UUID, VM_IP
+  local name
+  name=$(vm_name)
+  local pubkey
+  pubkey=$(cat "$SSH_KEY.pub")
+  log "Creating VM $name on PC ($VM_CPU vCPU / ${VM_MEM_GIB}G / ${VM_DISK_GIB}G)" >&2
+  local user_data
+  user_data=$(
+    cat <<EOF
+#cloud-config
+hostname: $name
+users:
+  - name: $VM_USER
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: sudo
+    shell: /bin/bash
+    ssh-authorized-keys:
+      - $pubkey
+growpart:
+  mode: auto
+  devices: ["/"]
+EOF
+  )
+  local b64
+  b64=$(printf '%s' "$user_data" | base64 | tr -d '\n')
+  local resp
+  resp=$(
+    pc_api POST /api/nutanix/v3/vms <<EOF
+{"api_version":"3.1","metadata":{"kind":"vm"},
+ "spec":{"name":"$name",
+  "cluster_reference":{"kind":"cluster","uuid":"$PE_CLUSTER_UUID"},
+  "resources":{
+   "num_sockets":2,"num_vcpus_per_socket":$((VM_CPU / 2)),"memory_size_mib":$((VM_MEM_GIB * 1024)),
+   "power_state":"ON",
+   "boot_config":{"boot_device_order_list":["DISK","CDROM","NETWORK"],"boot_type":"UEFI"},
+   "disk_list":[{"device_properties":{"device_type":"DISK","disk_address":{"adapter_type":"SCSI","device_index":0}},
+                 "data_source_reference":{"kind":"image","uuid":"$IMAGE_UUID"},
+                 "disk_size_mib":$((VM_DISK_GIB * 1024))}],
+   "nic_list":[{"nic_type":"NORMAL_NIC","subnet_reference":{"kind":"subnet","uuid":"$SUBNET_UUID"}}],
+   "guest_customization":{"cloud_init":{"user_data":"$b64"}}}}}
+EOF
+  )
+  VM_UUID=$(printf '%s' "$resp" | python3 -c 'import json,sys; print(json.load(sys.stdin)["metadata"]["uuid"])')
+  echo "$VM_UUID" >"$STATE_DIR/last-vm-uuid"
+  log "VM UUID: $VM_UUID - waiting for IP (DHCP + boot, ~2-4 min)" >&2
+  local ip=""
+  for _ in $(seq 1 60); do
+    ip=$(pc_api GET "/api/nutanix/v3/vms/$VM_UUID" </dev/null | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+ips=[e.get("ip") for n in d.get("status",{}).get("resources",{}).get("nic_list",[]) for e in n.get("ip_endpoint_list",[]) if e.get("ip")]
+print(ips[0] if ips else "")')
+    [ -n "$ip" ] && break
+    sleep 10
+  done
+  [ -n "$ip" ] || die "VM got no IP after 10 min - check PC console (uuid $VM_UUID)"
+  VM_IP="$ip"
+  log "VM IP: $VM_IP - waiting for SSH" >&2
+  for _ in $(seq 1 40); do
+    ssh "${SSH_OPTS[@]}" "$VM_USER@$VM_IP" true 2>/dev/null && return 0
+    sleep 10
+  done
+  die "SSH to $VM_IP not reachable after 7 min"
+}
+
+destroy_vm() { # <uuid>
+  log "Deleting VM $1"
+  pc_api DELETE "/api/nutanix/v3/vms/$1" </dev/null >/dev/null
+  echo "deleted"
+}
+
+# --- Test run -------------------------------------------------------------------
+KEEP=false
+cmd_run() {
+  local suites="$DEFAULT_SUITES"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    --suites)
+      suites="$2"
+      shift 2
+      ;;
+    --keep)
+      KEEP=true
+      shift
+      ;;
+    *) die "unknown flag $1" ;;
+    esac
+  done
+
+  require_creds
+  command -v gh >/dev/null || die "gh CLI required on your laptop"
+  gh auth status >/dev/null 2>&1 || die "Run: gh auth login (account with mesosphere + nutanix-cloud-native access)"
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || die "Run from inside the CAREN repo"
+  local branch sha
+  branch=$(git -C "$repo_root" branch --show-current)
+  sha=$(git -C "$repo_root" rev-parse --short HEAD)
+  [ -n "$branch" ] || die "Detached HEAD - checkout a branch"
+
+  # Snapshot the LOCAL working tree so you can gate changes before committing or
+  # pushing. The VM clones the repo history from origin (fast), and we ship only
+  # the delta: commits you have not pushed (as a git bundle), tracked-file edits
+  # (as a patch) and untracked files (as a tarball). That keeps the transfer in
+  # the KB range instead of rsyncing a multi-GB working tree over the VPN.
+  local snap
+  snap=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$snap'" RETURN
+  # Always produce all three files (empty is fine) so the transfer below is a
+  # single all-or-nothing step: a missing file would make scp fail as a whole
+  # and silently skip the others.
+  git -C "$repo_root" bundle create "$snap/local.bundle" HEAD --not --remotes=origin \
+    >/dev/null 2>&1 || : # fails (writes nothing) when HEAD is already on origin
+  [ -f "$snap/local.bundle" ] || : >"$snap/local.bundle"
+  git -C "$repo_root" diff HEAD --binary >"$snap/uncommitted.patch"
+  # ':(exclude)test-results' keeps this script's own output out of the payload
+  # even on branches that predate the .gitignore entry for it.
+  (cd "$repo_root" &&
+    git ls-files --others --exclude-standard -z -- ':(exclude)test-results' \
+      >"$snap/untracked.list")
+  if [ -s "$snap/untracked.list" ]; then
+    (cd "$repo_root" && tar --null -czf "$snap/untracked.tgz" -T "$snap/untracked.list")
+  else
+    : >"$snap/untracked.tgz"
+  fi
+
+  local dirty=false
+  if [ -s "$snap/uncommitted.patch" ] || [ -s "$snap/local.bundle" ] ||
+    [ -n "$(cd "$repo_root" && git ls-files --others --exclude-standard | head -1)" ]; then
+    dirty=true
+    log "Testing your LOCAL working tree (uncommitted and/or unpushed changes included)"
+  else
+    log "Working tree matches origin/$branch - testing $sha"
+  fi
+
+  ensure_ssh_key
+  provision_vm # sets VM_UUID VM_IP
+  trap '[ "${KEEP:-false}" = true ] || { echo "Cleaning up VM..."; destroy_vm "$VM_UUID" || true; }' EXIT
+
+  log "Bootstrapping VM (CI-parity toolchain: docker, nix, devbox, gh - ~10 min)"
+  ssh "${SSH_OPTS[@]}" "$VM_USER@$VM_IP" 'mkdir -p ~/bin'
+  scp -q -i "$SSH_KEY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+    "$repo_root/hack/dev-vm/caren-test-vm.sh" "$VM_USER@$VM_IP:caren-test-vm.sh"
+  ssh "${SSH_OPTS[@]}" "$VM_USER@$VM_IP" 'chmod +x caren-test-vm.sh && ./caren-test-vm.sh setup' |
+    grep -E "==>|ERROR" || true
+
+  log "Transferring GitHub token (not printed) + your local working tree"
+  gh auth token | ssh "${SSH_OPTS[@]}" "$VM_USER@$VM_IP" 'gh auth login --with-token && gh auth setup-git'
+  ssh "${SSH_OPTS[@]}" "$VM_USER@$VM_IP" 'rm -rf ~/localsync && mkdir -p ~/localsync'
+  scp -q -i "$SSH_KEY" -o BatchMode=yes "$snap/local.bundle" "$snap/uncommitted.patch" \
+    "$snap/untracked.tgz" "$VM_USER@$VM_IP:localsync/" ||
+    die "failed to transfer the local working-tree snapshot to the VM"
+  # sg docker: group membership from setup isn't active in this ssh session yet
+  ssh "${SSH_OPTS[@]}" "$VM_USER@$VM_IP" "sg docker -c './caren-test-vm.sh sync-local $sha'" |
+    tail -3
+
+  log "Running suites: $suites"
+  local ts results_dir
+  ts=$(date +%Y%m%d-%H%M%S)
+  results_dir="$repo_root/test-results/$ts"
+  mkdir -p "$results_dir"
+  ssh "${SSH_OPTS[@]}" "$VM_USER@$VM_IP" "cat > ~/run-suites.sh <<'EOF'
+#!/usr/bin/env bash
+set -u
+: > ~/results.txt
+rm -rf ~/artifacts && mkdir -p ~/artifacts
+for s in $suites; do
+  echo \"=== \$s start \$(date -u +%H:%M:%S) ===\"
+  start=\$SECONDS
+  if sg docker -c \"./caren-test-vm.sh \$s\" > ~/suite-\$s.log 2>&1; then
+    echo \"\$s PASS \$((SECONDS-start))s\" >> ~/results.txt
+  else
+    echo \"\$s FAIL \$((SECONDS-start))s\" >> ~/results.txt
+  fi
+  # Preserve this suite's artifacts before the next one overwrites them:
+  # go test json output, ginkgo/junit reports and the full log.
+  mkdir -p ~/artifacts/\$s
+  cp ~/suite-\$s.log ~/artifacts/\$s/
+  find ~/caren -maxdepth 2 \( -name 'test.json' -o -name 'junit*.xml' \) -exec mv {} ~/artifacts/\$s/ \; 2>/dev/null
+  find ~/caren/_artifacts -maxdepth 2 -name '*.xml' -exec cp {} ~/artifacts/\$s/ \; 2>/dev/null || true
+  sg docker -c 'for c in \$(kind get clusters 2>/dev/null); do kind delete cluster --name \"\$c\"; done; docker system prune -f' >/dev/null 2>&1
+  tail -1 ~/results.txt
+done
+EOF
+chmod +x ~/run-suites.sh && ~/run-suites.sh"
+
+  log "Collecting results"
+  scp -q -i "$SSH_KEY" -o BatchMode=yes "$VM_USER@$VM_IP:results.txt" "$results_dir/results.txt"
+  ssh "${SSH_OPTS[@]}" "$VM_USER@$VM_IP" 'tar -C ~ -czf - artifacts 2>/dev/null' >"$results_dir/artifacts.tar.gz" || true
+  tar -xzf "$results_dir/artifacts.tar.gz" -C "$results_dir" 2>/dev/null || true
+
+  # RESULTS.md - the artifact developers attach to their PR
+  local overall="PASSED"
+  grep -q FAIL "$results_dir/results.txt" && overall="FAILED"
+  {
+    echo "## CAREN pre-PR test results: $overall"
+    echo
+    echo "- **Branch:** \`$branch\` @ \`$sha\`$([ "$dirty" = true ] && echo " (local working tree, including uncommitted/unpushed changes)")"
+    echo "- **Date:** $(date -u '+%Y-%m-%d %H:%M UTC')"
+    echo "- **Runner:** dynamic PC VM ($VM_CPU vCPU / ${VM_MEM_GIB}G, Ubuntu 24.04, CI-parity devbox toolchain)"
+    echo
+    echo "| Suite | Result | Duration |"
+    echo "|---|---|---|"
+    awk '{printf "| %s | %s | %s |\n", $1, ($2=="PASS"?"✅ PASS":"❌ FAIL"), $3}' "$results_dir/results.txt"
+    echo
+    echo "<details><summary>Artifacts collected per suite</summary>"
+    echo
+    (cd "$results_dir" && find artifacts -type f 2>/dev/null | sort | sed 's/^/- `/;s/$/`/')
+    echo
+    echo "</details>"
+    echo
+    echo "_Generated by hack/dev-vm/caren-pc-test.sh; full logs + JUnit XMLs + coverage in this directory._"
+  } >"$results_dir/RESULTS.md"
+
+  cat "$results_dir/RESULTS.md"
+  log "Results in $results_dir (attach RESULTS.md when you raise the PR)"
+
+  if [ "$overall" = "FAILED" ]; then
+    KEEP=true
+    echo "Suites failed - VM kept for debugging: ssh -i $SSH_KEY $VM_USER@$VM_IP"
+    echo "Destroy later with: $0 destroy $VM_UUID"
+    exit 1
+  fi
+}
+
+cmd_list() {
+  require_creds
+  pc_api POST /api/nutanix/v3/vms/list <<<'{"kind":"vm","filter":"vm_name==caren-test-.*","length":100}' |
+    python3 -c '
+import json,sys
+for e in json.load(sys.stdin).get("entities",[]):
+    r=e["status"]["resources"]
+    ips=[i.get("ip") for n in r.get("nic_list",[]) for i in n.get("ip_endpoint_list",[]) if i.get("ip")]
+    print(e["metadata"]["uuid"], e["status"]["name"], r.get("power_state"), ",".join(ips))'
+}
+
+cmd_destroy() {
+  require_creds
+  [ -n "${1:-}" ] || die "usage: $0 destroy <vm-uuid>"
+  destroy_vm "$1"
+}
+
+case "${1:-}" in
+run)
+  shift
+  cmd_run "$@"
+  ;;
+list)
+  shift
+  cmd_list "$@"
+  ;;
+destroy)
+  shift
+  cmd_destroy "$@"
+  ;;
+*)
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+  exit 1
+  ;;
+esac

--- a/hack/dev-vm/caren-pc-test.sh
+++ b/hack/dev-vm/caren-pc-test.sh
@@ -41,9 +41,11 @@ VM_CPU="${VM_CPU:-16}"
 VM_MEM_GIB="${VM_MEM_GIB:-32}"
 VM_DISK_GIB="${VM_DISK_GIB:-200}"
 VM_USER="nkp"
-# The blocking jobs from .github/workflows/checks.yml. The heavier `helm` and
-# `e2e-docker` suites are available but opt-in (see --suites).
-DEFAULT_SUITES="${CAREN_TEST_SUITES:-precommit unit lint}"
+# Every blocking job in .github/workflows/checks.yml, so a green run here means
+# CI should be green too. `helm` short-circuits to about a minute when no charts
+# changed (same check CI does), and `e2e-docker` runs one focus rather than CI's
+# full matrix. For a quick loop use: --suites "precommit unit lint".
+DEFAULT_SUITES="${CAREN_TEST_SUITES:-precommit unit lint helm e2e-docker}"
 
 STATE_DIR="$HOME/.caren-pc-test"
 SSH_KEY="$STATE_DIR/id_ed25519"
@@ -254,9 +256,18 @@ cmd_run() {
   ts=$(date +%Y%m%d-%H%M%S)
   results_dir="$repo_root/test-results/$ts"
   mkdir -p "$results_dir"
+  # Forward the handful of knobs the suites honour, so `E2E_FOCUS=... run` and
+  # `CT_FORCE=true run` behave the way the README says they do.
+  local fwd="" v
+  for v in E2E_FOCUS E2E_SKIP CT_FORCE KIND_CLUSTER_NAME; do
+    [ -n "${!v:-}" ] && fwd="${fwd}export $v=$(printf '%q' "${!v}")
+"
+  done
+
   ssh "${SSH_OPTS[@]}" "$VM_USER@$VM_IP" "cat > ~/run-suites.sh <<'EOF'
 #!/usr/bin/env bash
 set -u
+$fwd
 : > ~/results.txt
 rm -rf ~/artifacts && mkdir -p ~/artifacts
 for s in $suites; do

--- a/hack/dev-vm/caren-test-vm.sh
+++ b/hack/dev-vm/caren-test-vm.sh
@@ -28,8 +28,10 @@ set -euo pipefail
 REPO_DIR="${CAREN_REPO_DIR:-$HOME/caren}"
 REPO_URL="${CAREN_REPO_URL:-https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix.git}"
 NIX_PROFILE_SH="/etc/profile.d/nix.sh"
-# Matches .github/workflows/checks.yml lint-test-helm.
+# Match .github/workflows/checks.yml lint-test-helm: kind.create writes the
+# kubeconfig to KIND_KUBECONFIG, and ct install reads it from there.
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-chart-testing}"
+KIND_KUBECONFIG="${KIND_KUBECONFIG:-ct-kind-kubeconfig}"
 
 log() { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
 die() {
@@ -243,20 +245,41 @@ cmd_helm() { # lint-test-helm job
   load_nix
   load_devbox
   github_token
+  # CI only does the expensive half when a chart actually changed; mirror that so
+  # this suite costs ~a minute on the majority of PRs. CT_FORCE=true overrides.
+  if [ "${CT_FORCE:-false}" != true ] &&
+    [ -z "$(devbox run -- ct list-changed --config charts/ct-config.yaml 2>/dev/null)" ]; then
+    log "No chart changes - skipping chart lint/install (same as CI)"
+    return 0
+  fi
+
   log "chart-testing: lint, then install onto a kind cluster"
-  devbox run -- bash -euxo pipefail -c '
-    ct lint --config charts/ct-config.yaml
-    make kind.create
-    make release-snapshot
-    tag="$(gojq -r .version dist/metadata.json)-$(go env GOARCH)"
-    kind load docker-image --name '"$KIND_CLUSTER_NAME"' \
-      "ko.local/cluster-api-runtime-extensions-nutanix:${tag}" \
-      "ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer:${tag}"
-    make clusterctl.init
-    KUBECONFIG=ct-kind-kubeconfig ct install --config charts/ct-config.yaml \
-      --helm-extra-set-args "--set-string image.repository=ko.local/cluster-api-runtime-extensions-nutanix --set-string image.tag=${tag} --set-string helmRepository.images.bundleInitializer.tag=${tag}"
-  '
-  devbox run -- make kind.delete || true
+  # Quoted heredoc: nothing expands here, it all runs inside devbox on the VM.
+  # KIND_CLUSTER_NAME is passed through the environment rather than interpolated,
+  # which keeps the quoting intact.
+  cat >/tmp/caren-helm.sh <<'INNER'
+set -euxo pipefail
+ct lint --config charts/ct-config.yaml
+# kind.create is a no-op when a cluster of this name already exists, and then no
+# kubeconfig is written and clusterctl/ct fail. CI always starts from a fresh
+# runner; on a reused VM, start from a known state.
+kind delete cluster --name "${KIND_CLUSTER_NAME}" >/dev/null 2>&1 || true
+make kind.create
+make release-snapshot
+tag="$(gojq -r .version dist/metadata.json)-$(go env GOARCH)"
+kind load docker-image --name "${KIND_CLUSTER_NAME}" \
+  "ko.local/cluster-api-runtime-extensions-nutanix:${tag}" \
+  "ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer:${tag}"
+make clusterctl.init
+KUBECONFIG="${KIND_KUBECONFIG}" ct install --config charts/ct-config.yaml \
+  --helm-extra-set-args "--set-string image.repository=ko.local/cluster-api-runtime-extensions-nutanix --set-string image.tag=${tag} --set-string helmRepository.images.bundleInitializer.tag=${tag}"
+INNER
+  KIND_CLUSTER_NAME="$KIND_CLUSTER_NAME" KIND_KUBECONFIG="$KIND_KUBECONFIG" \
+    devbox run -- bash /tmp/caren-helm.sh
+  # kind.delete reads KIND_CLUSTER_NAME too - without it the chart-testing
+  # cluster would be left running.
+  KIND_CLUSTER_NAME="$KIND_CLUSTER_NAME" KIND_KUBECONFIG="$KIND_KUBECONFIG" \
+    devbox run -- make kind.delete || true
 }
 
 cmd_e2e_docker() { # e2e-quick-start / e2e-self-hosted, Docker provider

--- a/hack/dev-vm/caren-test-vm.sh
+++ b/hack/dev-vm/caren-test-vm.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC1091,SC2016,SC2029
+#
+# caren-test-vm.sh — bootstrap a VM and run the CAREN checks on it.
+#
+# Sets a fresh Ubuntu VM up like the GitHub Actions runner and runs the same
+# targets .github/workflows/checks.yml runs, so a developer can gate a change
+# before committing it.
+#
+# Usage:
+#   ./caren-test-vm.sh setup                # one-time VM bootstrap (idempotent)
+#   ./caren-test-vm.sh clone [branch]       # clone the repo (optional branch)
+#   ./caren-test-vm.sh sync-local <sha>     # reproduce laptop's tree (used by caren-pc-test.sh)
+#   ./caren-test-vm.sh precommit            # make pre-commit          (= pre-commit job)
+#   ./caren-test-vm.sh unit                 # make test               (= unit-test job)
+#   ./caren-test-vm.sh lint                 # make lint               (= lint-go job)
+#   ./caren-test-vm.sh helm                 # chart lint + install on kind (= lint-test-helm job)
+#   ./caren-test-vm.sh e2e-docker           # Docker-provider e2e     (= e2e-* jobs)
+#   ./caren-test-vm.sh pre-pr               # precommit + unit + lint
+#   ./caren-test-vm.sh clean                # delete kind clusters, prune docker
+#
+# Requirements:
+#   - Ubuntu 22.04/24.04 x86_64 VM, user with passwordless sudo
+#   - >= 8 vCPU / 32 GiB RAM / 200 GiB disk (the e2e and helm suites need kind)
+
+set -euo pipefail
+
+REPO_DIR="${CAREN_REPO_DIR:-$HOME/caren}"
+REPO_URL="${CAREN_REPO_URL:-https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix.git}"
+NIX_PROFILE_SH="/etc/profile.d/nix.sh"
+# Matches .github/workflows/checks.yml lint-test-helm.
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-chart-testing}"
+
+log() { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
+die() {
+  printf '\033[1;31mERROR: %s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+# ------------------------------------------------------------------------------
+# Environment helpers
+# ------------------------------------------------------------------------------
+load_nix() {
+  if ! command -v nix >/dev/null 2>&1; then
+    [ -f "$NIX_PROFILE_SH" ] && . "$NIX_PROFILE_SH"
+    [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ] &&
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+  fi
+  return 0
+}
+
+load_devbox() {
+  command -v devbox >/dev/null 2>&1 || export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
+}
+
+github_token() {
+  # CAREN itself has no private module dependencies, but a token avoids
+  # anonymous GitHub API rate limits during tool downloads.
+  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    GH_TOKEN="$(gh auth token)"
+    export GH_TOKEN
+  fi
+  return 0
+}
+
+ensure_docker_group() {
+  if ! docker info >/dev/null 2>&1; then
+    if id -nG "$USER" | grep -qw docker && [ -z "${_CTV_REEXEC:-}" ]; then
+      exec sg docker -c "_CTV_REEXEC=1 $(printf '%q ' "$0" "$@")"
+    fi
+    die "Docker daemon not reachable. Run '$0 setup', then log out and back in."
+  fi
+}
+
+# goreleaser/ko build linux/arm64 images as well as amd64. A binfmt handler
+# registered by a container does not survive later package installs (systemd
+# re-registers only /etc/binfmt.d/ entries), so ensure it at point of use.
+ensure_binfmt() {
+  if [ ! -f /proc/sys/fs/binfmt_misc/qemu-aarch64 ]; then
+    log "Registering QEMU arm64 binfmt handler"
+    docker run --privileged --rm tonistiigi/binfmt --install arm64 >/dev/null
+  fi
+}
+
+in_repo() {
+  [ -d "$REPO_DIR/.git" ] || die "CAREN repo not found at $REPO_DIR. Run: $0 clone [branch]"
+  cd "$REPO_DIR"
+}
+
+devbox_make() {
+  in_repo
+  load_nix
+  load_devbox
+  github_token
+  log "devbox run -- make $*"
+  devbox run -- make "$@"
+}
+
+# ------------------------------------------------------------------------------
+# setup
+# ------------------------------------------------------------------------------
+cmd_setup() {
+  [ "$(uname -s)" = "Linux" ] || die "Run this on the Linux VM, not your laptop"
+  grep -qiE 'ubuntu|debian' /etc/os-release || die "This script supports Ubuntu/Debian"
+  sudo -n true 2>/dev/null || die "Passwordless sudo required"
+
+  # Nutanix dev VLANs block outbound port 80 and archive.ubuntu.com entirely,
+  # so the stock apt sources hang forever. Switch to reachable HTTPS mirrors.
+  if ! curl -sI -m 8 http://archive.ubuntu.com/ubuntu/dists/noble/Release -o /dev/null 2>/dev/null; then
+    log "Port 80 / archive.ubuntu.com blocked - switching apt to HTTPS mirrors"
+    for f in /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list; do
+      sudo sed -i -E \
+        -e 's|http://(archive\|us.archive)\.ubuntu\.com/ubuntu|https://us.archive.ubuntu.com/ubuntu|g' \
+        -e 's|http://security\.ubuntu\.com/ubuntu|https://security.ubuntu.com/ubuntu|g' \
+        "$f" 2>/dev/null || true
+    done
+  fi
+
+  log "Installing base packages"
+  sudo apt-get update -q
+  # libatomic1: devbox's node needs libatomic.so.1, which the GitHub runner image
+  # ships but a bare Ubuntu cloud image does not. Without it the markdownlint
+  # prek hook fails to install ("npm install" exits 127).
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
+    make git curl ca-certificates gnupg unzip xz-utils openssh-client jq libatomic1
+
+  log "Installing Docker Engine"
+  command -v docker >/dev/null 2>&1 || curl -fsSL https://get.docker.com | sudo sh
+  sudo systemctl enable --now docker
+  sudo usermod -aG docker "$USER"
+
+  log "Configuring inotify limits for kind"
+  sudo tee /etc/sysctl.d/99-kind-inotify.conf >/dev/null <<'EOF'
+fs.inotify.max_user_watches=524288
+fs.inotify.max_user_instances=512
+EOF
+  sudo sysctl --system >/dev/null
+
+  log "Installing gh CLI"
+  if ! command -v gh >/dev/null 2>&1; then
+    sudo mkdir -p -m 755 /etc/apt/keyrings
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |
+      sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |
+      sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+    sudo apt-get update -q && sudo apt-get install -y -q gh
+  fi
+
+  log "Installing Nix (daemon mode)"
+  if [ ! -d /nix ]; then
+    curl -fsSL https://nixos.org/nix/install -o /tmp/nix-install.sh
+    sh /tmp/nix-install.sh --daemon --yes
+  fi
+  load_nix
+  command -v nix >/dev/null 2>&1 || die "nix not on PATH after install - open a new shell and re-run"
+
+  log "Installing devbox"
+  command -v devbox >/dev/null 2>&1 || curl -fsSL https://get.jetify.com/devbox | bash -s -- -f
+  load_devbox
+  log "Setup complete"
+}
+
+# ------------------------------------------------------------------------------
+# clone / sync-local
+# ------------------------------------------------------------------------------
+cmd_clone() {
+  load_nix
+  load_devbox
+  github_token
+  if [ ! -d "$REPO_DIR/.git" ]; then
+    log "Cloning CAREN into $REPO_DIR"
+    git clone "$REPO_URL" "$REPO_DIR"
+  fi
+  cd "$REPO_DIR"
+  git fetch origin --tags --prune
+  if [ -n "${1:-}" ]; then
+    git checkout "$1"
+    git pull --ff-only || true
+  fi
+  log "Warming devbox environment (first run downloads the whole toolchain)"
+  devbox run -- bash -c 'go version && golangci-lint --version >/dev/null && echo devbox OK'
+}
+
+# Reproduce the developer's LOCAL working tree. The orchestrator leaves a git
+# bundle of unpushed commits, a patch of tracked edits and a tarball of
+# untracked files in ~/localsync; base history still comes from origin.
+cmd_sync_local() {
+  local sha="${1:?usage: $0 sync-local <sha>}"
+  local x="$HOME/localsync"
+  load_nix
+  load_devbox
+  github_token
+  if [ ! -d "$REPO_DIR/.git" ]; then
+    log "Cloning CAREN base history into $REPO_DIR"
+    git clone "$REPO_URL" "$REPO_DIR"
+  fi
+  cd "$REPO_DIR"
+  git fetch origin --tags --prune --quiet
+
+  if [ -s "$x/local.bundle" ]; then
+    log "Applying local commits (not on origin)"
+    git fetch --quiet "$x/local.bundle" "HEAD:refs/heads/devvm-local" --force
+    git checkout --quiet --force devvm-local
+  else
+    git checkout --quiet --force "$sha"
+  fi
+  git reset --hard --quiet HEAD
+
+  if [ -s "$x/uncommitted.patch" ]; then
+    log "Applying uncommitted changes"
+    git apply --whitespace=nowarn "$x/uncommitted.patch"
+  fi
+  if [ -s "$x/untracked.tgz" ]; then
+    log "Restoring untracked files"
+    tar -xzf "$x/untracked.tgz" -C "$REPO_DIR"
+  fi
+  log "Working tree ready: $(git rev-parse --short HEAD)$(git diff --quiet || echo ' + local edits')"
+
+  log "Warming devbox environment (first run downloads the whole toolchain)"
+  devbox run -- bash -c 'go version && golangci-lint --version >/dev/null && echo devbox OK'
+}
+
+# ------------------------------------------------------------------------------
+# suites (mirroring .github/workflows/checks.yml)
+# ------------------------------------------------------------------------------
+cmd_precommit() {
+  in_repo
+  load_nix
+  load_devbox
+  github_token
+  # Same skips CI uses: those hooks have dedicated jobs.
+  log "devbox run -- make pre-commit"
+  devbox run -- env SKIP=no-commit-to-branch,golangci-lint,actionlint-system make pre-commit
+}
+
+cmd_unit() { devbox_make test; }
+cmd_lint() { devbox_make lint; }
+
+cmd_helm() { # lint-test-helm job
+  ensure_docker_group "$@"
+  ensure_binfmt
+  in_repo
+  load_nix
+  load_devbox
+  github_token
+  log "chart-testing: lint, then install onto a kind cluster"
+  devbox run -- bash -euxo pipefail -c '
+    ct lint --config charts/ct-config.yaml
+    make kind.create
+    make release-snapshot
+    tag="$(gojq -r .version dist/metadata.json)-$(go env GOARCH)"
+    kind load docker-image --name '"$KIND_CLUSTER_NAME"' \
+      "ko.local/cluster-api-runtime-extensions-nutanix:${tag}" \
+      "ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer:${tag}"
+    make clusterctl.init
+    KUBECONFIG=ct-kind-kubeconfig ct install --config charts/ct-config.yaml \
+      --helm-extra-set-args "--set-string image.repository=ko.local/cluster-api-runtime-extensions-nutanix --set-string image.tag=${tag} --set-string helmRepository.images.bundleInitializer.tag=${tag}"
+  '
+  devbox run -- make kind.delete || true
+}
+
+cmd_e2e_docker() { # e2e-quick-start / e2e-self-hosted, Docker provider
+  ensure_docker_group "$@"
+  ensure_binfmt
+  local focus="${E2E_FOCUS:-Quick start}"
+  in_repo
+  load_nix
+  load_devbox
+  github_token
+  log "devbox run -- make e2e-test (provider:Docker, focus: $focus)"
+  devbox run -- make e2e-test E2E_LABEL='provider:Docker' E2E_FOCUS="$focus" E2E_VERBOSE=true
+}
+
+cmd_clean() {
+  in_repo
+  load_nix
+  load_devbox
+  devbox run -- bash -c 'for c in $(kind get clusters 2>/dev/null); do kind delete cluster --name "$c"; done' || true
+  docker system prune -f >/dev/null 2>&1 || true
+}
+
+cmd_pre_pr() {
+  cmd_precommit
+  cmd_unit
+  cmd_lint
+}
+
+usage() { sed -n '3,25p' "$0" | sed 's/^# \{0,1\}//'; }
+
+case "${1:-}" in
+setup)
+  shift
+  cmd_setup "$@"
+  ;;
+clone)
+  shift
+  cmd_clone "$@"
+  ;;
+sync-local)
+  shift
+  cmd_sync_local "$@"
+  ;;
+precommit)
+  shift
+  cmd_precommit "$@"
+  ;;
+unit)
+  shift
+  cmd_unit "$@"
+  ;;
+lint)
+  shift
+  cmd_lint "$@"
+  ;;
+helm)
+  shift
+  cmd_helm "$@"
+  ;;
+e2e-docker)
+  shift
+  cmd_e2e_docker "$@"
+  ;;
+pre-pr)
+  shift
+  cmd_pre_pr "$@"
+  ;;
+clean)
+  shift
+  cmd_clean "$@"
+  ;;
+*)
+  usage
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
## What

Adds `hack/dev-vm/` — a self-service pre-PR gate that runs the CI checks on a **dynamically provisioned Prism Central VM**, against your **local working tree**, plus a manual-stage pre-commit hook to invoke it.

```bash
export NUTANIX_USER=<pc-username> NUTANIX_PASSWORD=<pc-password>
./hack/dev-vm/caren-pc-test.sh run
# or: pre-commit run caren-pc-test --hook-stage manual
```

## What runs

Every blocking job in `checks.yml` runs by default:

| Suite | Mirrors CI job | Typical duration |
|---|---|---|
| `precommit` | `pre-commit` | ~5 min |
| `unit` | `unit-test` (`make test`: root, `api`, `common`) | ~5 min |
| `lint` | `lint-go` (custom `golangci-lint-kube-api-linter`) | ~2 min |
| `helm` | `lint-test-helm` (`ct lint`, kind, `release-snapshot`, `clusterctl.init`, `ct install`) | ~1 min, ~15 min if charts changed |
| `e2e-docker` | `e2e-quick-start` / `e2e-self-hosted`, Docker provider | ~13 min |
