### PR TITLE
ci: run self-hosted e2e via pull_request_target with an approval gate

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           test-results: test.json
 
+  # NOTE: Nutanix (self-hosted) e2e runs in e2e-nutanix.yaml, which triggers on
+  # pull_request_target so the approval gate is owned by the base branch and
+  # cannot be modified by a fork. This workflow (pull_request) only runs the
+  # Docker matrix on GitHub-hosted runners, so it must never target a
+  # self-hosted runner.
   e2e-quick-start:
     needs:
       - "lint-gha"
@@ -69,9 +74,6 @@ jobs:
     strategy:
       matrix:
         config:
-          - {"provider": "Nutanix", "kubernetesMinor": "v1.33", "kubernetesVersion": "v1.33.5", "baseOS": "rocky-9.7"}
-          - {"provider": "Nutanix", "kubernetesMinor": "v1.34", "kubernetesVersion": "v1.34.3", "baseOS": "rocky-9.7"}
-          - {"provider": "Nutanix", "kubernetesMinor": "v1.35", "kubernetesVersion": "v1.35.2", "baseOS": "rocky-9.7"}
           - {"provider": "Docker", "kubernetesMinor": "v1.33", "kubernetesVersion": "v1.33.10"}
           - {"provider": "Docker", "kubernetesMinor": "v1.34", "kubernetesVersion": "v1.34.6"}
           - {"provider": "Docker", "kubernetesMinor": "v1.35", "kubernetesVersion": "v1.35.3"}
@@ -84,13 +86,15 @@ jobs:
       focus: Quick start
       provider: ${{ matrix.config.provider }}
       kubernetes-version: ${{ matrix.config.kubernetesVersion }}
-      runs-on: ${{ matrix.config.provider == 'Nutanix' && 'self-hosted-nutanix-docker-medium' || 'ubuntu-24.04' }}
-      base-os:  ${{ matrix.config.provider == 'Nutanix' && matrix.config.baseOS || '' }}
+      runs-on: ubuntu-24.04
     secrets: inherit
     permissions:
       contents: read
       checks: write
 
+  # This workflow runs on the fork-controlled `pull_request` event, so it must
+  # only ever use GitHub-hosted runners. Any Nutanix (self-hosted) e2e must be
+  # added to e2e-nutanix.yaml (pull_request_target, approval-gated) instead.
   e2e-self-hosted:
     needs:
       - "lint-gha"
@@ -104,9 +108,6 @@ jobs:
           - {"provider": "Docker", "kubernetesMinor": "v1.33", "kubernetesVersion": "v1.33.10"}
           - {"provider": "Docker", "kubernetesMinor": "v1.34", "kubernetesVersion": "v1.34.6"}
           - {"provider": "Docker", "kubernetesMinor": "v1.35", "kubernetesVersion": "v1.35.3"}
-          # Uncomment below once we have the ability to run e2e tests on other providers from GHA.
-          # - {"provider": "Nutanix", "kubernetesMinor": "v1.29", "kubernetesVersion": "v1.29.6"}
-          # - {"provider": "AWS", "kubernetesMinor": "v1.29", "kubernetesVersion": "v1.29.6"}
       fail-fast: false
     name: e2e-self-hosted (${{ matrix.config.provider }} provider, Kubernetes ${{ matrix.config.kubernetesMinor }})
     uses: ./.github/workflows/e2e.yml
@@ -114,7 +115,7 @@ jobs:
       focus: Self-hosted
       provider: ${{ matrix.config.provider }}
       kubernetes-version: ${{ matrix.config.kubernetesVersion }}
-      runs-on: ${{ matrix.config.provider == 'Nutanix' && 'self-hosted-nutanix-docker-medium' || 'ubuntu-24.04' }}
+      runs-on: ubuntu-24.04
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/e2e-nutanix.yaml
+++ b/.github/workflows/e2e-nutanix.yaml
@@ -1,0 +1,90 @@
+# Copyright 2024 Nutanix. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Nutanix (self-hosted) e2e tests.
+#
+# These run on self-hosted runners, so untrusted fork code must not execute
+# until a maintainer has reviewed it. This workflow is triggered by
+# pull_request_target, which means the workflow definition (including the
+# approval gate below) always comes from the base branch and cannot be
+# modified by a fork's pull request. The gate therefore cannot be bypassed by
+# editing a workflow file in the PR.
+#
+# Trust model:
+#   - push / merge_group / internal (same-repo) PRs are trusted and run directly.
+#   - external (fork) PRs run only after the check_approvals gate passes, which
+#     requires an approval on the PR's latest commit AND the 'integration-test'
+#     label. Fork code (head SHA) is checked out only inside the gated e2e job,
+#     never before the gate.
+name: e2e-nutanix
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+  merge_group:
+    types:
+      - checks_requested
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check_approvals:
+    # Only external fork PRs need the gate; the job is skipped for trusted
+    # events (push / merge_group / internal PRs), which are handled by the
+    # `if` on the e2e job below.
+    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      # Fail closed: approved only when the approval step actually succeeded.
+      # continue-on-error keeps the job green so this output is always readable.
+      approved: ${{ steps.check.outcome == 'success' }}
+    steps:
+      - name: Check approval status
+        id: check
+        continue-on-error: true
+        uses: nutanix-cloud-native/action-check-approvals@v1
+
+  e2e-quick-start:
+    needs: check_approvals
+    # Run for trusted events unconditionally; for external fork PRs run only
+    # once the approval gate has passed. always() is required because
+    # check_approvals is skipped for trusted events.
+    if: ${{ always() && (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository || needs.check_approvals.outputs.approved == 'true') }}
+    strategy:
+      matrix:
+        config:
+          - {"provider": "Nutanix", "kubernetesMinor": "v1.33", "kubernetesVersion": "v1.33.5", "baseOS": "rocky-9.7"}
+          - {"provider": "Nutanix", "kubernetesMinor": "v1.34", "kubernetesVersion": "v1.34.3", "baseOS": "rocky-9.7"}
+          - {"provider": "Nutanix", "kubernetesMinor": "v1.35", "kubernetesVersion": "v1.35.2", "baseOS": "rocky-9.7"}
+      fail-fast: false
+    name: e2e-quick-start (${{ matrix.config.provider }} provider, Kubernetes ${{ matrix.config.kubernetesMinor }})
+    uses: ./.github/workflows/e2e.yml
+    with:
+      focus: Quick start
+      provider: ${{ matrix.config.provider }}
+      kubernetes-version: ${{ matrix.config.kubernetesVersion }}
+      runs-on: self-hosted-nutanix-docker-medium
+      base-os: ${{ matrix.config.baseOS }}
+      # Under pull_request_target the default checkout is the base branch. The
+      # gate above has approved this exact commit, so test the PR head. For
+      # push / merge_group this resolves to the triggering SHA.
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+    secrets: inherit
+    permissions:
+      contents: read
+      checks: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,14 @@ on:
         description: The OS image to use for the machine template
         type: string
         required: false
+      ref:
+        description: >-
+          Git ref to check out. Leave empty to use the event's default ref.
+          Callers running under pull_request_target pass the PR head SHA so the
+          approved PR code is tested; that path is gated by an approval check.
+        type: string
+        required: false
+        default: ''
 
 jobs:
   e2e-test:
@@ -38,6 +46,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref }}
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22


### PR DESCRIPTION
## Summary

Self-hosted (Nutanix) e2e ran from `checks.yml` on the `pull_request` event. On that event the workflow definition is taken from the PR's own merge ref, so a fork can edit the workflow — any in-workflow gate on `pull_request` is not enforceable.

This moves the self-hosted e2e into a new `e2e-nutanix.yaml` triggered by `pull_request_target`, so the workflow (and its approval gate) always comes from the **base branch** and cannot be modified by a fork.

## What changed

- **`e2e-nutanix.yaml`** (new): `pull_request_target` (+ `push`, `merge_group`). A `check_approvals` job gates external fork PRs behind an approval on the PR's **latest commit** plus the **`integration-test`** label; the gate is computed from the step outcome and **fails closed**. Fork code (`head.sha`) is checked out **only inside the gated e2e job** — nothing untrusted runs before the gate. `push` / `merge_group` / internal PRs run directly.
- **`checks.yml`**: dropped the Nutanix (self-hosted) matrix entries; the `pull_request` path is now Docker-only on GitHub-hosted runners and never targets a self-hosted runner. Also hard-pinned `e2e-self-hosted` to `ubuntu-24.04` to remove a latent self-hosted footgun.
- **`e2e.yml`**: added an optional `ref` input so the gated job can check out the approved PR head (default unchanged for existing callers).

## Reviewer notes

- **Required status checks**: the Nutanix e2e check names move from `checks / e2e-quick-start (Nutanix …)` to `e2e-nutanix / e2e-quick-start (Nutanix …)`. Branch-protection required checks will need updating to the new names.
- This makes the gate **enforceable**, but it is not a substitute for the org setting *"Require approval for all outside collaborators"*, which is still the backstop against a fork adding its own self-hosted job in an unrelated workflow. Recommend confirming that setting is enabled.